### PR TITLE
fx: use empty defaults

### DIFF
--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -38,28 +38,34 @@ func resourceAPIExtension() *schema.Resource {
 						"url": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 						"azure_authentication": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 						"authorization_header": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 
 						// AWSLambda specific fields
 						"arn": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 						"access_key": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 						"access_secret": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},


### PR DESCRIPTION
coercing nil to string causes panics
leaves terraform in a tainted state
Optional fields should have a safe default

AWS might also have a library to validate access tokens before use. I think they comply to some format.