### PR TITLE
Bugfix/localizedstring enum values

### DIFF
--- a/commercetools/resource_product_type.go
+++ b/commercetools/resource_product_type.go
@@ -547,8 +547,7 @@ func resourceProductTypeAttributeChangeActions(oldValues []interface{}, newValue
 				} else {
 					oldEnumValue := oldEnumKeys[enumValue.Key].(map[string]interface{})
 					oldLocalizedLabel := oldEnumValue["label"].(map[string]interface{})
-					newLocalizedLabel := enumValue.Label
-					labelChanged := !reflect.DeepEqual(oldLocalizedLabel, newLocalizedLabel)
+					labelChanged := !localizedStringCompare(*enumValue.Label, oldLocalizedLabel)
 					if labelChanged {
 						actions = append(
 							actions,

--- a/commercetools/resource_product_type_test.go
+++ b/commercetools/resource_product_type_test.go
@@ -125,7 +125,7 @@ func TestAccProductTypes_basic(t *testing.T) {
 						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
 					),
 					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.#", "1",
+						"commercetools_product_type.acctest_product_type", "attribute.#", "2",
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
@@ -139,10 +139,86 @@ func TestAccProductTypes_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.0.type.0.name", "text",
 					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.en", "Snack",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.nl", "maaltijd",
+					),
+				),
+			},
+			{
+				Config: testAccProductTypeConfigLabelChange(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "key", name,
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "name", "Shipping info",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.0.label.en", "Location change",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.en", "snack",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.nl", "nomnom",
+					),
 				),
 			},
 		},
 	})
+}
+
+func testAccProductTypeConfigLabelChange(name string) string {
+	return fmt.Sprintf(`
+resource "commercetools_product_type" "acctest_product_type" {
+	key = "%s"
+	name = "Shipping info"
+	description = "All things related shipping"
+
+	attribute {
+		name = "location"
+		label = {
+			en = "Location change"
+			nl = "Locatie"
+		}
+		type {
+			name = "text"
+		}
+	}
+
+	attribute {
+		name = "meal"
+		label = {
+			en = "meal"
+			nl = "maaltijd"
+		}
+
+		type = {
+			name = "lenum"
+
+            localized_value = {
+			  key = "snack"
+
+			  label {
+				en = "snack"
+				nl = "nomnom"
+			  }
+			}
+		}
+	}
+}`, name)
 }
 
 func testAccProductTypeConfig(name string) string {
@@ -160,6 +236,27 @@ resource "commercetools_product_type" "acctest_product_type" {
 		}
 		type {
 			name = "text"
+		}
+	}
+
+	attribute {
+		name = "meal"
+		label = {
+			en = "meal"
+			nl = "maaltijd"
+		}
+
+		type = {
+			name = "lenum"
+
+			localized_value = {
+			  key = "snack"
+
+			  label {
+				en = "Snack"
+				nl = "maaltijd"
+			  }
+			}
 		}
 	}
 }`, name)

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -35,8 +35,21 @@ func expandStringMap(input map[string]interface{}) map[string]string {
 	return s
 }
 
-func localizedStringToMap(input commercetools.LocalizedString) map[string]interface{} {
-	result := make(map[string]interface{}, len(input))
+func localizedStringCompare(a commercetools.LocalizedString, b map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+
+func localizedStringToMap(input commercetools.LocalizedString) map[string]string {
+	result := make(map[string]string, len(input))
 	for k, v := range input {
 		result[k] = v
 	}


### PR DESCRIPTION
For context: https://play.golang.org/p/ztjdeLroKHt

Tldr; map[string]string and map[string]interface{} comparing with reflect.DeepEqual doesn't work.