### PR TITLE
Use singular resource_type_id for changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ resource "commercetools_subscription" "subscribe" {
   }
 
   changes {
-    resource_type_ids = ["product"]
+    resource_type_id = ["product"]
   }
 
   message {

--- a/commercetools/resource_subscription.go
+++ b/commercetools/resource_subscription.go
@@ -121,7 +121,7 @@ func resourceSubscription() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"resource_type_ids": {
+						"resource_type_id": {
 							Type:     schema.TypeList,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -320,7 +320,7 @@ func resourceSubscriptionGetChanges(d *schema.ResourceData) []subscriptions.Chan
 
 	for _, raw := range input {
 		i := raw.(map[string]interface{})
-		rawTypeIds := expandStringArray(i["resource_type_ids"].([]interface{}))
+		rawTypeIds := expandStringArray(i["resource_type_id"].([]interface{}))
 
 		for _, item := range rawTypeIds {
 			result = append(result, subscriptions.ChangeSubscription{

--- a/commercetools/resource_subscription_test.go
+++ b/commercetools/resource_subscription_test.go
@@ -95,7 +95,7 @@ resource "commercetools_subscription" "subscription_%[1]s" {
 	}
 	
 	changes {
-		resource_type_ids = ["customer"]
+		resource_type_id = ["customer"]
 	}
 	
 	message {


### PR DESCRIPTION
For consistency between `messages` and `changes`