### PR TITLE
adding a category resource ( with most fields supported )

### DIFF
--- a/commercetools/provider.go
+++ b/commercetools/provider.go
@@ -73,6 +73,7 @@ func Provider() terraform.ResourceProvider {
 			"commercetools_subscription":       resourceSubscription(),
 			"commercetools_tax_category_rate":  resourceTaxCategoryRate(),
 			"commercetools_tax_category":       resourceTaxCategory(),
+			"commercetools_category":           resourceCategory(),
 			"commercetools_type":               resourceType(),
 		},
 		ConfigureFunc: providerConfigure,

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -75,17 +75,17 @@ func resourceCategoryCreate(d *schema.ResourceData, m interface{}) error {
 	name := commercetools.LocalizedString(expandStringMap(d.Get("name").(map[string]interface{})))
 	desc := commercetools.LocalizedString(expandStringMap(d.Get("description").(map[string]interface{})))
 	slug := commercetools.LocalizedString(expandStringMap(d.Get("slug").(map[string]interface{})))
-	metaTitle := commercetools.LocalizedString(expandStringMap(d.Get("metaTitle").(map[string]interface{})))
-	metaDescription := commercetools.LocalizedString(expandStringMap(d.Get("metaDescription").(map[string]interface{})))
-	metaKeywords := commercetools.LocalizedString(expandStringMap(d.Get("metaKeywords").(map[string]interface{})))
+	metaTitle := commercetools.LocalizedString(expandStringMap(d.Get("meta_title").(map[string]interface{})))
+	metaDescription := commercetools.LocalizedString(expandStringMap(d.Get("meta_description").(map[string]interface{})))
+	metaKeywords := commercetools.LocalizedString(expandStringMap(d.Get("meta_keywords").(map[string]interface{})))
 
 	draft := &commercetools.CategoryDraft{
 		Key: d.Get("key").(string),
 		Name:        &name,
 		Description: &desc,
 		Slug:        &slug,
-		OrderHint:  d.Get("orderHint").(string),
-		ExternalID:  d.Get("externalId").(string),
+		OrderHint:  d.Get("order_hint").(string),
+		ExternalID:  d.Get("external_id").(string),
 		MetaTitle: &metaTitle,
 		MetaDescription: &metaDescription,
 		MetaKeywords: &metaKeywords,
@@ -142,11 +142,18 @@ func resourceCategoryRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("key", category.Key)
 		d.Set("name", *category.Name)
 		d.Set("description", *category.Description)
-		d.Set("orderHint", category.OrderHint)
-		d.Set("externalId", category.ExternalID)
-		d.Set("metaTitle", *category.MetaTitle)
-		d.Set("metaDescription", *category.MetaDescription)
-		d.Set("metaKeywords", *category.MetaKeywords)
+		d.Set("order_hint", category.OrderHint)
+		d.Set("external_id", category.ExternalID)
+		if  category.MetaTitle != nil {
+			d.Set("meta_title", *category.MetaTitle)
+		}
+		if category.MetaDescription != nil {
+			d.Set("meta_description", *category.MetaDescription)
+		}
+		if category.MetaKeywords != nil {
+			d.Set("meta_keywords", *category.MetaKeywords)
+		}
+
 	}
 	return nil
 }
@@ -188,18 +195,15 @@ func resourceCategoryUpdate(d *schema.ResourceData, m interface{}) error {
 			&commercetools.CategorySetKeyAction{Key: newKey})
 	}
 
