### PR TITLE
Add state transitions resource

### DIFF
--- a/commercetools/provider.go
+++ b/commercetools/provider.go
@@ -71,6 +71,7 @@ func Provider() terraform.ResourceProvider {
 			"commercetools_tax_category_rate":  resourceTaxCategoryRate(),
 			"commercetools_shipping_zone":      resourceShippingZone(),
 			"commercetools_state":              resourceState(),
+			"commercetools_state_transitions":  resourceStateTransitions(),
 			"commercetools_cart_discount":      resourceCartDiscount(),
 			"commercetools_discount_code":      resourceDiscountCode(),
 		},

--- a/commercetools/resource_state.go
+++ b/commercetools/resource_state.go
@@ -110,8 +110,7 @@ func resourceStateCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.SetId(state.ID)
-	return resourceStateRead(d, m)
+	return setStateResourceState(d, state)
 }
 
 func resourceStateRead(d *schema.ResourceData, m interface{}) error {
@@ -129,20 +128,7 @@ func resourceStateRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.SetId(state.ID)
-	d.Set("key", state.Key)
-	d.Set("type", state.Type)
-	if state.Name != nil {
-		d.Set("name", *state.Name)
-	}
-	if state.Description != nil {
-		d.Set("description", *state.Description)
-	}
-	d.Set("initial", state.Initial)
-	if state.Roles != nil {
-		d.Set("roles", state.Roles)
-	}
-	return nil
+	return setStateResourceState(d, state)
 }
 
 func resourceStateUpdate(d *schema.ResourceData, m interface{}) error {
@@ -210,12 +196,12 @@ func resourceStateUpdate(d *schema.ResourceData, m interface{}) error {
 			&commercetools.StateSetRolesAction{Roles: roles})
 	}
 
-	_, err = client.StateUpdateWithID(input)
+	updatedState, err := client.StateUpdateWithID(input)
 	if err != nil {
 		return err
 	}
 
-	return resourceStateRead(d, m)
+	return setStateResourceState(d, updatedState)
 }
 
 func resourceStateDelete(d *schema.ResourceData, m interface{}) error {
@@ -234,6 +220,23 @@ func resourceStateDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err = client.StateDeleteWithID(stateID, state.Version)
 	return err
+}
+
+func setStateResourceState(d *schema.ResourceData, state *commercetools.State) error {
+	d.SetId(state.ID)
+	d.Set("key", state.Key)
+	d.Set("type", state.Type)
+	if state.Name != nil {
+		d.Set("name", *state.Name)
+	}
+	if state.Description != nil {
+		d.Set("description", *state.Description)
+	}
+	d.Set("initial", state.Initial)
+	if state.Roles != nil {
+		d.Set("roles", state.Roles)
+	}
+	return nil
 }
 
 func resourceStateResourceV0() *schema.Resource {

--- a/commercetools/resource_state_test.go
+++ b/commercetools/resource_state_test.go
@@ -15,8 +15,6 @@ func TestAccState_createAndUpdateWithID(t *testing.T) {
 
 	newName := "new test state name"
 
-	transition := "state-b"
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -44,30 +42,6 @@ func TestAccState_createAndUpdateWithID(t *testing.T) {
 					),
 				),
 			},
-			{
-				Config: testAccTransitionConfig(t, transition),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-t1", "transitions.#", "1",
-					),
-				),
-			},
-			{
-				Config: testAccTransitionsConfig(t, "null"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr(
-						"commercetools_state.acctest-transitions", "transitions",
-					),
-				),
-			},
-			{
-				Config: testAccTransitionsConfig(t, "[]"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-transitions", "transitions.#", "0",
-					),
-				),
-			},
 		},
 	})
 }
@@ -92,42 +66,6 @@ func testAccStateConfig(t *testing.T, name string, key string, addRole bool) str
 	newState := buf.String()
 
 	return newState
