### PR TITLE
Remove bugged type["name"] condition in resourceType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+====================
+ - Type Resource: Remove invalid type["name"] condition
+
 v0.27.0 (2021-03-01)
 ====================
  - Resource Project: Add new `carts` field to documentation

--- a/commercetools/resource_type.go
+++ b/commercetools/resource_type.go
@@ -99,9 +99,6 @@ func resourceType() *schema.Resource {
 					newType := newF["type"].([]interface{})[0].(map[string]interface{})
 
 					if oldType["name"] != newType["name"] {
-						if oldType["name"] != "" || newType["name"] == "" {
-							continue
-						}
 						return fmt.Errorf(
 							"Field '%s' type changed from %s to %s. Changing types is not supported; please remove the field first and re-define it later",
 							name, oldType["name"], newType["name"])


### PR DESCRIPTION
Closes: https://github.com/labd/terraform-provider-commercetools/issues/99

My guess is the original check was supposed to be:
```go
if oldType["name"] != "" && newType["name"] == "" { 
 		continue 
 	} 
```
To allow for deleting the fieldType without throwing a type changing error. As it was written as a `||` check however it also allowed changing types. 

#### Solution: 
I can't replicate what I assume to be the desired deletion behaviour, and since `type["name"]` is required (https://docs.commercetools.com/api/projects/types#fieldtype) and deleting the whole field works fine, I am removing the extra check to repair the type changing error. 

