### PR TITLE
refactor(provider): to make fields required and remove default values

### DIFF
--- a/.azure-pipelines/jobs/test-ubuntu.yml
+++ b/.azure-pipelines/jobs/test-ubuntu.yml
@@ -24,11 +24,14 @@ jobs:
         displayName: "Run tests"
         env:
           TF_ACC: 1
-          CTP_AUTH_URL: http://localhost:8989
-          CTP_PROJECT_KEY: unittest
+          CTP_CLIENT_ID: clientid
+          CTP_CLIENT_SECRET: clientsecret
+          CTP_PROJECT_KEY: projectkey
+          CTP_SCOPES: view_project:projectkey
+          CTP_REGION: europe-west1
+          CTP_CLOUD_PROVIDER: gcp
           CTP_API_URL: http://localhost:8989
-          CTP_CLIENT_ID: unittest
-          CTP_CLIENT_SECRET: x
+          CTP_AUTH_URL: http://localhost:8989
 
       - task: Go@0
         displayName: 'Build'

--- a/.azure-pipelines/jobs/test-ubuntu.yml
+++ b/.azure-pipelines/jobs/test-ubuntu.yml
@@ -28,8 +28,6 @@ jobs:
           CTP_CLIENT_SECRET: clientsecret
           CTP_PROJECT_KEY: projectkey
           CTP_SCOPES: view_project:projectkey
-          CTP_REGION: europe-west1
-          CTP_CLOUD_PROVIDER: gcp
           CTP_API_URL: http://localhost:8989
           CTP_AUTH_URL: http://localhost:8989
 

--- a/.azure-pipelines/jobs/test-ubuntu.yml
+++ b/.azure-pipelines/jobs/test-ubuntu.yml
@@ -24,10 +24,10 @@ jobs:
         displayName: "Run tests"
         env:
           TF_ACC: 1
-          CTP_CLIENT_ID: clientid
-          CTP_CLIENT_SECRET: clientsecret
-          CTP_PROJECT_KEY: projectkey
-          CTP_SCOPES: view_project:projectkey
+          CTP_CLIENT_ID: unittest
+          CTP_CLIENT_SECRET: x
+          CTP_PROJECT_KEY: unittest
+          CTP_SCOPES: manage_project:unittest
           CTP_API_URL: http://localhost:8989
           CTP_AUTH_URL: http://localhost:8989
 

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,10 @@ testacct:
 
 mockacc:
 	TF_ACC=1 \
-	CTP_PROJECT_KEY=projectkey \
 	CTP_CLIENT_ID=clientid \
 	CTP_CLIENT_SECRET=clientsecret \
-	CTP_REGION=europe-west1 \
-	CTP_CLOUD_PROVIDER=gcp \
+	CTP_PROJECT_KEY=projectkey \
+	CTP_SCOPES=view_project:projectkey \
 	CTP_API_URL=http://localhost:8989 \
 	CTP_AUTH_URL=http://localhost:8989 \
 	go test -count=1 -v ./...

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ testacct:
 
 mockacc:
 	TF_ACC=1 \
-	CTP_CLIENT_ID=clientid \
-	CTP_CLIENT_SECRET=clientsecret \
-	CTP_PROJECT_KEY=projectkey \
-	CTP_SCOPES=view_project:projectkey \
+	CTP_CLIENT_ID=unittest \
+	CTP_CLIENT_SECRET=x \
+	CTP_PROJECT_KEY=unittest \
+	CTP_SCOPES=manage_project:projectkey \
 	CTP_API_URL=http://localhost:8989 \
 	CTP_AUTH_URL=http://localhost:8989 \
 	go test -count=1 -v ./...

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,12 @@ testacct:
 	TF_ACC=1 go test -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... -v ./...
 
 mockacc:
-	TF_ACC=1 CTP_AUTH_URL=http://localhost:8989 CTP_PROJECT_KEY=unittest CTP_API_URL=http://localhost:8989 CTP_CLIENT_ID=unittest CTP_CLIENT_SECRET=x go test -count=1 -v ./...
+	TF_ACC=1 \
+	CTP_PROJECT_KEY=projectkey \
+	CTP_CLIENT_ID=clientid \
+	CTP_CLIENT_SECRET=clientsecret \
+	CTP_REGION=europe-west1 \
+	CTP_CLOUD_PROVIDER=gcp \
+	CTP_API_URL=http://localhost:8989 \
+	CTP_AUTH_URL=http://localhost:8989 \
+	go test -count=1 -v ./...