-}
-
-func testAccTransitionConfig(t *testing.T, transition string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_state" "acctest-t1" {
-		depends_on = [commercetools_state.acctest_t2]
-		key = "state-a"
-		type = "ReviewState"
-		name = {
-			en = "State #1"
-		}
-		transitions = ["%[1]s"]
-	}
-
-	resource "commercetools_state" "acctest_t2" {
-		key = "%[1]s"
-		type = "ReviewState"
-		name = {
-			en = "State #2"
-		}
-		transitions = []
-	}
-	`, transition)
-}
-
-func testAccTransitionsConfig(t *testing.T, transitions string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_state" "acctest-transitions" {
-		key = "state-c"
-		type = "ReviewState"
-		name = {
-			en = "State C"
-		}
-		transitions = %s
-	}
-	`, transitions)
 }
 
 func testAccCheckStateDestroy(s *terraform.State) error {

--- a/commercetools/resource_state_transitions.go
+++ b/commercetools/resource_state_transitions.go
@@ -1,0 +1,235 @@
+package commercetools
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/labd/commercetools-go-sdk/commercetools"
+)
+
+func resourceStateTransitions() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceStateTransitionsCreate,
+		Read:   resourceStateTransitionsRead,
+		Update: resourceStateTransitionsUpdate,
+		Delete: resourceStateTransitionsDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"from": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"to": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceStateTransitionsCreate(d *schema.ResourceData, m interface{}) error {
+	fromStateID := d.Get("from").(string)
+
+	// Lock to prevent concurrent updates due to Version number conflicts
+	ctMutexKV.Lock(fromStateID)
+	defer ctMutexKV.Unlock(fromStateID)
+
+	client := getClient(m)
+	log.Printf("[DEBUG] Reading state from commercetools, with id: %s", fromStateID)
+	fromState, err := client.StateGetWithID(fromStateID)
+	if err != nil {
+		return err
+	}
+
+	updatedState, err := updateTransitions(client, stateTransitionsUpdateInput{
+		ID:            fromState.ID,
+		Version:       fromState.Version,
+		TransitionIDs: d.Get("to").(*schema.Set).List(),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(updatedState.ID)
+	return setStateTransitionsResourceState(d, updatedState)
+}
+
+func resourceStateTransitionsRead(d *schema.ResourceData, m interface{}) error {
+	fromStateID := d.Id()
+	client := getClient(m)
+	log.Printf("[DEBUG] Reading state from commercetools, with id: %s", fromStateID)
+	fromState, err := client.StateGetWithID(fromStateID)
+
+	if err != nil {
+		if ctErr, ok := err.(commercetools.ErrorResponse); ok {
+			log.Printf("[DEBUG] No state found with id: %s", fromStateID)
+			if ctErr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	if fromState == nil {
+		log.Printf("[DEBUG] No state found with id: %s", fromStateID)
+		d.SetId("")
+	} else {
+		log.Printf("[DEBUG] No state found with id: %s", fromStateID)
+		log.Print(stringFormatObject(fromState))
+
+		err = setStateTransitionsResourceState(d, fromState)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceStateTransitionsUpdate(d *schema.ResourceData, m interface{}) error {
+	fromStateID := d.Get("from").(string)
+
+	// Lock to prevent concurrent updates due to Version number conflicts
+	ctMutexKV.Lock(fromStateID)
+	defer ctMutexKV.Unlock(fromStateID)
+
+	client := getClient(m)
+	log.Printf("[DEBUG] Reading state from commercetools, with id: %s", fromStateID)
+	fromState, err := client.StateGetWithID(fromStateID)
+
+	if err != nil {
+		return err
+	}
+
+	if d.HasChange("to") {
+		updatedState, err := updateTransitions(client, stateTransitionsUpdateInput{
+			ID:            fromStateID,
+			Version:       fromState.Version,
+			TransitionIDs: d.Get("to").(*schema.Set).List(),
+		})
+		if err != nil {
+			return err
+		}
+
+		return setStateTransitionsResourceState(d, updatedState)
+	}
+
+	return nil
+}
+
+func resourceStateTransitionsDelete(d *schema.ResourceData, m interface{}) error {
+	fromStateID := d.Get("from").(string)
+
+	// Lock to prevent concurrent updates due to Version number conflicts
+	ctMutexKV.Lock(fromStateID)
+	defer ctMutexKV.Unlock(fromStateID)
+
+	client := getClient(m)
+	log.Printf("[DEBUG] Reading state from commercetools, with id: %s", fromStateID)
+	fromState, err := client.StateGetWithID(fromStateID)
+
+	if err != nil {
+		return err
+	}
+
+	// TODO: How do we indicate that we should be destroyed before other
+	// transitions are created for this state?
+	_, err = updateTransitions(client, stateTransitionsUpdateInput{
+		ID:            fromState.ID,
+		Version:       fromState.Version,
+		TransitionIDs: nil,
+	})
+	if ctErr, ok := err.(commercetools.ErrorResponse); ok {
+		if ctErr.StatusCode == 404 {
+			return nil // Ignore a 404, the state is destroyed so we have been destroyed implicitly
+		}
+	}
+	return err
+}
+
+func setStateTransitionsResourceState(d *schema.ResourceData, state *commercetools.State) error {
+	if state.Transitions == nil {
+		d.SetId("")
+		return nil
+	}
+
+	toStates := make([]string, len(state.Transitions))
+	for i, stateRef := range state.Transitions {
+		toStates[i] = stateRef.ID
+	}
+
+	d.Set("from", state.ID)
+	d.Set("to", toStates)
+
+	log.Printf("[DEBUG] New state: %#v", d)
+	return nil
+}
+
+// Commerce Tools client patch
+//
+// There is a BIG difference between states with transitions = null vs transitions = []
+// A state with transitions = null is one that can be transitioned into any other state
+// A state with transitions = [] is one that can not be transitioned at all
+//
+// Unfortunately, the Commerce Tools go SDK omits empty transitions from the setTransitions
+// update action, meaning that an empty array of transitions or a null transitions array
+// will both result in null transitions in Commerce Tools.
+//
+// Would need to tackle this https://github.com/labd/commercetools-go-sdk/pull/45 if we
+// wanted to fix this upstream.
+
+type stateTransitionsUpdateInput struct {
+	ID            string
+	Version       int
+	TransitionIDs []interface{}
+}
+
+// Our patched version of commercetools.StateSetTransitionsAction
+type stateSetTransitionsAction struct {
+	Transitions []commercetools.StateResourceIdentifier `json:"transitions"`
+}
+
+// MarshalJSON override to set the discriminator value
+func (obj stateSetTransitionsAction) MarshalJSON() ([]byte, error) {
+	type Alias stateSetTransitionsAction
+	return json.Marshal(struct {
+		Action string `json:"action"`
+		*Alias
+	}{Action: "setTransitions", Alias: (*Alias)(&obj)})
+}
+
+func updateTransitions(client *commercetools.Client, input stateTransitionsUpdateInput) (result *commercetools.State, err error) {
+	var transitions []commercetools.StateResourceIdentifier
+	if input.TransitionIDs != nil {
+		transitions = make([]commercetools.StateResourceIdentifier, len(input.TransitionIDs))
+		for i, value := range input.TransitionIDs {
+			transitions[i] = commercetools.StateResourceIdentifier{
+				ID: value.(string),
+			}
+		}
+	}
+
+	actions := []interface{}{stateSetTransitionsAction{Transitions: transitions}}
+	endpoint := strings.Replace("states/{ID}", "{ID}", input.ID, 1)
+
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		attemptErr := client.Update(endpoint, nil, input.Version, actions, &result)
+		if attemptErr != nil {
+			return handleCommercetoolsError(attemptErr)
+		}
+		return nil
+	})
+
+	return
+}

--- a/commercetools/resource_state_transitions_test.go
+++ b/commercetools/resource_state_transitions_test.go
@@ -1,0 +1,176 @@
+package commercetools
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccStateTransitions_create(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStateTransitionsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStateTransitionsOneTransitionConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"commercetools_state_transitions.test_transition", "from",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_state_transitions.test_transition", "to.#", "1",
+					),
+					// TODO: Could we write a check to assert the set actually contains the state ids?
+				),
+			},
+			{
+				Config: testAccStateTransitionsTwoTransitionsConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"commercetools_state_transitions.test_transition", "from",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_state_transitions.test_transition", "to.#", "2",
+					),
+					// TODO: Could we write a check to assert the set actually contains the state ids?
+				),
+			},
+			{
+				ResourceName:      "commercetools_state_transitions.test_transition",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccStateTransitionsZeroTransitionsConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"commercetools_state_transitions.test_transition", "from",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_state_transitions.test_transition", "to.#", "0",
+					),
+				),
+			},
+			{
+				Config: testAccStateTransitionsComplexConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"commercetools_state_transitions.test_state_a", "from",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_state_transitions.test_state_a", "to.#", "1",
+					),
+					resource.TestCheckResourceAttrSet(
+						"commercetools_state_transitions.test_state_b", "from",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_state_transitions.test_state_b", "to.#", "1",
+					),
+					resource.TestCheckResourceAttrSet(
+						"commercetools_state_transitions.test_state_c", "from",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_state_transitions.test_state_c", "to.#", "0",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccStateTransitionsStateFixtures() string {
+	return fmt.Sprintf(`
+resource "commercetools_state" "test_state_a" {
+	key = "state-a"
+	type = "ReviewState"
+	name = {
+		en = "State A"
+	}
+}
+
+resource "commercetools_state" "test_state_b" {
+	key = "state-b"
+	type = "ReviewState"
+	name = {
+		en = "State B"
+	}
+}
+
+resource "commercetools_state" "test_state_c" {
+	key = "state-c"
+	type = "ReviewState"
+	name = {
+		en = "State C"
+	}
+}
+`)
+}
+
+func testAccStateTransitionsZeroTransitionsConfig() string {
+	stateConfig := testAccStateTransitionsStateFixtures()
+	return fmt.Sprintf(`%s
+
+resource "commercetools_state_transitions" "test_transition" {
+	from = commercetools_state.test_state_a.id
+	to   = []
+}
+`, stateConfig)
+}
+
+func testAccStateTransitionsOneTransitionConfig() string {
+	stateConfig := testAccStateTransitionsStateFixtures()
+	return fmt.Sprintf(`%s
+
+resource "commercetools_state_transitions" "test_transition" {
+	from = commercetools_state.test_state_a.id
+	to   = [commercetools_state.test_state_b.id]
+}
+`, stateConfig)
+}
+
+func testAccStateTransitionsTwoTransitionsConfig() string {
+	stateConfig := testAccStateTransitionsStateFixtures()
+	return fmt.Sprintf(`%s
+
+resource "commercetools_state_transitions" "test_transition" {
+	from = commercetools_state.test_state_a.id
+	to   = [
+		commercetools_state.test_state_b.id,
+		commercetools_state.test_state_c.id
+	]
+}
+`, stateConfig)
+}
+
+func testAccStateTransitionsComplexConfig() string {
+	stateConfig := testAccStateTransitionsStateFixtures()
+	return fmt.Sprintf(`%s
+
+resource "commercetools_state_transitions" "test_state_a" {
+	from = commercetools_state.test_state_a.id
+	to   = [
+		commercetools_state.test_state_b.id
+	]
+}
+
+resource "commercetools_state_transitions" "test_state_b" {
+	from = commercetools_state.test_state_b.id
+	to   = [
+		commercetools_state.test_state_c.id
+	]
+}
+
+resource "commercetools_state_transitions" "test_state_c" {
+	from = commercetools_state.test_state_c.id
+	to   = []
+}
+`, stateConfig)
+}
+
+func testAccCheckStateTransitionsDestroy(s *terraform.State) error {
+	// TODO: Implement me
+	return nil
+}

