### PR TITLE
Add State Transitions Attribute

### DIFF
--- a/commercetools/resource_state.go
+++ b/commercetools/resource_state.go
@@ -59,11 +59,10 @@ func resourceState() *schema.Resource {
 				},
 			},
 			"transitions": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
-					// TODO: ValidateFunc to ensure keys are used?
 				},
 			},
 		},
@@ -81,10 +80,10 @@ func resourceStateCreate(d *schema.ResourceData, m interface{}) error {
 		roles = append(roles, commercetools.StateRoleEnum(value))
 	}
 
-	transitions := []commercetools.StateResourceIdentifier{}
-	for _, value := range expandStringArray(d.Get("transitions").([]interface{})) {
+	var transitions []commercetools.StateResourceIdentifier
+	for _, value := range d.Get("transitions").(*schema.Set).List() {
 		transitions = append(transitions, commercetools.StateResourceIdentifier{
-			Key: value,
+			Key: value.(string),
 		})
 	}
 
@@ -204,10 +203,10 @@ func resourceStateUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if d.HasChange("transitions") {
-		transitions := []commercetools.StateResourceIdentifier{}
-		for _, value := range expandStringArray(d.Get("transitions").([]interface{})) {
+		var transitions []commercetools.StateResourceIdentifier
+		for _, value := range d.Get("transitions").(*schema.Set).List() {
 			transitions = append(transitions, commercetools.StateResourceIdentifier{
-				Key: value,
+				Key: value.(string),
 			})
 		}
 		input.Actions = append(

--- a/commercetools/resource_state_test.go
+++ b/commercetools/resource_state_test.go
@@ -16,6 +16,8 @@ func TestAccState_createAndUpdateWithID(t *testing.T) {
 
 	newName := "new test state name"
 
+	transition := "state-b"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -43,6 +45,17 @@ func TestAccState_createAndUpdateWithID(t *testing.T) {
 					),
 				),
 			},
+			{
+				Config: testAccTransitionConfig(t, transition),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_state.acctest-state-a", "transitions.#", "1",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_state.acctest-state-a", "transitions.0", transition,
+					),
+				),
+			},
 		},
 	})
 }
@@ -67,6 +80,19 @@ func testAccStateConfig(t *testing.T, name string, key string, addRole bool) str
 	newState := buf.String()
 
 	return newState
+}
+
+func testAccTransitionConfig(t *testing.T, transition string) string {
+	return fmt.Sprintf(`
+	resource "commercetools_state" "acctest-transitions" {
+		key = "state-a"
+		type = "ReviewState"
+		name = {
+			en = "State A"
+		}
+		transitions = ["%s"]
+	}
+	`, transition)
 }
 
 func testAccCheckStateDestroy(s *terraform.State) error {

--- a/commercetools/resource_state_test.go
+++ b/commercetools/resource_state_test.go
@@ -50,9 +50,6 @@ func TestAccState_createAndUpdateWithID(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_state.acctest-t1", "transitions.#", "1",
 					),
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-t1", "transitions.0", transition,
-					),
 				),
 			},
 			{

--- a/docs/resource_state.md
+++ b/docs/resource_state.md
@@ -6,6 +6,8 @@ Also see the [states HTTP API documentation][commercetool-states].
 
 ## Example Usage
 
+Review state:
+
 ```hcl
 resource "commercetools_state" "review_unreviewed" {
   key = "review-unreviewed"
@@ -21,6 +23,34 @@ resource "commercetools_state" "review_unreviewed" {
 }
 ```
 
+State with transitions specified:
+
+```hcl
+resource "commercetools_state" "product_for_sale" {
+  key = "product-for-sale"
+  type = "ProductState"
+  name = {
+      en = "For Sale"
+  }
+  description = {
+    en = "Regularly stocked product."
+  }
+  initial = true
+  transitions = ["${commercetools_state.product_clearance.key}"]
+}
+
+resource "commercetools_state" "product_clearance" {
+  key = "product-clearance"
+  type = "ProductState"
+  name = {
+      en = "On Clearance"
+  }
+  description = {
+    en = "The product line will not be ordered again."
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -31,7 +61,6 @@ The following arguments are supported:
 * `description` - Optional, localized description of the state.
 * `initial` - Optional, initial state of the state machine.
 * `roles` - Optional, list of roles this state has. See [Commercetools documentation][commercetools-states] for possible values.
-
-**Transitions are not yet supported**
+* `transitions` - Optional, list of state keys representing the states this state can transition to. If empty then this state can be transitioned to any other state.
 
 [commercetool-states]: https://docs.commercetools.com/http-api-projects-states.html


### PR DESCRIPTION
State in CommerceTools isn't particularly useful for us unless we can also provide transitions between states (to better enable CS to make changes in the Merchant Center).

This PR adds the transition attribute into state.