### PR TITLE
feat: added cart discount and discount code entities

### DIFF
--- a/commercetools/provider.go
+++ b/commercetools/provider.go
@@ -71,6 +71,8 @@ func Provider() terraform.ResourceProvider {
 			"commercetools_tax_category_rate":  resourceTaxCategoryRate(),
 			"commercetools_shipping_zone":      resourceShippingZone(),
 			"commercetools_state":              resourceState(),
+			"commercetools_cart_discount":      resourceCartDiscount(),
+			"commercetools_discount_code":      resourceDiscountCode(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/commercetools/resource_cart_discount.go
+++ b/commercetools/resource_cart_discount.go
@@ -1,0 +1,544 @@
+package commercetools
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/labd/commercetools-go-sdk/commercetools"
+)
+
+func resourceCartDiscount() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCartDiscountCreate,
+		Read:   resourceCartDiscountRead,
+		Update: resourceCartDiscountUpdate,
+		Delete: resourceCartDiscountDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     TypeLocalizedString,
+				Required: true,
+			},
+			"description": {
+				Type:     TypeLocalizedString,
+				Optional: true,
+			},
+			"value": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateValueType,
+						},
+						// Relative discount specific fields
+						"permyriad": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						// Absolute discount specific fields
+						"money": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"currency_code": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: ValidateCurrencyCode,
+									},
+									"cent_amount": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
+						// Gift Line Item discount specific fields
+						"product_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"variant": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"supply_channel_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"distribution_channel_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"predicate": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateTargetType,
+						},
+						// LineItems/CustomLineItems target specific fields
+						"predicate": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"sort_order": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_active": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"valid_from": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"valid_until": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"requires_discount_code": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"stacking_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateStackingMode,
+				Default:      "Stacking",
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func validateValueType(val interface{}, key string) (warns []string, errs []error) {
+	switch val {
+	case
+		"relative",
+		"absolute",
+		"giftLineItem":
+		return
+	default:
+		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
+	}
+	return
+}
+
+func validateTargetType(val interface{}, key string) (warns []string, errs []error) {
+	switch val {
+	case
+		"lineItems",
+		"customLineItems",
+		"shipping":
+		return
+	default:
+		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
+	}
+	return
+}
+
+func validateStackingMode(val interface{}, key string) (warns []string, errs []error) {
+	switch val {
+	case
+		"Stacking",
+		"StopAfterThisDiscount":
+		return
+	default:
+		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
+	}
+	return
+}
+
+func resourceCartDiscountCreate(d *schema.ResourceData, m interface{}) error {
+	client := getClient(m)
+	var cartDiscount *commercetools.CartDiscount
+
+	name := commercetools.LocalizedString(
+		expandStringMap(d.Get("name").(map[string]interface{})))
+	description := commercetools.LocalizedString(
+		expandStringMap(d.Get("description").(map[string]interface{})))
+
+	value, err := resourceCartDiscountGetValue(d)
+	if err != nil {
+		return err
+	}
+
+	stackingMode, err := resourceCartDiscountGetStackingMode(d)
+	if err != nil {
+		return err
+	}
+
+	draft := &commercetools.CartDiscountDraft{
+		Key:                  d.Get("key").(string),
+		Name:                 &name,
+		Description:          &description,
+		Value:                &value,
+		CartPredicate:        d.Get("predicate").(string),
+		SortOrder:            d.Get("sort_order").(string),
+		IsActive:             d.Get("is_active").(bool),
+		RequiresDiscountCode: d.Get("requires_discount_code").(bool),
+		StackingMode:         stackingMode,
+	}
+
+	if val := d.Get("target").(map[string]interface{}); len(val) > 0 {
+		target, err := resourceCartDiscountGetTarget(d)
+		if err != nil {
+			return err
+		}
+		draft.Target = &target
+	}
+
+	if val := d.Get("valid_from").(string); len(val) > 0 {
+		validFrom, err := expandDate(val)
+		if err != nil {
+			return err
+		}
+		draft.ValidFrom = &validFrom
+	}
+	if val := d.Get("valid_until").(string); len(val) > 0 {
+		validUntil, err := expandDate(val)
+		if err != nil {
+			return err
+		}
+		draft.ValidUntil = &validUntil
+	}
+
+	errorResponse := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+
+		cartDiscount, err = client.CartDiscountCreate(draft)
+
+		if err != nil {
+			return handleCommercetoolsError(err)
+		}
+		return nil
+	})
+
+	if errorResponse != nil {
+		return errorResponse
+	}
+
+	if cartDiscount == nil {
+		log.Fatal("No cart discount created")
+	}
+
+	d.SetId(cartDiscount.ID)
+	d.Set("version", cartDiscount.Version)
+
+	return resourceCartDiscountRead(d, m)
+}
+
+func resourceCartDiscountRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] Reading cart discount from commercetools, with cartDiscount id: %s", d.Id())
+
+	client := getClient(m)
+
+	cartDiscount, err := client.CartDiscountGetWithID(d.Id())
+
+	if err != nil {
+		if ctErr, ok := err.(commercetools.ErrorResponse); ok {
+			if ctErr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	if cartDiscount == nil {
+		log.Print("[DEBUG] No cart discount found")
+		d.SetId("")
+	} else {
+		log.Print("[DEBUG] Found following cart discount:")
+		log.Print(stringFormatObject(cartDiscount))
+
+		d.Set("version", cartDiscount.Version)
+		d.Set("key", cartDiscount.Key)
+		d.Set("name", cartDiscount.Name)
+		d.Set("description", cartDiscount.Description)
+		d.Set("value", cartDiscount.Value)
+		d.Set("predicate", cartDiscount.CartPredicate)
+		d.Set("target", cartDiscount.Target)
+		d.Set("sort_order", cartDiscount.SortOrder)
+		d.Set("is_active", cartDiscount.IsActive)
+		d.Set("valid_from", cartDiscount.ValidFrom)
+		d.Set("valid_until", cartDiscount.ValidUntil)
+		d.Set("requires_discount_code", cartDiscount.RequiresDiscountCode)
+		d.Set("stacking_mode", cartDiscount.StackingMode)
+	}
+
+	return nil
+}
+
+func resourceCartDiscountUpdate(d *schema.ResourceData, m interface{}) error {
+	client := getClient(m)
+	cartDiscount, err := client.CartDiscountGetWithID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &commercetools.CartDiscountUpdateWithIDInput{
+		ID:      d.Id(),
+		Version: cartDiscount.Version,
+		Actions: []commercetools.CartDiscountUpdateAction{},
+	}
+
+	if d.HasChange("key") {
+		newKey := d.Get("key").(string)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountSetKeyAction{Key: newKey})
+	}
+
+	if d.HasChange("name") {
+		newName := commercetools.LocalizedString(
+			expandStringMap(d.Get("name").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountChangeNameAction{Name: &newName})
+	}
+
+	if d.HasChange("description") {
+		newDescription := commercetools.LocalizedString(
+			expandStringMap(d.Get("description").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountSetDescriptionAction{Description: &newDescription})
+	}
+
+	if d.HasChange("value") {
+		value, err := resourceCartDiscountGetValue(d)
+		if err != nil {
+			return err
+		}
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountChangeValueAction{Value: value})
+	}
+
+	if d.HasChange("predicate") {
+		newPredicate := d.Get("predicate").(string)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountChangeCartPredicateAction{CartPredicate: newPredicate})
+	}
+
+	if d.HasChange("target") {
+		if val := d.Get("target").(map[string]interface{}); len(val) > 0 {
+			target, err := resourceCartDiscountGetTarget(d)
+			if err != nil {
+				return err
+			}
+			input.Actions = append(
+				input.Actions,
+				&commercetools.CartDiscountChangeTargetAction{Target: target})
+		} else {
+			return errors.New("Cannot change target to empty")
+		}
+
+	}
+
+	if d.HasChange("sort_order") {
+		newSortOrder := d.Get("sort_order").(string)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountChangeSortOrderAction{SortOrder: newSortOrder})
+	}
+
+	if d.HasChange("is_active") {
+		newIsActive := d.Get("is_active").(bool)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountChangeIsActiveAction{IsActive: newIsActive})
+	}
+
+	if d.HasChange("valid_from") {
+		if val := d.Get("valid_from").(string); len(val) > 0 {
+			newValidFrom, err := expandDate(d.Get("valid_from").(string))
+			if err != nil {
+				return err
+			}
+			input.Actions = append(
+				input.Actions,
+				&commercetools.CartDiscountSetValidFromAction{ValidFrom: &newValidFrom})
+		} else {
+			input.Actions = append(
+				input.Actions,
+				&commercetools.CartDiscountSetValidFromAction{})
+		}
+	}
+
+	if d.HasChange("valid_until") {
+		if val := d.Get("valid_until").(string); len(val) > 0 {
+			newValidUntil, err := expandDate(d.Get("valid_until").(string))
+			if err != nil {
+				return err
+			}
+			input.Actions = append(
+				input.Actions,
+				&commercetools.CartDiscountSetValidUntilAction{ValidUntil: &newValidUntil})
+		} else {
+			input.Actions = append(
+				input.Actions,
+				&commercetools.CartDiscountSetValidUntilAction{})
+		}
+	}
+
+	if d.HasChange("requires_discount_code") {
+		newRequiresDiscountCode := d.Get("requires_discount_code").(bool)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountChangeRequiresDiscountCodeAction{RequiresDiscountCode: newRequiresDiscountCode})
+	}
+
+	if d.HasChange("stacking_mode") {
+		newStackingMode, err := resourceCartDiscountGetStackingMode(d)
+		if err != nil {
+			return err
+		}
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CartDiscountChangeStackingModeAction{StackingMode: newStackingMode})
+	}
+
+	log.Printf(
+		"[DEBUG] Will perform update operation with the following actions:\n%s",
+		stringFormatActions(input.Actions))
+
+	_, err = client.CartDiscountUpdateWithID(input)
+	if err != nil {
+		if ctErr, ok := err.(commercetools.ErrorResponse); ok {
+			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+		}
+		return err
+	}
+
+	return resourceCartDiscountRead(d, m)
+}
+
+func resourceCartDiscountDelete(d *schema.ResourceData, m interface{}) error {
+	client := getClient(m)
+	version := d.Get("version").(int)
+	_, err := client.CartDiscountDeleteWithID(d.Id(), version)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resourceCartDiscountGetValue(d *schema.ResourceData) (commercetools.CartDiscountValueDraft, error) {
+	value := d.Get("value").([]interface{})[0].(map[string]interface{})
+	switch value["type"].(string) {
+	case "relative":
+		return commercetools.CartDiscountValueRelativeDraft{
+			Permyriad: value["permyriad"].(int),
+		}, nil
+	case "absolute":
+		money := resourceCartDiscountGetMoney(value)
+		return commercetools.CartDiscountValueAbsoluteDraft{
+			Money: money,
+		}, nil
+	case "giftLineItem":
+
+		draft := &commercetools.CartDiscountValueGiftLineItemDraft{}
+
+		if val := value["supply_channel_id"].(string); len(val) > 0 {
+			draft.SupplyChannel = &commercetools.ChannelReference{ID: val}
+		}
+		if val := value["product_id"].(string); len(val) > 0 {
+			draft.Product = &commercetools.ProductReference{ID: val}
+		}
+		if val := value["distribution_channel_id"].(string); len(val) > 0 {
+			draft.DistributionChannel = &commercetools.ChannelReference{ID: val}
+		}
+
+		draft.VariantID = value["variant"].(int)
+
+		return draft, nil
+
+	default:
+		return nil, fmt.Errorf("Value type %s not implemented", value["type"])
+	}
+}
+
+func resourceCartDiscountGetMoney(d map[string]interface{}) []commercetools.Money {
+	input := d["money"].([]interface{})
+	var result []commercetools.Money
+
+	for _, raw := range input {
+		i := raw.(map[string]interface{})
+		priceCurrencyCode := commercetools.CurrencyCode(i["currency_code"].(string))
+
+		result = append(result, commercetools.Money{
+			CurrencyCode: priceCurrencyCode,
+			CentAmount:   i["cent_amount"].(int),
+		})
+	}
+
+	return result
+}
+
+func resourceCartDiscountGetTarget(d *schema.ResourceData) (commercetools.CartDiscountTarget, error) {
+	input := d.Get("target").(map[string]interface{})
+
+	switch input["type"].(string) {
+	case "lineItems":
+		return commercetools.CartDiscountLineItemsTarget{
+			Predicate: input["predicate"].(string),
+		}, nil
+	case "customLineItems":
+		return commercetools.CartDiscountCustomLineItemsTarget{
+			Predicate: input["predicate"].(string),
+		}, nil
+	case "shipping":
+		return commercetools.CartDiscountShippingCostTarget{}, nil
+	default:
+		return nil, fmt.Errorf("Target type %s not implemented", input["type"])
+	}
+
+}
+
+func resourceCartDiscountGetStackingMode(d *schema.ResourceData) (commercetools.StackingMode, error) {
+	switch d.Get("stacking_mode").(string) {
+	case "Stacking":
+		return commercetools.StackingModeStacking, nil
+	case "StopAfterThisDiscount":
+		return commercetools.StackingModeStopAfterThisDiscount, nil
+	default:
+		return "", fmt.Errorf("Stacking mode %s not implemented", d.Get("stacking_mode").(string))
+	}
+}

--- a/commercetools/resource_cart_discount_test.go
+++ b/commercetools/resource_cart_discount_test.go
@@ -1,0 +1,246 @@
+package commercetools
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccCartDiscountCreate_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCartDiscountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCartDiscountConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "key", "standard",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "name.en", "standard name",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "description.en", "Standard description",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "sort_order", "0.9",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "predicate", "1=1",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "requires_discount_code", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "valid_from", "2020-01-02T15:04:05.000Z",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "valid_until", "2021-01-02T15:04:05.000Z",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "target.type", "lineItems",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "target.predicate", "1=1",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "value.0.type", "relative",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "is_active", "true",
+					),
+				),
+			},
+			{
+				Config: testAccCartDiscountUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "key", "standard_new",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "name.en", "standard name",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "description.en", "Standard description new",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "sort_order", "0.8",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "predicate", "1=1",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "requires_discount_code", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "valid_from", "2018-01-02T15:04:05.000Z",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "valid_until", "2019-01-02T15:04:05.000Z",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "target.type", "lineItems",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "target.predicate", "1=1",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "value.0.type", "relative",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "is_active", "false",
+					),
+				),
+			},
+			{
+				Config: testAccCartDiscountRemoveProperties(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "key", "standard_new",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "name.en", "standard name",
+					),
+					resource.TestCheckNoResourceAttr(
+						"commercetools_cart_discount.standard", "description",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "sort_order", "0.8",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "predicate", "1=1",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "requires_discount_code", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "valid_from", "",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "valid_until", "",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "target.type", "lineItems",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "target.predicate", "1=1",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "value.0.type", "relative",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_cart_discount.standard", "is_active", "true",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCartDiscountConfig() string {
+	return `
+	resource "commercetools_cart_discount" "standard" {
+		key = "standard"
+		name = {
+		  en = "standard name"
+		}
+		description = {
+			en = "Standard description"
+		  }
+		sort_order             = "0.9"
+		predicate              = "1=1"
+		stacking_mode          = "Stacking"
+		requires_discount_code = true
+		valid_from             = "2020-01-02T15:04:05.000Z"
+		valid_until            = "2021-01-02T15:04:05.000Z"
+		target = {
+		  type      = "lineItems"
+		  predicate = "1=1"
+		}
+
+		value {
+			type      = "relative"
+			permyriad = 1000
+		}
+	  }
+	  `
+}
+
+func testAccCartDiscountUpdate() string {
+	return `
+	resource "commercetools_cart_discount" "standard" {
+		key = "standard_new"
+		name = {
+		  en = "standard name"
+		}
+		description = {
+			en = "Standard description new"
+		  }
+		sort_order             = "0.8"
+		predicate              = "1=1"
+		stacking_mode          = "Stacking"
+		requires_discount_code = true
+		valid_from             = "2018-01-02T15:04:05.000Z"
+		valid_until            = "2019-01-02T15:04:05.000Z"
+		target = {
+			type      = "lineItems"
+			predicate = "1=1"
+		}
+		
+		value {
+			type      = "relative"
+			permyriad = 1000
+		}
+
+		is_active = false
+	  }
+	  `
+}
+
+func testAccCartDiscountRemoveProperties() string {
+	return `
+	resource "commercetools_cart_discount" "standard" {
+		key = "standard_new"
+		name = {
+		  en = "standard name"
+		}
+		sort_order             = "0.8"
+		predicate              = "1=1"	
+		requires_discount_code = true
+		target = {
+			type      = "lineItems"
+			predicate = "1=1"
+		}
+		value {
+			type      = "relative"
+			permyriad = 1000
+		}
+	  }
+	  `
+}
+
+func testAccCheckCartDiscountDestroy(s *terraform.State) error {
+	return nil
+}

--- a/commercetools/resource_discount_code.go
+++ b/commercetools/resource_discount_code.go
@@ -1,0 +1,328 @@
+package commercetools
+
+import (
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/labd/commercetools-go-sdk/commercetools"
+)
+
+func resourceDiscountCode() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDiscountCodeCreate,
+		Read:   resourceDiscountCodetRead,
+		Update: resourceDiscountCodeUpdate,
+		Delete: resourceDiscountCodeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     TypeLocalizedString,
+				Optional: true,
+			},
+			"description": {
+				Type:     TypeLocalizedString,
+				Optional: true,
+			},
+			"code": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"valid_from": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"valid_until": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_active": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"predicate": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"max_applications_per_customer": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_applications": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cart_discounts": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDiscountCodeCreate(d *schema.ResourceData, m interface{}) error {
+	client := getClient(m)
+	var discountCode *commercetools.DiscountCode
+
+	name := commercetools.LocalizedString(
+		expandStringMap(d.Get("name").(map[string]interface{})))
+	description := commercetools.LocalizedString(
+		expandStringMap(d.Get("description").(map[string]interface{})))
+
+	draft := &commercetools.DiscountCodeDraft{
+		Name:                       &name,
+		Description:                &description,
+		Code:                       d.Get("code").(string),
+		CartPredicate:              d.Get("predicate").(string),
+		IsActive:                   d.Get("is_active").(bool),
+		MaxApplicationsPerCustomer: d.Get("max_applications_per_customer").(int),
+		MaxApplications:            d.Get("max_applications").(int),
+		Groups:                     resourceDiscountCodeGetGroups(d),
+		CartDiscounts:              resourceDiscountCodeGetCartDiscounts(d),
+	}
+
+	if val := d.Get("valid_from").(string); len(val) > 0 {
+		validFrom, err := expandDate(val)
+		if err != nil {
+			return err
+		}
+		draft.ValidFrom = &validFrom
+	}
+	if val := d.Get("valid_until").(string); len(val) > 0 {
+		validUntil, err := expandDate(val)
+		if err != nil {
+			return err
+		}
+		draft.ValidUntil = &validUntil
+	}
+
+	errorResponse := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+
+		discountCode, err = client.DiscountCodeCreate(draft)
+
+		if err != nil {
+			return handleCommercetoolsError(err)
+		}
+		return nil
+	})
+
+	if errorResponse != nil {
+		return errorResponse
+	}
+
+	if discountCode == nil {
+		log.Fatal("No discount code created")
+	}
+
+	d.SetId(discountCode.ID)
+	d.Set("version", discountCode.Version)
+
+	return resourceDiscountCodetRead(d, m)
+}
+
+func resourceDiscountCodetRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] Reading discount code from commercetools, with discount code id: %s", d.Id())
+
+	client := getClient(m)
+
+	discountCode, err := client.DiscountCodeGetWithID(d.Id())
+
+	if err != nil {
+		if ctErr, ok := err.(commercetools.ErrorResponse); ok {
+			if ctErr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	if discountCode == nil {
+		log.Print("[DEBUG] No discount code found")
+		d.SetId("")
+	} else {
+		log.Print("[DEBUG] Found following discount code:")
+		log.Print(stringFormatObject(discountCode))
+
+		d.Set("version", discountCode.Version)
+		d.Set("code", discountCode.Code)
+		d.Set("name", discountCode.Name)
+		d.Set("description", discountCode.Description)
+		d.Set("predicate", discountCode.CartPredicate)
+		d.Set("cart_discounts", discountCode.CartDiscounts)
+		d.Set("groups", discountCode.Groups)
+		d.Set("is_active", discountCode.IsActive)
+		d.Set("valid_from", discountCode.ValidFrom)
+		d.Set("valid_until", discountCode.ValidUntil)
+		d.Set("max_applications_per_customer", discountCode.MaxApplicationsPerCustomer)
+		d.Set("max_applications", discountCode.MaxApplications)
+	}
+
+	return nil
+}
+
+func resourceDiscountCodeUpdate(d *schema.ResourceData, m interface{}) error {
+	client := getClient(m)
+	discountCode, err := client.DiscountCodeGetWithID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &commercetools.DiscountCodeUpdateWithIDInput{
+		ID:      d.Id(),
+		Version: discountCode.Version,
+		Actions: []commercetools.DiscountCodeUpdateAction{},
+	}
+
+	if d.HasChange("name") {
+		newName := commercetools.LocalizedString(
+			expandStringMap(d.Get("name").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.DiscountCodeSetNameAction{Name: &newName})
+	}
+
+	if d.HasChange("description") {
+		newDescription := commercetools.LocalizedString(
+			expandStringMap(d.Get("description").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.DiscountCodeSetDescriptionAction{Description: &newDescription})
+	}
+
+	if d.HasChange("predicate") {
+		newPredicate := d.Get("predicate").(string)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.DiscountCodeSetCartPredicateAction{CartPredicate: newPredicate})
+	}
+
+	if d.HasChange("max_applications") {
+		newMaxApplications := d.Get("max_applications").(int)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.DiscountCodeSetMaxApplicationsAction{MaxApplications: newMaxApplications})
+	}
+
+	if d.HasChange("max_applications_per_customer") {
+		newMaxApplications := d.Get("max_applications_per_customer").(int)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.DiscountCodeSetMaxApplicationsPerCustomerAction{MaxApplicationsPerCustomer: newMaxApplications})
+	}
+
+	if d.HasChange("cart_discounts") {
+		newCartDiscounts := resourceDiscountCodeGetCartDiscounts(d)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.DiscountCodeChangeCartDiscountsAction{CartDiscounts: newCartDiscounts})
+	}
+
+	if d.HasChange("groups") {
+		newGroups := resourceDiscountCodeGetGroups(d)
+		if len(newGroups) > 0 {
+			input.Actions = append(
+				input.Actions,
+				&commercetools.DiscountCodeChangeGroupsAction{Groups: newGroups})
+		} else {
+			input.Actions = append(
+				input.Actions,
+				&commercetools.DiscountCodeChangeGroupsAction{Groups: []string{}})
+		}
+	}
+
+	if d.HasChange("is_active") {
+		newIsActive := d.Get("is_active").(bool)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.DiscountCodeChangeIsActiveAction{IsActive: newIsActive})
+	}
+
+	if d.HasChange("valid_from") {
+		if val := d.Get("valid_from").(string); len(val) > 0 {
+			newValidFrom, err := expandDate(d.Get("valid_from").(string))
+			if err != nil {
+				return err
+			}
+			input.Actions = append(
+				input.Actions,
+				&commercetools.DiscountCodeSetValidFromAction{ValidFrom: &newValidFrom})
+		} else {
+			input.Actions = append(
+				input.Actions,
+				&commercetools.DiscountCodeSetValidFromAction{})
+		}
+	}
+
+	if d.HasChange("valid_until") {
+		if val := d.Get("valid_until").(string); len(val) > 0 {
+			newValidUntil, err := expandDate(d.Get("valid_until").(string))
+			if err != nil {
+				return err
+			}
+			input.Actions = append(
+				input.Actions,
+				&commercetools.DiscountCodeSetValidUntilAction{ValidUntil: &newValidUntil})
+		} else {
+			input.Actions = append(
+				input.Actions,
+				&commercetools.DiscountCodeSetValidUntilAction{})
+		}
+	}
+
+	log.Printf(
+		"[DEBUG] Will perform update operation with the following actions:\n%s",
+		stringFormatActions(input.Actions))
+
+	_, err = client.DiscountCodeUpdateWithID(input)
+	if err != nil {
+		if ctErr, ok := err.(commercetools.ErrorResponse); ok {
+			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+		}
+		return err
+	}
+
+	return resourceDiscountCodetRead(d, m)
+}
+
+func resourceDiscountCodeDelete(d *schema.ResourceData, m interface{}) error {
+	client := getClient(m)
+	version := d.Get("version").(int)
+	_, err := client.DiscountCodeDeleteWithID(d.Id(), version, false)
+	if err != nil {
+		log.Printf("[ERROR] Error during deleting discount code resource %s", err)
+		return nil
+	}
+	return nil
+}
+
+func resourceDiscountCodeGetGroups(d *schema.ResourceData) []string {
+	var groups []string
+	for _, group := range expandStringArray(d.Get("groups").([]interface{})) {
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func resourceDiscountCodeGetCartDiscounts(d *schema.ResourceData) []commercetools.CartDiscountResourceIdentifier {
+	var cartDiscounts []commercetools.CartDiscountResourceIdentifier
+	for _, cartDiscount := range expandStringArray(d.Get("cart_discounts").([]interface{})) {
+		cartDiscounts = append(cartDiscounts, commercetools.CartDiscountResourceIdentifier{ID: cartDiscount})
+	}
+	return cartDiscounts
+}

--- a/commercetools/resource_discount_code_test.go
+++ b/commercetools/resource_discount_code_test.go
@@ -1,0 +1,180 @@
+package commercetools
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDiscountCodeCreate_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiscountCodeConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "name.en", "Standard name",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "description.en", "Standard description",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "code", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "valid_from", "2020-01-02T15:04:05.000Z",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "valid_until", "2021-01-02T15:04:05.000Z",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "is_active", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "predicate", "1=1",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "max_applications_per_customer", "10",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "max_applications", "100",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "cart_discounts.0", "cart-discount-id-0",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "cart_discounts.1", "cart-discount-id-1",
+					),
+				),
+			},
+			{
+				Config: testAccDiscountCodeUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "name.en", "Standard name new",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "description.en", "Standard description new",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "code", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "valid_from", "2018-01-02T15:04:05.000Z",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "valid_until", "2019-01-02T15:04:05.000Z",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "is_active", "false",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "predicate", "1=2",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "max_applications_per_customer", "5",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "max_applications", "50",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "cart_discounts.0", "cart-discount-id-0",
+					),
+					resource.TestCheckNoResourceAttr(
+						"commercetools_discount_code.standard", "cart_discounts.1",
+					),
+				),
+			},
+			{
+				Config: testAccDiscountCodeRemoveProperties(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"commercetools_discount_code.standard", "name.en",
+					),
+					resource.TestCheckNoResourceAttr(
+						"commercetools_discount_code.standard", "description.en",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "code", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "valid_from", "",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "valid_until", "",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "is_active", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "predicate", "",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "max_applications_per_customer", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "max_applications", "0",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_discount_code.standard", "cart_discounts.0", "cart-discount-id-0",
+					),
+					resource.TestCheckNoResourceAttr(
+						"commercetools_discount_code.standard", "cart_discounts.1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDiscountCodeConfig() string {
+	return `
+	resource "commercetools_discount_code" "standard" {
+		name = {
+		  en = "Standard name"
+		}
+		description = {
+			en = "Standard description"
+		  }
+		code           = "2"
+		valid_from             = "2020-01-02T15:04:05.000Z"
+		valid_until            = "2021-01-02T15:04:05.000Z"
+		is_active      = true
+        predicate      = "1=1"
+        max_applications_per_customer = 10
+        max_applications    = 100
+		cart_discounts = ["cart-discount-id-0", "cart-discount-id-1"]
+	  }  `
+}
+
+func testAccDiscountCodeUpdate() string {
+	return `
+	resource "commercetools_discount_code" "standard" {
+		name = {
+		  en = "Standard name new"
+		}
+		description = {
+			en = "Standard description new"
+		  }
+		code           = "2"
+		valid_from             = "2018-01-02T15:04:05.000Z"
+		valid_until            = "2019-01-02T15:04:05.000Z"
+		is_active      = false
+        predicate      = "1=2"
+        max_applications_per_customer = 5
+        max_applications    = 50
+		cart_discounts = ["cart-discount-id-0"]
+	  }  `
+}
+
+func testAccDiscountCodeRemoveProperties() string {
+	return `
+	resource "commercetools_discount_code" "standard" {
+		code           = "2"
+		cart_discounts = ["cart-discount-id-0"]
+	  }  `
+}

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -309,4 +310,8 @@ func ValidateCurrencyCode(val interface{}, key string) (warns []string, errs []e
 		errs = append(errs, fmt.Errorf("%q unknown currency code, must be valid ISO 4217 code, got: %s", key, currency))
 	}
 	return
+}
+
+func expandDate(input string) (time.Time, error) {
+	return time.Parse(time.RFC3339, input)
 }