--- a/docs/resource_state.md
+++ b/docs/resource_state.md
@@ -36,7 +36,11 @@ resource "commercetools_state" "product_for_sale" {
     en = "Regularly stocked product."
   }
   initial = true
-  transitions = ["${commercetools_state.product_clearance.key}"]
+}
+
+resource "commercetools_state_transitions" "product_for_sale" {
+  from = commercetools_state.product_for_sale.id
+  to   = [commercetools_state.product_clearance.id]
 }
 
 resource "commercetools_state" "product_clearance" {
@@ -61,6 +65,7 @@ The following arguments are supported:
 * `description` - Optional, localized description of the state.
 * `initial` - Optional, initial state of the state machine.
 * `roles` - Optional, list of roles this state has. See [Commercetools documentation][commercetools-states] for possible values.
-* `transitions` - Optional, list of state keys representing the states this state can transition to. If empty then this state can be transitioned to any other state.
+
+If you want to declare state transitions, use the [`commercetools_state_transitions`](/docs/resource_state_transitions.md) resource.
 
 [commercetool-states]: https://docs.commercetools.com/http-api-projects-states.html

--- a/docs/resource_state_transitions.md
+++ b/docs/resource_state_transitions.md
@@ -1,0 +1,84 @@
+# State Transitions
+
+State transitions allow you to define a subset of valid changes of state.
+By default, if no state transitions are defined, a state can be transitioned to any other state.
+Using state transitions narrows the number of states an initial state can be transitioned to.
+Use a `state_transitions` with an empty list of transitions to prevent any transitioning of that state.
+
+Also see the [states HTTP API documentation][commercetool-states].
+
+## Example Usage
+
+Product state transitions from on sale to on clearance or recalled.
+
+```hcl
+resource "commercetools_state" "product_for_sale" {
+  key = "product-for-sale"
+  type = "ProductState"
+  name = {
+    en = "For Sale"
+  }
+  initial = true
+}
+
+resource "commercetools_state" "product_clearance" {
+  key = "product-clearance"
+  type = "ProductState"
+  name = {
+    en = "On Clearance"
+  }
+}
+
+resource "commercetools_state" "product_recalled" {
+  key = "product-clearance"
+  type = "ProductState"
+  name = {
+    en = "Recalled"
+  }
+}
+
+resource "commercetools_state_transitions" "product_for_sale" {
+  from = commercetools_state.product_for_sale.id
+  to   = [
+    commercetools_state.product_clearance.id,
+    commercetools_state.product_recalled.id,
+  ]
+}
+```
+
+Defining a state that can not be transitioned to any other state.
+
+```
+resource "commercetools_state" "review_archived" {
+  key = "review-archived"
+  type = "ReviewState"
+  name = {
+    en = "Archived"
+  }
+  description = {
+    en = "No longer viewable by customers."
+  }
+}
+
+resource "commercetools_state_transitions" "review_archived" {
+  from = commercetools_state.review_archived.id
+  to   = []
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `from` - The id of the state to transition from.
+* `to` - The ids of the states the "from" state can be transitioned to.
+
+[commercetool-states]: https://docs.commercetools.com/http-api-projects-states.html
+
+## Import
+
+State transitions can be imported using the state id, e.g.
+
+```
+$ terraform import commercetools_state_transitions.example 838411e7-84a6-4553-b546-51fb29705529 
+```


### PR DESCRIPTION
This PR introduces a new resource `commercetools_state_transitions` and removes the `transitions` property from `commercetools_state`. This pull request fixes #86, the limitations with the existing attribute based approach are discussed there.

## TODO

- [x] Add state transitions lifecycle
- [x] Import state transitions resource
- [x] Update state resource with mutex
- [x] Handle deletion race conditions
- [x] Update documentation
- [x] Remove `commercetools_state` resource's `transitions` attribute
- [x] Remove redundant `StateGetWithID` call to CT API on `commercetools_state` update
- [x] ~Investigate [multiple resource import](https://www.terraform.io/docs/extend/resources/import.html#multiple-resource-import) for `commercetools_state`~ _Will tackle this in a separate PR, this one's on the larger side already._

## Possible contention points

### Removing the version attribute from state

The `commercetools_state` resource has a `version` attribute which I don't think makes sense any more. It's possible for this version attribute to fall out of sync due to changes in a related `commercetools_state_transitions` resource.

1. `commercetools_state` is created, version is stored in TF state as `version=1`
2. `commercetools_state_transitions` are created, updating the `commercetools_state` and increasing the version in Commerce Tools state to `version=2`
3. The versions between CT and TF now no longer match (TF still thinks `version=1`)

Because of this I have chosen to remove the version attribute, I can't _think_ of any use cases that require it, but it would be good to discuss this change further.

### Multiple state transitions resources for a single state

I was wondering whether there was a way to guard against multiple state transitions resources referencing the same state in Commerce Tools. ie. is there any way to return an error to the user in the following scenario:

```hcl
resource "commercetools_state" "state_a" { /* omitted */ }

resource "commercetools_state_transitions" "state_a" {
	from = commercetools_state.test_state_a.id
	to   = [ /* etc. */ ]
}

resource "commercetools_state_transitions" "state_a_duplicate" {
	from = commercetools_state.test_state_a.id
	to   = [ /* etc. */ ]
}
```
Seems like this is more of a design problem for Terraform core, as individual resources don't know about other resources of the same type. There is an open issue in the Terraform repo about this topic https://github.com/hashicorp/terraform/issues/18444