--- a/commercetools/provider.go
+++ b/commercetools/provider.go
@@ -49,14 +49,14 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CTP_API_URL", nil),
 				Description: "The API URL of the commercetools platform. https://docs.commercetools.com/http-api",
-				Removed:     "Use the region and cloud_provider fields, to let the provider construct the correct hostname.",
+				Deprecated:  "Use the region and cloud_provider fields, to let the provider construct the correct hostname.",
 			},
 			"token_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CTP_AUTH_URL", nil),
 				Description: "The authentication URL of the commercetools platform. https://docs.commercetools.com/http-api-authorization",
-				Removed:     "Use the region and cloud_provider fields, to let the provider construct the correct hostname.",
+				Deprecated:  "Use the region and cloud_provider fields, to let the provider construct the correct hostname.",
 			},
 			"region": {
 				Type:        schema.TypeString,

--- a/commercetools/provider.go
+++ b/commercetools/provider.go
@@ -3,7 +3,6 @@ package commercetools
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
@@ -19,56 +18,42 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"client_id": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CTP_CLIENT_ID", nil),
 				Description: "The OAuth Client ID for a commercetools platform project. https://docs.commercetools.com/http-api-authorization",
 				Sensitive:   true,
 			},
 			"client_secret": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CTP_CLIENT_SECRET", nil),
 				Description: "The OAuth Client Secret for a commercetools platform project. https://docs.commercetools.com/http-api-authorization",
 				Sensitive:   true,
 			},
 			"project_key": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CTP_PROJECT_KEY", nil),
 				Description: "The project key of commercetools platform project. https://docs.commercetools.com/getting-started",
 				Sensitive:   true,
 			},
 			"scopes": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CTP_SCOPES", nil),
 				Description: "A list as string of OAuth scopes assigned to a project key, to access resources in a commercetools platform project. https://docs.commercetools.com/http-api-authorization",
 			},
 			"api_url": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CTP_API_URL", nil),
 				Description: "The API URL of the commercetools platform. https://docs.commercetools.com/http-api",
-				Deprecated:  "Use the region and cloud_provider fields, to let the provider construct the correct hostname.",
 			},
 			"token_url": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CTP_AUTH_URL", nil),
 				Description: "The authentication URL of the commercetools platform. https://docs.commercetools.com/http-api-authorization",
-				Deprecated:  "Use the region and cloud_provider fields, to let the provider construct the correct hostname.",
-			},
-			"region": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CTP_REGION", nil),
-				Description: "The region where the commercetools platform runs, for example 'europe-west1', 'us-central1', etc. https://docs.commercetools.com/http-api.html#regions",
-			},
-			"cloud_provider": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CTP_CLOUD_PROVIDER", nil),
-				Description: "The cloud provider where the commercetools platform runs: 'gcp', 'aws'. https://docs.commercetools.com/http-api.html#regions",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -96,10 +81,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	clientSecret := d.Get("client_secret").(string)
 	projectKey := d.Get("project_key").(string)
 	scopesRaw := d.Get("scopes").(string)
+	apiURL := d.Get("api_url").(string)
+	authURL := d.Get("token_url").(string)
 
 	oauthScopes := strings.Split(scopesRaw, " ")
