### PR TITLE
Remove max_message_size from SQS example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -14,7 +14,6 @@ provider "commercetools" {}
 resource "aws_sqs_queue" "ct_queue" {
   name                      = "terraform-queue-two"
   delay_seconds             = 90
-  max_message_size          = 2048
   message_retention_seconds = 86400
   receive_wait_time_seconds = 10
 }


### PR DESCRIPTION
As documented [here](https://docs.commercetools.com/http-api-projects-subscriptions.html#aws-sqs-destination), the SQS queue must be created with the default (maximum) message size. Otherwise, the commercetools platform will not be able to deliver larger messages.

PS: I keep wondering why we've seen quite a few people create queues with this low max message size. Now I know why 😉 