### PR TITLE
Update documentation for API ext, remove invalid type for api_ext types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+==========
+ - Resource API Extension: Removed unused `azure_functions` type
+
 v0.27.0 (2021-03-01)
 ====================
  - Resource project: Add `carts` field with countryTaxRateFallBackEnabled setting 

--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -100,8 +100,7 @@ func validateDestinationType(val interface{}, key string) (warns []string, errs 
 	switch v {
 	case
 		"http",
-		"awslambda",
-		"azurefunctions":
+		"awslambda":
 		return
 	default:
 		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))

--- a/docs-rtd/resource_api_extension.md
+++ b/docs-rtd/resource_api_extension.md
@@ -11,8 +11,8 @@ resource "commercetools_api_extension" "my-extension" {
   key = "test-case"
 
   destination {
-    type                 = "HTTP"
-    url                  = "https://example.com"
+    type = "HTTP"
+    url = "https://example.com"
     authorization_header = "Basic 12345"
   }
 
@@ -21,7 +21,6 @@ resource "commercetools_api_extension" "my-extension" {
     actions          = ["Create", "Update"]
   }
 }
-
 ```
 
 ## Argument Reference
@@ -31,6 +30,53 @@ The following arguments are supported:
 * `key` - User-specific unique identifier for the subscription
 * `destination` - Details where the extension can be reached
 * `triggers` - Describes what triggers the extension
-* `timeout_in_ms` - The maximum time the commercetools platform waits for a
-  response from the extension. If not present, 2000 (2 seconds) is used.
+* `timeout_in_ms` - The maximum time the commercetools platform waits for a response from the extension. If not present,
+  2000 (2 seconds) is used.
 
+### Azure Functions
+
+The `destination` field supports Azure functions. In this case pass the `azure_authentication` value instead
+of `authorization_header` like so:
+
+```hcl
+resource "commercetools_api_extension" "my-extension" {
+  key = "test-case"
+
+  destination = {
+    type = "http"
+    url = "https://some_azure_url"
+    azure_authentication = "an_azure_function_key"
+  }
+
+  trigger {
+    resource_type_id = "payment"
+    actions = ["Create", "Update"]
+  }
+
+  timeout_in_ms = 2000
+}
+```
+
+### AWS Lambda
+The `destination` field supports AWS Lambda functions. In this case set `type` to be `awslambda` and pass 
+`arn`, `access_key` and `access_secret` fields like so: 
+
+```hcl
+resource "commercetools_api_extension" "my-extension" {
+  key = "test-case"
+
+  destination = {
+    type = "awslambda"
+    arn = "arn:aws:lambda:some_lambda_arn"
+    access_key = "access_key_123"
+    access_secret = "123secretabc"
+  }
+
+  trigger {
+    resource_type_id = "customer"
+    actions = ["Create", "Update"]
+  }
+
+  timeout_in_ms = 2000
+}
+```


### PR DESCRIPTION
Closes https://github.com/labd/terraform-provider-commercetools/issues/154 

The above issue showed that the api_extension resource documentation could do with some more examples.

This PR also removes a type that is not used and invalid