### PR TITLE
Bugfix: Adding an action to a `commercetools_api_extension` has no effect

### DIFF
--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -65,7 +65,7 @@ func resourceAPIExtension() *schema.Resource {
 					},
 				},
 			},
-			"triggers": {
+			"trigger": {
 				Type:     schema.TypeList,
 				Required: true,
 				Elem: &schema.Resource{
@@ -176,7 +176,7 @@ func resourceAPIExtensionRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("version", extension.Version)
 		d.Set("key", extension.Key)
 		d.Set("destination", extension.Destination)
-		d.Set("triggers", extension.Triggers)
+		d.Set("trigger", extension.Triggers)
 		d.Set("timeout_in_ms", extension.TimeoutInMs)
 	}
 	return nil
@@ -198,7 +198,7 @@ func resourceAPIExtensionUpdate(d *schema.ResourceData, m interface{}) error {
 			&commercetools.ExtensionSetKeyAction{Key: newKey})
 	}
 
-	if d.HasChange("triggers") {
+	if d.HasChange("trigger") {
 		triggers := resourceAPIExtensionGetTriggers(d)
 		input.Actions = append(
 			input.Actions,
@@ -296,7 +296,7 @@ func resourceAPIExtensionGetAuthentication(destInput map[string]interface{}) (co
 }
 
 func resourceAPIExtensionGetTriggers(d *schema.ResourceData) []commercetools.ExtensionTrigger {
-	input := d.Get("triggers").([]interface{})
+	input := d.Get("trigger").([]interface{})
 	var result []commercetools.ExtensionTrigger
 
 	for _, raw := range input {

--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -65,7 +65,7 @@ func resourceAPIExtension() *schema.Resource {
 					},
 				},
 			},
-			"trigger": {
+			"triggers": {
 				Type:     schema.TypeList,
 				Required: true,
 				Elem: &schema.Resource{
@@ -296,7 +296,7 @@ func resourceAPIExtensionGetAuthentication(destInput map[string]interface{}) (co
 }
 
 func resourceAPIExtensionGetTriggers(d *schema.ResourceData) []commercetools.ExtensionTrigger {
-	input := d.Get("trigger").([]interface{})
+	input := d.Get("triggers").([]interface{})
 	var result []commercetools.ExtensionTrigger
 
 	for _, raw := range input {

--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -80,6 +80,26 @@ func TestAccAPIExtension_basic(t *testing.T) {
 						"commercetools_api_extension.ext", "key", name),
 					resource.TestCheckResourceAttr(
 						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "trigger.0.actions.#", "1"),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
+				),
+			},
+			{
+				Config: testAccAPIExtensionUpdate(name, timeoutInMs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAPIExtensionExists("ext"),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "key", name),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "trigger.0.actions.#", "2"),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "trigger.0.actions.1", "Update"),
 				),
 			},
 		},
@@ -87,6 +107,26 @@ func TestAccAPIExtension_basic(t *testing.T) {
 }
 
 func testAccAPIExtensionConfig(name string, timeoutInMs int) string {
+	return fmt.Sprintf(`
+resource "commercetools_api_extension" "ext" {
+  key = "%s"
+  timeout_in_ms = %d
+
+  destination = {
+    type                 = "HTTP"
+    url                  = "https://example.com"
+    authorization_header = "Basic 12345"
+  }
+
+  trigger {
+    resource_type_id = "customer"
+    actions = ["Create"]
+  }
+}
+`, name, timeoutInMs)
+}
+
+func testAccAPIExtensionUpdate(name string, timeoutInMs int) string {
 	return fmt.Sprintf(`
 resource "commercetools_api_extension" "ext" {
   key = "%s"

--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -81,9 +81,9 @@ func TestAccAPIExtension_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "triggers.0.actions.#", "1"),
+						"commercetools_api_extension.ext", "trigger.0.actions.#", "1"),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "triggers.0.actions.0", "Create"),
+						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
 				),
 			},
 			{
@@ -95,11 +95,11 @@ func TestAccAPIExtension_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "triggers.0.actions.#", "2"),
+						"commercetools_api_extension.ext", "trigger.0.actions.#", "2"),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "triggers.0.actions.0", "Create"),
+						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "triggers.0.actions.1", "Update"),
+						"commercetools_api_extension.ext", "trigger.0.actions.1", "Update"),
 				),
 			},
 		},
@@ -118,7 +118,7 @@ resource "commercetools_api_extension" "ext" {
     authorization_header = "Basic 12345"
   }
 
-  triggers {
+  trigger {
     resource_type_id = "customer"
     actions = ["Create"]
   }
@@ -138,7 +138,7 @@ resource "commercetools_api_extension" "ext" {
     authorization_header = "Basic 12345"
   }
 
-  triggers {
+  trigger {
     resource_type_id = "customer"
     actions = ["Create", "Update"]
   }

--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -81,9 +81,9 @@ func TestAccAPIExtension_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.#", "1"),
+						"commercetools_api_extension.ext", "triggers.0.actions.#", "1"),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
+						"commercetools_api_extension.ext", "triggers.0.actions.0", "Create"),
 				),
 			},
 			{
@@ -95,11 +95,11 @@ func TestAccAPIExtension_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.#", "2"),
+						"commercetools_api_extension.ext", "triggers.0.actions.#", "2"),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
+						"commercetools_api_extension.ext", "triggers.0.actions.0", "Create"),
 					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.1", "Update"),
+						"commercetools_api_extension.ext", "triggers.0.actions.1", "Update"),
 				),
 			},
 		},
@@ -118,7 +118,7 @@ resource "commercetools_api_extension" "ext" {
     authorization_header = "Basic 12345"
   }
 
-  trigger {
+  triggers {
     resource_type_id = "customer"
     actions = ["Create"]
   }
@@ -138,7 +138,7 @@ resource "commercetools_api_extension" "ext" {
     authorization_header = "Basic 12345"
   }
 
-  trigger {
+  triggers {
     resource_type_id = "customer"
     actions = ["Create", "Update"]
   }


### PR DESCRIPTION
Fixes #129 

**Cause:** 
Occurrence of both `triggers` as well as `trigger` was causing provider to miss updates to the block. 

**Solution:**
As we allow a slice of actions and will soon allow a slice of triggers for different resourceTypeIDs ( https://github.com/labd/terraform-provider-commercetools/pull/143 ), we should stick to `triggers`. Also added tests to verify.