### PR TITLE
Fix link in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ This is the Terraform provider for commercetools. It allows you to configure you
 commercetools project with infrastructure-as-code principles.
 
 ## Installation
-This is a third-party provider and that means that terraform cannot download it automatically. Packages of the releases are available at https://github.com/labd/terraform-provider-commercetools/releases See the [terraform documentation](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) for more information about installing third-party providers.
+This is a third-party provider and that means that terraform cannot download it automatically. Packages of the releases are available at [the GitHub Repo](https://github.com/labd/terraform-provider-commercetools/releases). See the [terraform documentation](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) for more information about installing third-party providers.
 
 
 ## Using the provider


### PR DESCRIPTION
The link isn't clickable in readthedocs.