-	apiURL := getAPIURL(d)
-	authURL := getAuthURL(d)
 
 	oauth2Config := &clientcredentials.Config{
 		ClientID:     clientID,
@@ -123,25 +108,3 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 // This is a global MutexKV for use within this plugin.
 var ctMutexKV = mutexkv.NewMutexKV()
-
-func getAPIURL(d *schema.ResourceData) string {
-	testAPIURL := os.Getenv("CTP_API_URL")
-	if testAPIURL != "" {
-		return testAPIURL
-	}
-	return fmt.Sprintf("https://api.%s", getBaseHostname(d))
-}
-
-func getAuthURL(d *schema.ResourceData) string {
-	testAuthURL := os.Getenv("CTP_AUTH_URL")
-	if testAuthURL != "" {
-		return testAuthURL
-	}
-	return fmt.Sprintf("https://auth.%s", getBaseHostname(d))
-}
-
-func getBaseHostname(d *schema.ResourceData) string {
-	region := d.Get("region").(string)
-	cloudProvider := d.Get("cloud_provider").(string)
-	return fmt.Sprintf("%s.%s.commercetools.com", region, cloudProvider)
-}

--- a/commercetools/provider_test.go
+++ b/commercetools/provider_test.go
@@ -43,8 +43,9 @@ func testAccPreCheck(t *testing.T) {
 		"CTP_CLIENT_ID",
 		"CTP_CLIENT_SECRET",
 		"CTP_PROJECT_KEY",
-		"CTP_REGION",
-		"CTP_CLOUD_PROVIDER",
+		"CTP_SCOPES",
+		"CTP_API_URL",
+		"CTP_AUTH_URL",
 	}
 	for _, val := range requiredEnvs {
 		if os.Getenv(val) == "" {

--- a/commercetools/provider_test.go
+++ b/commercetools/provider_test.go
@@ -43,6 +43,8 @@ func testAccPreCheck(t *testing.T) {
 		"CTP_CLIENT_ID",
 		"CTP_CLIENT_SECRET",
 		"CTP_PROJECT_KEY",
+		"CTP_REGION",
+		"CTP_CLOUD_PROVIDER",
 	}
 	for _, val := range requiredEnvs {
 		if os.Getenv(val) == "" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,11 +16,9 @@ The provider attempts to read the required values from environment variables:
 - `CTP_CLIENT_ID`
 - `CTP_CLIENT_SECRET`
 - `CTP_PROJECT_KEY`
-- `CTP_REGION`
-- `CTP_CLOUD_PROVIDER`
 - `CTP_SCOPES`
-
-> The following fields have been removed: `CTP_AUTH_URL`, `CTP_API_URL`. Use `CTP_REGION` and `CTP_CLOUD_PROVIDER` instead.
+- `CTP_API_URL`
+- `CTP_AUTH_URL`
 
 Alternatively, you can set it up directly in the terraform file:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,11 +12,15 @@ This is a third-party provider and that means that terraform cannot download it 
 
 
 ## Using the provider
-Setting up the commercetools credentials The provider reads the environment
-variables `CTP_PROJECT_KEY`, `CTP_CLIENT_SECRET`, `CTP_CLIENT_ID`,
-`CTP_AUTH_URL`, `CTP_API_URL` and `CTP_SCOPES`. This is compatible with the
-"Environment Variables" format you can download in the Merchant Center after
-creating an API Client.
+The provider attempts to read the required values from environment variables:
+- `CTP_CLIENT_ID`
+- `CTP_CLIENT_SECRET`
+- `CTP_PROJECT_KEY`
+- `CTP_REGION`
+- `CTP_CLOUD_PROVIDER`
+- `CTP_SCOPES`
+
+> The following fields have been removed: `CTP_AUTH_URL`, `CTP_API_URL`. Use `CTP_REGION` and `CTP_CLOUD_PROVIDER` instead.
 
 Alternatively, you can set it up directly in the terraform file:
 

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,7 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4/go.mod h1:JDmizlhaP5P0rYTTZB0reDMefAiJyfWPEtugV4in1oI=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0 h1:3AjuuV1LJKs1NlG+heUgqWN6/QCSx2kDhyS6K7F0fTw=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0/go.mod h1:NuwtLpEpPsFaKJPJNGtMcn9vlhe6Ofe+Y6NqXhJgV2M=
+github.com/hashicorp/terraform-plugin-sdk v1.7.0 h1:B//oq0ZORG+EkVrIJy0uPGSonvmXqxSzXe8+GhknoW0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=


### PR DESCRIPTION
commercetools now officially supports regions and cloud providers in the hostnames.

https://docs.commercetools.com/http-api.html#regions

~~Therefore, we should prefer to use `region` and `cloud_provider` fields in the TF provider and let the provider construct the correct hostname.~~ Also, there should not be any default values, as the user should explicitly provide them.

~~The fields `token_url` and `api_url` have been marked as `Removed` in the TF provider schema. However, the `CTP_API_URL` and `CTP_AUTH_URL` environment variables can still be used, for example for the test environment.~~

Update: this PR now changes the following:
- all the fields must be required
- there should not be any default values