-	if d.HasChange("orderHint") {
-		newVal := d.Get("orderHint").(string)
-		input.Actions = append(
-			input.Actions,
-			&commercetools.CategorySetKeyAction{Key: newVal})
+	if d.HasChange("order_hint") {
+		// cant update order once created
 	}
 
-	if d.HasChange("externalId") {
-		newVal := d.Get("externalId").(string)
+	if d.HasChange("external_id") {
+		newVal := d.Get("external_id").(string)
 		input.Actions = append(
 			input.Actions,
-			&commercetools.CategorySetKeyAction{Key: newVal})
+			&commercetools.CategorySetExternalIDAction{ExternalID: newVal})
 	}
 
 	if d.HasChange("description") {
@@ -209,25 +213,25 @@ func resourceCategoryUpdate(d *schema.ResourceData, m interface{}) error {
 			&commercetools.CategorySetDescriptionAction{Description: &newDescription})
 	}
 
-	if d.HasChange("metaTitle") {
-		newMetaTitle := commercetools.LocalizedString(expandStringMap(d.Get("metaTitle").(map[string]interface{})))
+	if d.HasChange("meta_title") {
+		newMetaTitle := commercetools.LocalizedString(expandStringMap(d.Get("meta_title").(map[string]interface{})))
 		input.Actions = append(
 			input.Actions,
-			&commercetools.CategorySetDescriptionAction{Description: &newMetaTitle})
+			&commercetools.CategorySetMetaTitleAction{MetaTitle: &newMetaTitle})
 	}
 
-	if d.HasChange("metaDescription") {
-		newMetaDescription := commercetools.LocalizedString(expandStringMap(d.Get("metaDescription").(map[string]interface{})))
+	if d.HasChange("meta_description") {
+		newMetaDescription := commercetools.LocalizedString(expandStringMap(d.Get("meta_description").(map[string]interface{})))
 		input.Actions = append(
 			input.Actions,
-			&commercetools.CategorySetDescriptionAction{Description: &newMetaDescription})
+			&commercetools.CategorySetMetaDescriptionAction{MetaDescription: &newMetaDescription})
 	}
 
-	if d.HasChange("metaKeywords") {
-		newMetaKeywords := commercetools.LocalizedString(expandStringMap(d.Get("metaKeywords").(map[string]interface{})))
+	if d.HasChange("meta_keywords") {
+		newMetaKeywords := commercetools.LocalizedString(expandStringMap(d.Get("meta_keywords").(map[string]interface{})))
 		input.Actions = append(
 			input.Actions,
-			&commercetools.CategorySetDescriptionAction{Description: &newMetaKeywords})
+			&commercetools.CategorySetMetaKeywordsAction{MetaKeywords: &newMetaKeywords})
 	}
 
 	log.Printf(

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -39,7 +39,11 @@ func resourceCategory() *schema.Resource {
 				Required: true,
 			},
 			//parent
-			//order_hint,
+			//order_hint
+			"order_hint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"external_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -81,6 +85,7 @@ func resourceCategoryCreate(d *schema.ResourceData, m interface{}) error {
 		Name:        &name,
 		Description: &desc,
 		Slug:        &slug,
+		OrderHint:  d.Get("order_hint").(string),
 		ExternalID:  d.Get("external_id").(string),
 		MetaTitle: &metaTitle,
 		MetaDescription: &metaDescription,
@@ -138,6 +143,7 @@ func resourceCategoryRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("key", category.Key)
 		d.Set("name", *category.Name)
 		d.Set("description", *category.Description)
+		d.Set("order_hint", category.OrderHint)
 		d.Set("external_id", category.ExternalID)
 		if  category.MetaTitle != nil {
 			d.Set("meta_title", *category.MetaTitle)
@@ -190,6 +196,12 @@ func resourceCategoryUpdate(d *schema.ResourceData, m interface{}) error {
 			&commercetools.CategorySetKeyAction{Key: newKey})
 	}
 
+	if d.HasChange("order_hint") {
+		newKey := d.Get("order_hint").(string)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategoryChangeOrderHintAction{OrderHint: newKey})
+	}
 
 	if d.HasChange("external_id") {
 		newVal := d.Get("external_id").(string)

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -23,10 +23,12 @@ func resourceCategory() *schema.Resource {
 			"key": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"name": {
 				Type:     schema.TypeMap,
 				Required: true,
+				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeMap,

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -39,23 +39,23 @@ func resourceCategory() *schema.Resource {
 				Required: true,
 			},
 			//parent
-			"orderHint": {
+			"order_hint": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"externalId": {
+			"external_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"metaTitle": {
+			"meta_title": {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
-			"metaDescription": {
+			"meta_description": {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
-			"metaKeywords": {
+			"meta_keywords": {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -1,0 +1,263 @@
+package commercetools
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/labd/commercetools-go-sdk/commercetools"
+)
+
+func resourceCategory() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCategoryCreate,
+		Read:   resourceCategoryRead,
+		Update: resourceCategoryUpdate,
+		Delete: resourceCategoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeMap,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+			"slug": {
+				Type:     schema.TypeMap,
+				Required: true,
+			},
+			//parent
+			"orderHint": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"externalId": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"metaTitle": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+			"metaDescription": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+			"metaKeywords": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+			//custom
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCategoryCreate(d *schema.ResourceData, m interface{}) error {
+	client := getClient(m)
+	var category *commercetools.Category
+
+	name := commercetools.LocalizedString(expandStringMap(d.Get("name").(map[string]interface{})))
+	desc := commercetools.LocalizedString(expandStringMap(d.Get("description").(map[string]interface{})))
+	slug := commercetools.LocalizedString(expandStringMap(d.Get("slug").(map[string]interface{})))
+	metaTitle := commercetools.LocalizedString(expandStringMap(d.Get("metaTitle").(map[string]interface{})))
+	metaDescription := commercetools.LocalizedString(expandStringMap(d.Get("metaDescription").(map[string]interface{})))
+	metaKeywords := commercetools.LocalizedString(expandStringMap(d.Get("metaKeywords").(map[string]interface{})))
+
+	draft := &commercetools.CategoryDraft{
+		Key: d.Get("key").(string),
+		Name:        &name,
+		Description: &desc,
+		Slug:        &slug,
+		OrderHint:  d.Get("orderHint").(string),
+		ExternalID:  d.Get("externalId").(string),
+		MetaTitle: &metaTitle,
+		MetaDescription: &metaDescription,
+		MetaKeywords: &metaKeywords,
+	}
+
+	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		var err error
+
+		category, err = client.CategoryCreate(context.Background(), draft)
+		if err != nil {
+			return handleCommercetoolsError(err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if category == nil {
+		log.Fatal("No  category created?")
+	}
+
+	d.SetId(category.ID)
+	d.Set("version", category.Version)
+
+	return resourceCategoryRead(d, m)
+}
+
+func resourceCategoryRead(d *schema.ResourceData, m interface{}) error {
+	log.Printf("[DEBUG] Reading category from commercetools, with category id: %s", d.Id())
+	client := getClient(m)
+
+	category, err := client.CategoryGetWithID(context.Background(), d.Id())
+
+	if err != nil {
+		if ctErr, ok := err.(commercetools.ErrorResponse); ok {
+			if ctErr.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	if category == nil {
+		log.Print("[DEBUG] No category found")
+		d.SetId("")
+	} else {
+		log.Print("[DEBUG] Found following category:")
+		log.Print(stringFormatObject(category))
+
+		d.Set("version", category.Version)
+		d.Set("key", category.Key)
+		d.Set("name", *category.Name)
+		d.Set("description", *category.Description)
+		d.Set("orderHint", category.OrderHint)
+		d.Set("externalId", category.ExternalID)
+		d.Set("metaTitle", *category.MetaTitle)
+		d.Set("metaDescription", *category.MetaDescription)
+		d.Set("metaKeywords", *category.MetaKeywords)
+	}
+	return nil
+}
+
+func resourceCategoryUpdate(d *schema.ResourceData, m interface{}) error {
+	ctMutexKV.Lock(d.Id())
+	defer ctMutexKV.Unlock(d.Id())
+
+	client := getClient(m)
+	category, err := client.CategoryGetWithID(context.Background(), d.Id())
+	if err != nil {
+		return err
+	}
+
+	input := &commercetools.CategoryUpdateWithIDInput{
+		ID:      d.Id(),
+		Version: category.Version,
+		Actions: []commercetools.CategoryUpdateAction{},
+	}
+
+	if d.HasChange("name") {
+		newName := commercetools.LocalizedString(expandStringMap(d.Get("name").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategoryChangeNameAction{Name: &newName})
+	}
+
+	if d.HasChange("slug") {
+		newSlug := commercetools.LocalizedString(expandStringMap(d.Get("slug").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategoryChangeSlugAction{Slug: &newSlug})
+	}
+
+	if d.HasChange("key") {
+		newKey := d.Get("key").(string)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategorySetKeyAction{Key: newKey})
+	}
+
+	if d.HasChange("orderHint") {
+		newVal := d.Get("orderHint").(string)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategorySetKeyAction{Key: newVal})
+	}
+
+	if d.HasChange("externalId") {
+		newVal := d.Get("externalId").(string)
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategorySetKeyAction{Key: newVal})
+	}
+
+	if d.HasChange("description") {
+		newDescription := commercetools.LocalizedString(expandStringMap(d.Get("description").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategorySetDescriptionAction{Description: &newDescription})
+	}
+
+	if d.HasChange("metaTitle") {
+		newMetaTitle := commercetools.LocalizedString(expandStringMap(d.Get("metaTitle").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategorySetDescriptionAction{Description: &newMetaTitle})
+	}
+
+	if d.HasChange("metaDescription") {
+		newMetaDescription := commercetools.LocalizedString(expandStringMap(d.Get("metaDescription").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategorySetDescriptionAction{Description: &newMetaDescription})
+	}
+
+	if d.HasChange("metaKeywords") {
+		newMetaKeywords := commercetools.LocalizedString(expandStringMap(d.Get("metaKeywords").(map[string]interface{})))
+		input.Actions = append(
+			input.Actions,
+			&commercetools.CategorySetDescriptionAction{Description: &newMetaKeywords})
+	}
+
+	log.Printf(
+		"[DEBUG] Will perform update operation with the following actions:\n%s",
+		stringFormatActions(input.Actions))
+
+	_, err = client.CategoryUpdateWithID(context.Background(), input)
+	if err != nil {
+		if ctErr, ok := err.(commercetools.ErrorResponse); ok {
+			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+		}
+		return err
+	}
+
+	return resourceCategoryRead(d, m)
+}
+
+func resourceCategoryDelete(d *schema.ResourceData, m interface{}) error {
+	client := getClient(m)
+
+	// Lock to prevent concurrent updates due to Version number conflicts
+	ctMutexKV.Lock(d.Id())
+	defer ctMutexKV.Unlock(d.Id())
+
+	category, err := client.CategoryGetWithID(context.Background(), d.Id())
+	if err != nil {
+		return err
+	}
+	_, err = client.CategoryDeleteWithID(context.Background(), d.Id(), category.Version)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -39,10 +39,7 @@ func resourceCategory() *schema.Resource {
 				Required: true,
 			},
 			//parent
-			"order_hint": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+			//order_hint,
 			"external_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -84,7 +81,6 @@ func resourceCategoryCreate(d *schema.ResourceData, m interface{}) error {
 		Name:        &name,
 		Description: &desc,
 		Slug:        &slug,
-		OrderHint:  d.Get("order_hint").(string),
 		ExternalID:  d.Get("external_id").(string),
 		MetaTitle: &metaTitle,
 		MetaDescription: &metaDescription,
@@ -142,7 +138,6 @@ func resourceCategoryRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("key", category.Key)
 		d.Set("name", *category.Name)
 		d.Set("description", *category.Description)
-		d.Set("order_hint", category.OrderHint)
 		d.Set("external_id", category.ExternalID)
 		if  category.MetaTitle != nil {
 			d.Set("meta_title", *category.MetaTitle)
@@ -195,9 +190,6 @@ func resourceCategoryUpdate(d *schema.ResourceData, m interface{}) error {
 			&commercetools.CategorySetKeyAction{Key: newKey})
 	}
 
-	if d.HasChange("order_hint") {
-		// cant update order once created
-	}
 
 	if d.HasChange("external_id") {
 		newVal := d.Get("external_id").(string)

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -1,0 +1,86 @@
+package commercetools
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"testing"
+)
+
+func testCategory() string {
+	return `resource "commercetools_category" "accessoriesz" {
+			name = {
+				en = "accessories"
+			}
+			key = "bananas123"
+			description = {
+				en = "da"
+			}
+			slug = {
+				en = "bananas_accessories"
+			}
+			order_hint = "0.001"
+			external_id = "iddqd"
+			meta_title = { en = "foo" }
+			meta_description = { en = "bar" }
+			meta_keywords = { en = "baz" }
+		}`
+}
+
+func testCategoryUpdate() string {
+	return `resource "commercetools_category" "accessoriesz" {
+			name = {
+				en = "accessories"
+			}
+			key = "bananas123"
+			description = {
+				en = "vi very viniversum vivus vicy"
+			}
+			slug = {
+				en = "bananas_accessories"
+			}
+			order_hint = "0.001"
+			external_id = "idclip"
+			meta_title = { en = "baz" }
+			meta_description = { en = "foo" }
+			meta_keywords = { en = "bar" }
+		}`
+}
+
+
+func TestCategoryCreate_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testCategory(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "name.en", "accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "da"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.001"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "iddqd"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "foo"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "bar"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_keywords.en", "baz"),
+				),
+			},
+			{
+				Config: testCategoryUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "name.en", "accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "vi very viniversum vivus vicy"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.001"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "idclip"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "baz"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "foo"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_keywords.en", "bar"),
+				),
+			},
+		},
+	})
+}

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -17,7 +17,6 @@ func testCategory() string {
 			slug = {
 				en = "bananas_accessories"
 			}
-			order_hint = "0.001"
 			external_id = "iddqd"
 			meta_title = { en = "foo" }
 			meta_description = { en = "bar" }
@@ -37,7 +36,6 @@ func testCategoryUpdate() string {
 			slug = {
 				en = "bananas_accessories"
 			}
-			order_hint = "0.001"
 			external_id = "idclip"
 			meta_title = { en = "baz" }
 			meta_description = { en = "foo" }
@@ -60,7 +58,6 @@ func TestCategoryCreate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "da"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.001"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "iddqd"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "foo"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "bar"),
@@ -74,7 +71,6 @@ func TestCategoryCreate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "vi very viniversum vivus vicy"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.001"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "idclip"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "baz"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "foo"),

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -17,6 +17,7 @@ func testCategory() string {
 			slug = {
 				en = "bananas_accessories"
 			}
+			order_hint = "0.001"
 			external_id = "iddqd"
 			meta_title = { en = "foo" }
 			meta_description = { en = "bar" }
@@ -36,6 +37,7 @@ func testCategoryUpdate() string {
 			slug = {
 				en = "bananas_accessories"
 			}
+			order_hint = "0.002"
 			external_id = "idclip"
 			meta_title = { en = "baz" }
 			meta_description = { en = "foo" }
@@ -58,6 +60,7 @@ func TestCategoryCreate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "da"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.001"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "iddqd"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "foo"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "bar"),
@@ -71,6 +74,7 @@ func TestCategoryCreate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "vi very viniversum vivus vicy"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.002"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "idclip"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "baz"),
 					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "foo"),

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -1,9 +1,66 @@
 package commercetools
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"testing"
 )
+
+func TestCategoryCreate_basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testCategory(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "name.en", "accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "da"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.001"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "iddqd"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "foo"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "bar"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_keywords.en", "baz"),
+				),
+			},
+			{
+				Config: testCategoryUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "name.en", "accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "vi very viniversum vivus vicy"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.002"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "idclip"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "baz"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "foo"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_keywords.en", "bar"),
+				),
+			},{
+				Config: testCreateChildCategory(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("commercetools_category.bracelets", "name.en", "bracelets"),
+					resource.TestCheckResourceAttr("commercetools_category.bracelets", "key", "bracelets123"),
+					resource.TestCheckResourceAttr("commercetools_category.bracelets", "description.en", "nice bracelets"),
+					resource.TestCheckResourceAttr("commercetools_category.bracelets", "slug.en", "foo_bracelets"),
+					resource.TestCheckResourceAttr("commercetools_category.bracelets", "parent_key", "bananas123"),
+
+				),
+			},
+			{
+				Config: testChangeParents(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("commercetools_category.bracelets", "parent_key", "new_parent"),
+				),
+			},
+		},
+	})
+}
+
 
 func testCategory() string {
 	return `resource "commercetools_category" "accessoriesz" {
@@ -45,42 +102,78 @@ func testCategoryUpdate() string {
 		}`
 }
 
+func testCreateChildCategory() string {
+	return fmt.Sprintf(`%s 
 
-func TestCategoryCreate_basic(t *testing.T) {
+resource "commercetools_category" "bracelets" {
+			name = {
+				en = "bracelets"
+			}
+			key = "bracelets123"
+			description = {
+				en = "nice bracelets"
+			}
+			slug = {
+				en = "foo_bracelets"
+			}
+			order_hint = "0.008"
+			parent_key = "bananas123"
+		}`,testCategoryUpdate())
+}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: nil,
-		Steps: []resource.TestStep{
-			{
-				Config: testCategory(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "name.en", "accessories"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "da"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.001"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "iddqd"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "foo"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "bar"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_keywords.en", "baz"),
-				),
-			},
-			{
-				Config: testCategoryUpdate(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "name.en", "accessories"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "key", "bananas123"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "description.en", "vi very viniversum vivus vicy"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "slug.en", "bananas_accessories"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "order_hint", "0.002"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "external_id", "idclip"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_title.en", "baz"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_description.en", "foo"),
-					resource.TestCheckResourceAttr("commercetools_category.accessoriesz", "meta_keywords.en", "bar"),
-				),
-			},
-		},
-	})
+
+
+
+
+func testChangeParents() string {
+	return `
+
+resource "commercetools_category" "accessoriesz" {
+			name = {
+				en = "accessories"
+			}
+			key = "bananas123"
+			description = {
+				en = "vi very viniversum vivus vicy"
+			}
+			slug = {
+				en = "bananas_accessories"
+			}
+			order_hint = "0.002"
+			external_id = "idclip"
+			meta_title = { en = "baz" }
+			meta_description = { en = "foo" }
+			meta_keywords = { en = "bar" }
+}
+
+
+resource "commercetools_category" "accessoriesxx" {
+			name = {
+				en = "accessoriesxx"
+			}
+			key = "new_parent"
+			description = {
+				en = "fooo"
+			}
+			slug = {
+				en = "bar_accessories"
+			}
+			order_hint = "0.002"
+}
+
+resource "commercetools_category" "bracelets" {
+			name = {
+				en = "bracelets"
+			}
+			key = "bracelets123"
+			description = {
+				en = "nice bracelets"
+			}
+			slug = {
+				en = "foo_bracelets"
+			}
+			order_hint = "0.008"
+			parent_key = "new_parent"
+}
+`
 }

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -61,6 +61,37 @@ func TestCategoryCreate_basic(t *testing.T) {
 	})
 }
 
+func TestCategoryCreate_withAssets(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAddAssets(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "key", "accessoriesz_with_assets"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.name.en", "ass1"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.key", "it_a_nice"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.sources.0.uri", "http://google.com"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.sources.0.key", "keywest"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.sources.0.dimensions.w", "240"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.sources.0.dimensions.h", "240"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.sources.0.content_type", "png"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.sources.1.uri", "http://tapuz.com"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.description.en", "terraform is so much fun"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.tags.0", "banana"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.0.tags.1", "tapuz"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.1.name.en", "ass2"),
+					resource.TestCheckResourceAttr("commercetools_category.accessoriesz_with_assets", "assets.1.sources.0.uri", "http://nice.com"),
+				),
+			},
+		},
+	})
+}
+
+
 
 func testCategory() string {
 	return `resource "commercetools_category" "accessoriesz" {
@@ -177,3 +208,54 @@ resource "commercetools_category" "bracelets" {
 }
 `
 }
