### PR TITLE
The official doc for Thrift Go client was updated to use github.com/a…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,6 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+


### PR DESCRIPTION
…pache/thrift instead of git.apache.org/thrift (https://thrift.apache.org/lib/go)

Fix can be applied for all tags I think.