### PR TITLE
fix: add logic for adding and removing external_oauth to/from commercetools

### DIFF
--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -1,10 +1,9 @@
 package commercetools
 
 import (
-	"log"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/labd/commercetools-go-sdk/commercetools"
+	"log"
 )
 
 func resourceProjectSettings() *schema.Resource {
@@ -136,6 +135,7 @@ func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("currencies", project.Currencies)
 	d.Set("countries", project.Countries)
 	d.Set("languages", project.Languages)
+	d.Set("external_oauth", project.ExternalOAuth)
 	// d.Set("createdAt", project.CreatedAt)
 	// d.Set("trialUntil", project.TrialUntil)
 	log.Print("[DEBUG] Logging messages enabled")
@@ -215,6 +215,21 @@ func projectUpdate(d *schema.ResourceData, client *commercetools.Client, version
 		input.Actions = append(
 			input.Actions,
 			&commercetools.ProjectChangeMessagesEnabledAction{MessagesEnabled: enabled})
+	}
+
+	if d.HasChange("external_oauth") {
+		externalOAuth := d.Get("external_oauth").(map[string]interface{})
+		if externalOAuth["url"] != nil && externalOAuth["authorization_header"] != nil {
+			newExternalOAuth := commercetools.ExternalOAuth{
+				URL:                 externalOAuth["url"].(string),
+				AuthorizationHeader: externalOAuth["authorization_header"].(string),
+			}
+			input.Actions = append(
+				input.Actions,
+				&commercetools.ProjectSetExternalOAuthAction{ExternalOAuth: &newExternalOAuth})
+		} else {
+			input.Actions = append(input.Actions, &commercetools.ProjectSetExternalOAuthAction{ExternalOAuth: nil})
+		}
 	}
 
 	_, err := client.ProjectUpdate(input)

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -3,13 +3,11 @@ package commercetools
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccProjectCreate_basic(t *testing.T) {
-	rName := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +15,7 @@ func TestAccProjectCreate_basic(t *testing.T) {
 		CheckDestroy: testAccCheckProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectConfig(rName),
+				Config: testAccProjectConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing",
@@ -34,6 +32,64 @@ func TestAccProjectCreate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_project_settings.acctest_project_settings", "messages.enabled", "true",
 					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "external_oauth.url", "https://example.com/oauth/token",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "external_oauth.authorization_header", "Bearer secret",
+					),
+				),
+			},
+			{
+				Config: testAccProjectConfigUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing new",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "countries.#", "4",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "currencies.#", "3",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "languages.#", "5",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "messages.enabled", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "external_oauth.url", "https://new-example.com/oauth/token",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "external_oauth.authorization_header", "Bearer new-secret",
+					),
+				),
+			},
+			{
+				Config: testAccProjectConfigDeleteOAuth(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing new",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "countries.#", "4",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "currencies.#", "3",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "languages.#", "5",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "messages.enabled", "false",
+					),
+					resource.TestCheckNoResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "external_oauth.url",
+					),
+					resource.TestCheckNoResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "external_oauth.authorization_header",
+					),
 				),
 			},
 		},
@@ -44,20 +100,49 @@ func testAccCheckProjectDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccProjectConfig(name string) string {
+func testAccProjectConfig() string {
 	return `
-resource "commercetools_project_settings" "acctest_project_settings" {
-	name       = "Test this thing"
-	countries  = ["NL", "DE", "US"]
-	currencies = ["EUR", "USD"]
-	languages  = ["nl", "de", "en", "en-US"]
-	external_oauth = {
-		url = "https://example.com/oauth/token"
-		authorization_header = "Bearer secret"
-	}
+		resource "commercetools_project_settings" "acctest_project_settings" {
+			name       = "Test this thing"
+			countries  = ["NL", "DE", "US"]
+			currencies = ["EUR", "USD"]
+			languages  = ["nl", "de", "en", "en-US"]
+			external_oauth = {
+				url = "https://example.com/oauth/token"
+				authorization_header = "Bearer secret"
+			}
+			messages = {
+			  enabled = true
+			}
+		}`
+}
 
-	messages = {
-	  enabled = true
-	}
-}`
+func testAccProjectConfigUpdate() string {
+	return `
+		resource "commercetools_project_settings" "acctest_project_settings" {
+			name       = "Test this thing new"
+			countries  = ["NL", "DE", "US", "GB"]
+			currencies = ["EUR", "USD", "GBP"]
+			languages  = ["nl", "de", "en", "en-US", "fr"]
+			external_oauth = {
+				url = "https://new-example.com/oauth/token"
+				authorization_header = "Bearer new-secret"
+			}
+			messages = {
+			  enabled = false
+			}
+		}`
+}
+
+func testAccProjectConfigDeleteOAuth() string {
+	return `
+		resource "commercetools_project_settings" "acctest_project_settings" {
+			name       = "Test this thing new"
+			countries  = ["NL", "DE", "US", "GB"]
+			currencies = ["EUR", "USD", "GBP"]
+			languages  = ["nl", "de", "en", "en-US", "fr"]
+			messages = {
+			  enabled = false
+			}
+		}`
 }

--- a/docs/resource_project.md
+++ b/docs/resource_project.md
@@ -18,6 +18,10 @@ resource "commercetools_project_settings" "project" {
   countries = ["NL", "DE", "US", "CA"]
   currencies = ["EUR", "USD", "CAD"]
   languages = ["nl", "de", "en", "fr-CA"]
+  external_oauth = {
+    url = "https://example.com/oauth/introspection"
+    authorization_header = "Bearer secret"
+  }
   messages = {
     enabled = true
   }
@@ -32,4 +36,6 @@ The following arguments are supported:
 * `countries` - A two-digit country code as per ISO 3166-1 alpha-2
 * `currencies` - A three-digit currency code as per ISO 4217
 * `languages` - An IETF language tag
+* `external_oauth.url` - The URL for your token introspection endpoint
+* `external_oauth.authorization_header` - The authorization header to send when querying the `external_oauth.url`
 * `messages.enabled` - When true the creation of messages is enabled


### PR DESCRIPTION
The original PR for this only added the changes to the terraform schema but didn't actually add any logic. This now adds in the logic so that the commercetools project is updated when external_oauth is added.

I also added a couple more tests to the project in order to ensure updating works correctly a second time and that external_oauth can be removed correctly as that required a little bit of extra logic so was worth testing.