+
+func testAddAssets() string {
+	return `
+
+resource "commercetools_category" "accessoriesz_with_assets" {
+			name = {
+				en = "banana"
+			}
+			key = "accessoriesz_with_assets"
+			description = {
+				en = "accessoriesz_with_assets"
+			}
+			slug = {
+				en = "accessoriesz_with_assets"
+			}
+			order_hint = "0.002"
+			assets {
+				name = {
+					en = "ass1"
+				}
+				key = "it_a_nice"
+				sources {
+					uri = "http://google.com"
+					key = "keywest"
+					content_type = "png"
+					dimensions = {
+						w = 240
+						h = 240
+					}
+				}
+				sources {
+					uri = "http://tapuz.com"
+				}
+				description = {
+					en = "terraform is so much fun"
+				}
+				tags = ["banana","tapuz"]
+			}
+			assets {
+				name = {
+					en = "ass2"
+				}
+				sources {
+					uri = "http://nice.com"
+				}
+			}
+}
+
+`
+}
+


### PR DESCRIPTION
added support to create flat commerce tools categories.
no support for hierarchies custom fields or assets. ( TBD )


```hsl
resource "commercetools_category" "accessories" {
  name = {
    en = "accessories"
  }
  key = "accessories"
  description = {
    en = "accessories"
  }
  slug = {
    en = "accessories"
  }

}
```

