### PR TITLE
Add destroy checks to acceptance tests

### DIFF
--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -186,7 +186,7 @@ func testAccCheckAPIExtensionDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -171,6 +172,23 @@ func testAccAPIExtensionExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckAPIExtensionDestroy(s *terraform.State) error {
-	// TODO: Implement
+	conn := testAccProvider.Meta().(*commercetools.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_api_extension" {
+			continue
+		}
+		response, err := conn.ExtensionGetWithID(context.Background(), rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.ID == rs.Primary.ID {
+				return fmt.Errorf("api extension (%s) still exists", rs.Primary.ID)
+			}
+			return nil
+		}
+		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+		if !strings.Contains(err.Error(), "was not found") {
+			return err
+		}
+	}
 	return nil
 }

--- a/commercetools/resource_cart_discount_test.go
+++ b/commercetools/resource_cart_discount_test.go
@@ -261,7 +261,7 @@ func testAccCheckCartDiscountDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_custom_object_test.go
+++ b/commercetools/resource_custom_object_test.go
@@ -189,7 +189,7 @@ func testAccCheckCustomObjectDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_customer_group_test.go
+++ b/commercetools/resource_customer_group_test.go
@@ -97,7 +97,7 @@ func testAccCheckCustomerGroupDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_customer_group_test.go
+++ b/commercetools/resource_customer_group_test.go
@@ -1,7 +1,13 @@
 package commercetools
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/labd/commercetools-go-sdk/commercetools"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
@@ -11,7 +17,7 @@ func TestAccCustomerGroupCreate_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: nil,
+		CheckDestroy: testAccCheckCustomerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCustomerGroupConfig(),
@@ -74,4 +80,26 @@ resource "commercetools_customer_group" "standard" {
 	name = "Standard name new"
 }
 `
+}
+
+func testAccCheckCustomerGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*commercetools.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_customer_group" {
+			continue
+		}
+		response, err := conn.CustomerGroupGetWithID(context.Background(), rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.ID == rs.Primary.ID {
+				return fmt.Errorf("customer group (%s) still exists", rs.Primary.ID)
+			}
+			return nil
+		}
+		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+		if !strings.Contains(err.Error(), "was not found") {
+			return err
+		}
+	}
+	return nil
 }

--- a/commercetools/resource_discount_code_test.go
+++ b/commercetools/resource_discount_code_test.go
@@ -338,7 +338,7 @@ func testAccCheckDiscountCodeDestroy(s *terraform.State) error {
 				}
 
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}
@@ -352,7 +352,7 @@ func testAccCheckDiscountCodeDestroy(s *terraform.State) error {
 					continue
 				}
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}

--- a/commercetools/resource_product_type_test.go
+++ b/commercetools/resource_product_type_test.go
@@ -1,7 +1,9 @@
 package commercetools
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -348,6 +350,23 @@ resource "commercetools_product_type" "acctest_product_type" {
 }
 
 func testAccCheckProductTypesDestroy(s *terraform.State) error {
-	// TODO: Implement
+	conn := testAccProvider.Meta().(*commercetools.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_product_type" {
+			continue
+		}
+		response, err := conn.ProductTypeGetWithID(context.Background(), rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.ID == rs.Primary.ID {
+				return fmt.Errorf("product type (%s) still exists", rs.Primary.ID)
+			}
+			return nil
+		}
+		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+		if !strings.Contains(err.Error(), "was not found") {
+			return err
+		}
+	}
 	return nil
 }

--- a/commercetools/resource_product_type_test.go
+++ b/commercetools/resource_product_type_test.go
@@ -364,7 +364,7 @@ func testAccCheckProductTypesDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -105,8 +105,6 @@ func TestAccProjectCreate_basic(t *testing.T) {
 	})
 }
 
-// TODO: We can't destroy a project resource but we could make an explicit check that all settings are returned to default
-// at the end of testing
 func testAccCheckProjectDestroy(s *terraform.State) error {
 	return nil
 }

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -105,6 +105,8 @@ func TestAccProjectCreate_basic(t *testing.T) {
 	})
 }
 
+// TODO: We can't destroy a project resource but we could make an explicit check that all settings are returned to default
+// at the end of testing
 func testAccCheckProjectDestroy(s *terraform.State) error {
 	return nil
 }

--- a/commercetools/resource_shipping_method_test.go
+++ b/commercetools/resource_shipping_method_test.go
@@ -1,8 +1,12 @@
 package commercetools
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/labd/commercetools-go-sdk/commercetools"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -95,5 +99,42 @@ resource "commercetools_shipping_method" "standard" {
 }
 
 func testAccCheckShippingMethodDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*commercetools.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "commercetools_tax_category":
+			{
+				response, err := conn.TaxCategoryGetWithID(context.Background(), rs.Primary.ID)
+				if err == nil {
+					if response != nil && response.ID == rs.Primary.ID {
+						return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
+					}
+					continue
+				}
+
+				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+				if !strings.Contains(err.Error(), "was not found") {
+					return err
+				}
+			}
+		case "commercetools_shipping_method":
+			{
+				response, err := conn.ShippingMethodGetWithID(context.Background(), rs.Primary.ID)
+				if err == nil {
+					if response != nil && response.ID == rs.Primary.ID {
+						return fmt.Errorf("shipping method (%s) still exists", rs.Primary.ID)
+					}
+					continue
+				}
+				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+				if !strings.Contains(err.Error(), "was not found") {
+					return err
+				}
+			}
+		default:
+			continue
+		}
+	}
 	return nil
 }

--- a/commercetools/resource_shipping_method_test.go
+++ b/commercetools/resource_shipping_method_test.go
@@ -114,7 +114,7 @@ func testAccCheckShippingMethodDestroy(s *terraform.State) error {
 				}
 
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}
@@ -128,7 +128,7 @@ func testAccCheckShippingMethodDestroy(s *terraform.State) error {
 					continue
 				}
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}

--- a/commercetools/resource_shipping_zone_rate_test.go
+++ b/commercetools/resource_shipping_zone_rate_test.go
@@ -102,7 +102,7 @@ func testAccCheckShippingZoneRateDestroy(s *terraform.State) error {
 					continue
 				}
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}
@@ -117,7 +117,7 @@ func testAccCheckShippingZoneRateDestroy(s *terraform.State) error {
 					continue
 				}
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}
@@ -131,7 +131,7 @@ func testAccCheckShippingZoneRateDestroy(s *terraform.State) error {
 					continue
 				}
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}

--- a/commercetools/resource_shipping_zone_rate_test.go
+++ b/commercetools/resource_shipping_zone_rate_test.go
@@ -1,8 +1,12 @@
 package commercetools
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/labd/commercetools-go-sdk/commercetools"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 
@@ -83,5 +87,57 @@ func testAccShippingZoneRateConfig(taxCategoryName string, shippingMethodName st
 }
 
 func testAccCheckShippingZoneRateDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*commercetools.Client)
+	// TODO: Do we want to check trailing rates separately? Similar to resource_tax_category_test_rate.go
+
+	for _, rs := range s.RootModule().Resources {
+		switch rs.Type {
+		case "commercetools_tax_category":
+			{
+				response, err := conn.TaxCategoryGetWithID(context.Background(), rs.Primary.ID)
+				if err == nil {
+					if response != nil && response.ID == rs.Primary.ID {
+						return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
+					}
+					continue
+				}
+				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+				if !strings.Contains(err.Error(), "was not found") {
+					return err
+				}
+			}
+		case "commercetools_shipping_method":
+			{
+				response, err := conn.ShippingMethodGetWithID(context.Background(), rs.Primary.ID)
+				if err == nil {
+					if response != nil && response.ID == rs.Primary.ID {
+
+						return fmt.Errorf("shipping method (%s) still exists", rs.Primary.ID)
+					}
+					continue
+				}
+				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+				if !strings.Contains(err.Error(), "was not found") {
+					return err
+				}
+			}
+		case "commercetools_shipping_zone":
+			{
+				response, err := conn.ZoneGetWithID(context.Background(), rs.Primary.ID)
+				if err == nil {
+					if response != nil && response.ID == rs.Primary.ID {
+						return fmt.Errorf("shipping zone (%s) still exists", rs.Primary.ID)
+					}
+					continue
+				}
+				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+				if !strings.Contains(err.Error(), "was not found") {
+					return err
+				}
+			}
+		default:
+			continue
+		}
+	}
 	return nil
 }

--- a/commercetools/resource_shipping_zone_test.go
+++ b/commercetools/resource_shipping_zone_test.go
@@ -234,7 +234,7 @@ func testAccCheckShippingZoneDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_shipping_zone_test.go
+++ b/commercetools/resource_shipping_zone_test.go
@@ -1,8 +1,12 @@
 package commercetools
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/labd/commercetools-go-sdk/commercetools"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -216,5 +220,23 @@ resource "commercetools_shipping_zone" "standard" {
 }
 
 func testAccCheckShippingZoneDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*commercetools.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_shipping_zone" {
+			continue
+		}
+		response, err := conn.ZoneGetWithID(context.Background(), rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.ID == rs.Primary.ID {
+				return fmt.Errorf("shipping zone (%s) still exists", rs.Primary.ID)
+			}
+			return nil
+		}
+		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+		if !strings.Contains(err.Error(), "was not found") {
+			return err
+		}
+	}
 	return nil
 }

--- a/commercetools/resource_state_test.go
+++ b/commercetools/resource_state_test.go
@@ -149,7 +149,7 @@ func testAccCheckStateDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_state_test.go
+++ b/commercetools/resource_state_test.go
@@ -2,8 +2,12 @@ package commercetools
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/labd/commercetools-go-sdk/commercetools"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -131,5 +135,23 @@ func testAccTransitionsConfig(t *testing.T, transitions string) string {
 }
 
 func testAccCheckStateDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*commercetools.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_state" {
+			continue
+		}
+		response, err := conn.StateGetWithID(context.Background(), rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.ID == rs.Primary.ID {
+				return fmt.Errorf("state (%s) still exists", rs.Primary.ID)
+			}
+			return nil
+		}
+		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+		if !strings.Contains(err.Error(), "was not found") {
+			return err
+		}
+	}
 	return nil
 }

--- a/commercetools/resource_store_test.go
+++ b/commercetools/resource_store_test.go
@@ -205,7 +205,7 @@ func testAccCheckStoreDestroy(s *terraform.State) error {
 				}
 
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}
@@ -219,7 +219,7 @@ func testAccCheckStoreDestroy(s *terraform.State) error {
 					continue
 				}
 				// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-				if !strings.Contains(err.Error(), "was not found") {
+				if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 					return err
 				}
 			}

--- a/commercetools/resource_subscription_test.go
+++ b/commercetools/resource_subscription_test.go
@@ -131,7 +131,7 @@ func testAccCheckSubscriptionDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_tax_category_rate_test.go
+++ b/commercetools/resource_tax_category_rate_test.go
@@ -23,7 +23,7 @@ func TestAccTaxCategoryRate_createAndUpdateWithID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTaxCategoryDestroy,
+		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTaxCategoryRateConfig(name, amount, true, country),
@@ -213,7 +213,7 @@ func TestAccTaxCategoryRate_createAndUpdateBothRateAndTaxCategory(t *testing.T) 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTaxCategoryDestroy,
+		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTaxCategoryRateDualUpdateConfig("foo", name, amount, true, country),
@@ -310,7 +310,7 @@ func testAccCheckTaxCategoryRateDestroy(s *terraform.State) error {
 		}
 
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_tax_category_rate_test.go
+++ b/commercetools/resource_tax_category_rate_test.go
@@ -1,8 +1,12 @@
 package commercetools
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/labd/commercetools-go-sdk/commercetools"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 
@@ -104,7 +108,7 @@ func TestAccTaxCategoryRate_createAndUpdateSubRates(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTaxCategoryDestroy,
+		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTaxCategoryRateSubRatesConfig(name, subRateAmount, true, country, true),
@@ -274,5 +278,41 @@ resource "commercetools_tax_category_rate" "test_rate" {
 }
 
 func testAccCheckTaxCategoryRateDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*commercetools.Client)
+	var rateIDs []string
+	// Because we can't directly query for Tax Categories, we are going to loop over the resources twice. Once to store
+	// the tax rate IDs of any rates present, and once to check the categories and their rates
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_tax_category_rate" {
+			continue
+		}
+		rateIDs = append(rateIDs, rs.Primary.ID)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_tax_category" {
+			continue
+		}
+		response, err := conn.TaxCategoryGetWithID(context.Background(), rs.Primary.ID)
+		if err == nil {
+			if response != nil && len(response.Rates) > 0 && response.ID == rs.Primary.ID {
+				var trailingTestRates []string
+				for _, rate := range response.Rates {
+					if stringInSlice(rate.ID, rateIDs) {
+						trailingTestRates = append(trailingTestRates, rate.ID)
+					}
+				}
+				return fmt.Errorf("tax category %s still exists with rates (%v)", rs.Primary.ID, trailingTestRates)
+			}
+			if response != nil && response.ID == rs.Primary.ID {
+				return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
+			}
+			continue
+		}
+
+		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+		if !strings.Contains(err.Error(), "was not found") {
+			return err
+		}
+	}
 	return nil
 }

--- a/commercetools/resource_tax_category_test.go
+++ b/commercetools/resource_tax_category_test.go
@@ -1,8 +1,12 @@
 package commercetools
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/labd/commercetools-go-sdk/commercetools"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -65,5 +69,23 @@ resource "commercetools_tax_category" "standard" {
 }
 
 func testAccCheckTaxCategoryDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*commercetools.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_tax_category" {
+			continue
+		}
+		response, err := conn.TaxCategoryGetWithID(context.Background(), rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.ID == rs.Primary.ID {
+				return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
+			}
+			return nil
+		}
+		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+		if !strings.Contains(err.Error(), "was not found") {
+			return err
+		}
+	}
 	return nil
 }

--- a/commercetools/resource_tax_category_test.go
+++ b/commercetools/resource_tax_category_test.go
@@ -83,7 +83,7 @@ func testAccCheckTaxCategoryDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_type_test.go
+++ b/commercetools/resource_type_test.go
@@ -392,7 +392,7 @@ func testAccCheckTypesDestroy(s *terraform.State) error {
 			return nil
 		}
 		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
-		if !strings.Contains(err.Error(), "was not found") {
+		if !strings.Contains(err.Error(), "was not found") && !strings.Contains(err.Error(), "Not Found (404)") {
 			return err
 		}
 	}

--- a/commercetools/resource_type_test.go
+++ b/commercetools/resource_type_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -377,6 +378,23 @@ func testAccTypeExists(n string) resource.TestCheckFunc {
 }
 
 func testAccCheckTypesDestroy(s *terraform.State) error {
-	// TODO: Implement
+	conn := testAccProvider.Meta().(*commercetools.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "commercetools_type" {
+			continue
+		}
+		response, err := conn.TypeGetWithID(context.Background(), rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.ID == rs.Primary.ID {
+				return fmt.Errorf("type (%s) still exists", rs.Primary.ID)
+			}
+			return nil
+		}
+		// If we don't get a was not found error, return the actual error. Otherwise resource is destroyed
+		if !strings.Contains(err.Error(), "was not found") {
+			return err
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Add checkDestroy functions to acceptance tests to raise errors in case of dangling resources with specific IDs. This should reduce the occasional erratic and inconsistent responses the acceptance tests can return, both for the mock server as well as an actual commercetool environment.

Closes: https://github.com/labd/terraform-provider-commercetools/issues/153 . For more info see the issue

Pre Merge Checklist:

- [x] Fix Discount Code mock test
- [x] Confirm `strings.Contains` checks are acceptable ways to differentiate 404 errors from other errors