### PR TITLE
added missing '=' for input_tip

### DIFF
--- a/docs/resource_product_type.md
+++ b/docs/resource_product_type.md
@@ -53,7 +53,7 @@ resource "commercetools_product_type" "my-product-type" {
             name = "text"
         }
         constraint = "Unique"
-        input_tip {
+        input_tip = {
             en = "Enter the product code"
             nl = "Voer de product code in"
         }


### PR DESCRIPTION
I bumped into a Terraform error where the "=" was missing. I saw this was because this missing in the documentation as well. Hereby added.