--- a/docs/resource_cart_discount.md
+++ b/docs/resource_cart_discount.md
@@ -1,0 +1,140 @@
+# Cart Discounts
+
+Cart discounts are used to change the prices of different elements within a cart.
+
+Also see the [Cart Discounts HTTP API documentation](https://docs.commercetools.com/http-api-projects-cartDiscounts).
+
+## Example Usage
+
+```hcl
+resource "commercetools_cart_discount" "my-cart-discount" {
+  key = "my_discount"
+  name = {
+    en = "My Discount name"
+  }
+  description = {
+    en = "My Discount description"
+  }
+  value {
+    type = "relative"
+    permyriad = 1000
+  }
+  predicate = "1=1"
+  target = {
+    type = "lineItems"
+    predicate = "1=1"
+  }
+  sort_order = "0.9"
+  is_active = true
+  valid_from = "2020-01-02T15:04:05.000Z"
+  valid_until = "2021-01-02T15:04:05.000Z"
+  requires_discount_code = true
+  stacking_mode = "Stacking"
+}
+
+resource "commercetools_cart_discount" "my-cart-discount" {
+  key = "my_discount"
+  name = {
+    en = "My Discount name"
+  }
+  description = {
+    en = "My Discount description"
+  }
+  value {
+    type = "absolute"
+    money {
+      currency_code = "USD"
+      cent_amount = "3000"
+    }
+    money {
+    currency_code = "EUR"
+    cent_amount = "4000"
+    }
+  }
+  predicate = "any-predicate"
+  target = {
+    type = "shipping"
+  }
+  sort_order = "0.8"
+  is_active = false
+  requires_discount_code = false
+  stacking_mode = "StopAfterThisDiscount"
+}
+
+resource "commercetools_cart_discount" "my-cart-discount" {
+  name = {
+    en = "My Discount name"
+  }
+  value {
+    type = "giftLineItem"
+    product_id = "product-id"
+    variant = 1
+    supply_channel_id = "supply-channel-id"
+    distribution_channel_id	= "distribution-channel-id"
+  }
+  predicate = "any-predicate"
+  target = {
+    type = "shipping"
+  }
+  sort_order = "0.8"
+}
+```
+
+## Argument Reference
+
+* `key` - string - Optional
+* `name` - string
+* `description` - string - Optional
+* `value` - should be one of [Cart Discount Value](#cart-discount-value)
+* `predicate` - string - should be valid [Cart Predicate][commercetool-cart-predicate]
+* `target` -  should be one of [Cart Discount Target](#cart-discount-target) - Optional - Must not be set when the `value` has type 'giftLineItem', otherwise a Cart Discount Target must be set.
+* `sort_order` - string - Optional - The string must contain a number between 0 and 1
+* `is_active` - boolean - Optional - By default: true
+* `valid_from` - string - Optional - A JSON string representation of UTC date & time in ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssZ)
+* `valid_until` - string - Optional - A JSON string representation of UTC date & time in ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssZ)
+* `requires_discount_code` - boolean - Optional - By default: false
+* `stacking_mode` - string - Optional - should be valid [Stacking Mode][commercetool-stacking-mode]. By default: 'Stacking'
+
+
+
+### Cart Discount Value
+[Cart Discount Value][commercetool-cart-discount-value] defines the effect the discount will have.
+
+These can have the following combination of arguments:
+* `type` - string - Value: 'relative'
+* `permyriad` - number - Per ten thousand. The fraction the price is reduced. 1000 will result in a 10% price reduction.
+-----
+* `type` - string - Value: 'absolute'
+* `money` - array of [Money][commercetool-money] - The array contains money values in different currencies.
+-----
+* `type` - string - Value: 'giftLineItem'
+* `product` - string - ID of appropriate [Product][commercetool-product]
+* `variantId` - number - Number of the product's variant
+* `supplyChannel` - string - Optional - Id of the [Channel][commercetool-channel]. Must have the role 'InventorySupply'
+* `distributionChannel` - string - Optional - Id of the [Channel][commercetool-channel]. Must have the role 'ProductDistribution'
+
+
+### Cart Discount Target
+[Cart Discount Target][commercetool-cart-discount-target] defines what part of the cart will be discounted.
+
+These can have the following combination arguments:
+
+* `type` - string - Value: 'lineItems'
+* `predicate` - string - should be valid [Line Item Predicate][commercetool-line-item-predicate]
+------
+* `type` - string - Value: 'customLineItems'
+* `predicate` - string - should be valid [Custom Line Item Predicate][commercetool-custom-line-item-predicate]
+------
+* `type` - string - Value: 'shipping'
+
+
+
+[commercetool-cart-discount-value]: https://docs.commercetools.com/http-api-projects-cartDiscounts.html#cartdiscountvalue
+[commercetool-cart-predicate]: https://docs.commercetools.com/http-api-projects-predicates#cart-predicates
+[commercetool-cart-discount-target]: https://docs.commercetools.com/http-api-projects-cartDiscounts#cartdiscounttarget
+[commercetool-stacking-mode]: https://docs.commercetools.com/http-api-projects-cartDiscounts#stackingmode
+[commercetool-money]: https://docs.commercetools.com/http-api-types.html#money
+[commercetool-channel]: https://docs.commercetools.com/http-api-projects-channels.html#channels
+[commercetool-product]: https://docs.commercetools.com/http-api-projects-products.html
+[commercetool-line-item-predicate]: https://docs.commercetools.com/http-api-projects-predicates.html#lineitem-field-identifiers
+[commercetool-custom-line-item-predicate]: https://docs.commercetools.com/http-api-projects-predicates.html#customlineitem-field-identifiers

--- a/docs/resource_discount_code.md
+++ b/docs/resource_discount_code.md
@@ -1,0 +1,52 @@
+# Discount Codes
+
+With discount codes it is possible to give specific cart discounts to an eligible set of users. They are defined by a string value which can be added to a cart so that specific cart discounts can be applied to the cart.
+
+
+Also see the [Discount Codes HTTP API documentation](https://docs.commercetools.com/http-api-projects-discountCodes#discount-codes).
+
+## Example Usage
+
+```hcl
+resource "commercetools_discount_code" "my_discount_code" {
+  name = {
+    en = "My Discount code name"
+  }
+  description = {
+    en = "My Discount code description"
+  }
+  code = "2"
+  valid_from = "2020-01-02T15:04:05.000Z"
+  valid_until = "2021-01-02T15:04:05.000Z"
+  is_active = true
+  predicate = "1=1"
+  max_applications_per_customer = 3
+  max_applications = 100
+  groups = ["0", "1"]
+  cart_discounts = ["cart-discount-id-1", "cart-discount-id-2"]
+}
+
+resource "commercetools_discount_code" "my_discount_code" {
+  code = "2"
+  cart_discounts = ["cart-discount-id-1"]
+}
+```
+
+## Argument Reference
+
+* `name` - string - Optional
+* `description` - string - Optional
+* `code` - string
+* `valid_from` - string - Optional - A JSON string representation of UTC date & time in ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssZ)
+* `valid_until` - string - Optional - A JSON string representation of UTC date & time in ISO 8601 format (YYYY-MM-DDThh:mm:ss.sssZ)
+* `is_active` - boolean - Optional - By default: true
+* `predicate` - string - should be valid [Cart Predicate][commercetool-cart-predicate]
+* `max_applications_per_customer` - number - Optional - The discount code can only be applied `max_applications_per_customer` times per customer.
+* `max_applications` - number - Optional - The discount code can only be applied `max_applications` times.
+* `groups` - []string - Optional - The groups to which this discount code belong.
+* `cart_discounts` - []string - The array of [Cart Discounts][commercetool-cart-discount] IDs
+
+
+
+[commercetool-cart-predicate]: https://docs.commercetools.com/http-api-projects-predicates#cart-predicates
+[commercetool-cart-discount]: https://docs.commercetools.com/http-api-projects-cartDiscounts.html#cartdiscount

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/labd/terraform-provider-commercetools
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/labd/commercetools-go-sdk v0.0.0-20190722144546-80b2ca71bd4d
+	github.com/labd/commercetools-go-sdk v0.0.0-20200309143931-ca72e918a79d
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3v
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/labd/commercetools-go-sdk v0.0.0-20190722144546-80b2ca71bd4d h1:tQPiC54Y3Eebi5G8jIQlVVIh9cqlaIQIuhlW82Yvqgg=
-github.com/labd/commercetools-go-sdk v0.0.0-20190722144546-80b2ca71bd4d/go.mod h1:4IG4Fi2139S7HAjJlaL2Z9kcyKdbIjUTdqd4l4pPXdw=
+github.com/labd/commercetools-go-sdk v0.0.0-20200309143931-ca72e918a79d h1:wI9Pc33M4Weg78J/fDFsKWTiEsAvriH6x4EHbcR3zus=
+github.com/labd/commercetools-go-sdk v0.0.0-20200309143931-ca72e918a79d/go.mod h1:uOXGd793oxD6CZiPp30hzs4L511bcYSF0yPu17LBqAo=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=


### PR DESCRIPTION
### Cart Discount https://docs.commercetools.com/http-api-projects-cartDiscounts

- Added supporting of new commercetools entity CartDiscount
- MultiBuyLineItems Target MultiBuyCustomLineItems Target (https://docs.commercetools.com/http-api-projects-cartDiscounts#multibuylineitems-target) was skipped because in commercetools it is beta feature
- Custom fields skipped 

###  Discount Code https://docs.commercetools.com/http-api-projects-discountCodes

- Custom fields skipped 

In future it is possible to extend this entities with missing fields

Notes:

- local testing was successfull (entities update/createation succcessful)
