### PR TITLE
Add Support for Order of Localized Enum Values and Remove of plain enum values from product types

### DIFF
--- a/commercetools/resource_product_type.go
+++ b/commercetools/resource_product_type.go
@@ -676,7 +676,7 @@ func handleLocalizedEnumTypeChanges(newFieldType platform.AttributeType, oldFiel
 						Value:         enumType.Values[i],
 					})
 			} else {
-				labelChanged := !localizedStringCompare(*enumValue.Label, oldEnumValues[idx]["label"].(map[string]interface{}))
+				labelChanged := !localizedStringCompare(enumValue.Label, oldEnumValues[idx]["label"].(map[string]interface{}))
 				if labelChanged {
 					actions = append(
 						actions,

--- a/commercetools/resource_product_type.go
+++ b/commercetools/resource_product_type.go
@@ -396,9 +396,9 @@ func resourceProductTypeUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if d.HasChange("attribute") {
-		old, new := d.GetChange("attribute")
+		old, newAttribute := d.GetChange("attribute")
 		attributeChangeActions, err := resourceProductTypeAttributeChangeActions(
-			old.([]interface{}), new.([]interface{}))
+			old.([]interface{}), newAttribute.([]interface{}))
 		if err != nil {
 			return err
 		}
@@ -523,36 +523,19 @@ func resourceProductTypeAttributeChangeActions(oldValues []interface{}, newValue
 
 		newFieldType := attrDef.Type
 		oldFieldType := oldV["type"].([]interface{})[0].(map[string]interface{})
-		oldEnumKeys := make(map[string]interface{})
-		newEnumKeys := make(map[string]interface{})
 
-		actions = handleEnumTypeChanges(newFieldType, oldFieldType, newEnumKeys, actions, name, oldEnumKeys)
+		actions = handlePlainEnumTypeChanges(newFieldType, oldFieldType, actions, name)
+		actions = handleLocalizedEnumTypeChanges(newFieldType, oldFieldType, actions, name)
 
 		if enumType, ok := newFieldType.(platform.AttributeSetType); ok {
 
 			myOldFieldType := oldFieldType["element_type"].([]interface{})[0].(map[string]interface{})
-			actions = handleEnumTypeChanges(enumType.ElementType, myOldFieldType, newEnumKeys, actions, name, oldEnumKeys)
+			actions = handlePlainEnumTypeChanges(newFieldType, oldFieldType, actions, name)
+			actions = handleLocalizedEnumTypeChanges(enumType.ElementType, myOldFieldType, actions, name)
 
 			log.Printf("[DEBUG] Set detected: %s", name)
 			log.Print(len(myOldFieldType))
 		}
-
-		removeEnumKeys := []string{}
-		for key := range oldEnumKeys {
-			if _, ok := newEnumKeys[key]; !ok {
-				removeEnumKeys = append(removeEnumKeys, key)
-			}
-		}
-
-		if len(removeEnumKeys) > 0 {
-			actions = append(
-				actions,
-				platform.ProductTypeRemoveEnumValuesAction{
-					AttributeName: name,
-					Keys:          removeEnumKeys,
-				})
-		}
-
 	}
 
 	oldNames := make([]string, len(oldValues))
@@ -580,12 +563,38 @@ func resourceProductTypeAttributeChangeActions(oldValues []interface{}, newValue
 	return actions, nil
 }
 
-func handleEnumTypeChanges(newFieldType platform.AttributeType, oldFieldType map[string]interface{}, newEnumKeys map[string]interface{}, actions []platform.ProductTypeUpdateAction, name string, oldEnumKeys map[string]interface{}) []platform.ProductTypeUpdateAction {
+func removeEnumValues(oldEnumKeys []map[string]interface{}, newEnumKeys []platform.AttributeLocalizedEnumValue, name string) *platform.ProductTypeRemoveEnumValuesAction {
+	var removeEnumKeys []string
+	for _, value := range oldEnumKeys {
+
+		idx := -1
+
+		for key, newValue := range newEnumKeys {
+			if newValue.Key == value["key"] {
+				idx = key
+				break
+			}
+		}
+
+		if idx == -1 {
+			removeEnumKeys = append(removeEnumKeys, value["key"].(string))
+		}
+	}
+
+	if len(removeEnumKeys) > 0 {
+		return &platform.ProductTypeRemoveEnumValuesAction{
+			AttributeName: name,
+			Keys:          removeEnumKeys,
+		}
+	}
+	return nil
+}
+
+func handlePlainEnumTypeChanges(newFieldType platform.AttributeType, oldFieldType map[string]interface{}, actions []platform.ProductTypeUpdateAction, name string) []platform.ProductTypeUpdateAction {
 	if enumType, ok := newFieldType.(platform.AttributeEnumType); ok {
 		oldEnumV := oldFieldType["values"].(map[string]interface{})
 
 		for i, enumValue := range enumType.Values {
-			newEnumKeys[enumValue.Key] = enumValue
 			if _, ok := oldEnumV[enumValue.Key]; !ok {
 				// Key does not appear in old enum values, so we'll add it
 				actions = append(
@@ -597,23 +606,39 @@ func handleEnumTypeChanges(newFieldType platform.AttributeType, oldFieldType map
 			}
 		}
 
-		return actions
 		// Action: changePlainEnumValueOrder
 		// TODO: Change the order of EnumValues: https://docs.commercetools.com/http-api-projects-productTypes.html#change-the-order-of-enumvalues
 
 	}
 
+	return actions
+}
+
+func handleLocalizedEnumTypeChanges(newFieldType platform.AttributeType, oldFieldType map[string]interface{}, actions []platform.ProductTypeUpdateAction, name string) []platform.ProductTypeUpdateAction {
+	oldEnumKeys := make([]map[string]interface{}, 0)
+	newEnumKeys := make([]platform.AttributeLocalizedEnumValue, 0)
+	addRemoveEnumValue := false
 	if enumType, ok := newFieldType.(platform.AttributeLocalizedEnumType); ok {
 		oldEnumV := oldFieldType["localized_value"].([]interface{})
 
 		for _, value := range oldEnumV {
-			v := value.(map[string]interface{})
-			oldEnumKeys[v["key"].(string)] = v
+			oldEnumKeys = append(oldEnumKeys, value.(map[string]interface{}))
 		}
 
 		for i, enumValue := range enumType.Values {
-			newEnumKeys[enumValue.Key] = enumValue
-			if _, ok := oldEnumKeys[enumValue.Key]; !ok {
+			newEnumKeys = append(newEnumKeys, enumValue)
+
+			idx := -1
+
+			for key, value := range oldEnumKeys {
+				if value["key"].(string) == enumValue.Key {
+					idx = key
+					break
+				}
+			}
+
+			if idx == -1 {
+				addRemoveEnumValue = true
 				// Key does not appear in old enum values, so we'll add it
 				actions = append(
 					actions,
@@ -622,9 +647,7 @@ func handleEnumTypeChanges(newFieldType platform.AttributeType, oldFieldType map
 						Value:         enumType.Values[i],
 					})
 			} else {
-				oldEnumValue := oldEnumKeys[enumValue.Key].(map[string]interface{})
-				oldLocalizedLabel := oldEnumValue["label"].(map[string]interface{})
-				labelChanged := !localizedStringCompare(enumValue.Label, oldLocalizedLabel)
+				labelChanged := !localizedStringCompare(enumValue.Label, oldEnumKeys[idx]["label"].(map[string]interface{}))
 				if labelChanged {
 					actions = append(
 						actions,
@@ -636,11 +659,47 @@ func handleEnumTypeChanges(newFieldType platform.AttributeType, oldFieldType map
 			}
 		}
 
+		action := removeEnumValues(oldEnumKeys, newEnumKeys, name)
+
+		if action != nil {
+			addRemoveEnumValue = true
+			actions = append(actions, action)
+		}
+
+		//if we remove enum values from the list and add at the same new ones, we should not try to change also the order at the same point
+		if addRemoveEnumValue {
+			return actions
+		}
+
+		listOfOldKeys := make([]string, 0)
+		listOfNewEnumKeys := make([]string, 0)
+
+		for _, value := range oldEnumKeys {
+			listOfOldKeys = append(listOfOldKeys, value["key"].(string))
+		}
+
+		for _, value := range newEnumKeys {
+			listOfNewEnumKeys = append(listOfNewEnumKeys, value.Key)
+		}
+
+		if len(listOfOldKeys) == len(listOfNewEnumKeys) && orderChanged(listOfNewEnumKeys, listOfOldKeys) {
+			actions = append(
+				actions,
+				platform.ProductTypeChangeLocalizedEnumValueOrderAction{Values: newFieldType.(platform.AttributeLocalizedEnumType).Values, AttributeName: name})
+		}
+
 		return actions
-		// Action: changeLocalizedEnumValueOrder
-		// TODO: Change the order of LocalizedEnumValues: https://docs.commercetools.com/http-api-projects-productTypes.html#change-the-order-of-localizedenumvalues
 	}
 	return actions
+}
+
+func orderChanged(a []string, b []string) bool {
+	for i, v := range a {
+		if v != b[i] {
+			return true
+		}
+	}
+	return false
 }
 
 func resourceProductTypeGetAttributeDefinitions(d *schema.ResourceData) ([]platform.AttributeDefinitionDraft, error) {

--- a/commercetools/resource_product_type.go
+++ b/commercetools/resource_product_type.go
@@ -25,7 +25,7 @@ func resourceProductType() *schema.Resource {
 		Description: "Product types are used to describe common characteristics, most importantly common custom " +
 			"attributes, of many concrete products. Please note: to customize other resources than products, " +
 			"please refer to resource_type.\n\n" +
-			"See also the [Product Type API Documentation](https://docs.commercetools.com/api/projects/productTypes)",
+			"See also the [Product Type API Documentation](https://docs.platform.com/api/projects/productTypes)",
 		Create: resourceProductTypeCreate,
 		Read:   resourceProductTypeRead,
 		Update: resourceProductTypeUpdate,
@@ -48,13 +48,13 @@ func resourceProductType() *schema.Resource {
 				Optional:    true,
 			},
 			"attribute": {
-				Description: "[Product attribute fefinition](https://docs.commercetools.com/api/projects/productTypes#attributedefinition)",
+				Description: "[Product attribute fefinition](https://docs.platform.com/api/projects/productTypes#attributedefinition)",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
-							Description: "[AttributeType](https://docs.commercetools.com/api/projects/productTypes#attributetype)",
+							Description: "[AttributeType](https://docs.platform.com/api/projects/productTypes#attributetype)",
 							Type:        schema.TypeList,
 							MaxItems:    1,
 							Required:    true,
@@ -85,7 +85,7 @@ func resourceProductType() *schema.Resource {
 						"constraint": {
 							Description: "Describes how an attribute or a set of attributes should be validated " +
 								"across all variants of a product. " +
-								"See also [Attribute Constraint](https://docs.commercetools.com/api/projects/productTypes#attributeconstraint-enum)",
+								"See also [Attribute Constraint](https://docs.platform.com/api/projects/productTypes#attributeconstraint-enum)",
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  platform.AttributeConstraintEnumNone,

--- a/commercetools/resource_product_type_test.go
+++ b/commercetools/resource_product_type_test.go
@@ -126,7 +126,7 @@ func TestAccProductTypes_basic(t *testing.T) {
 						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
 					),
 					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.#", "4",
+						"commercetools_product_type.acctest_product_type", "attribute.#", "6",
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
@@ -152,6 +152,24 @@ func TestAccProductTypes_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.en", "Lunch",
 					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.3.type.0.name", "lenum",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.3.type.0.localized_value.0.key", "cm",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.3.type.0.localized_value.1.key", "ml",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.4.type.0.name", "set",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.4.type.0.element_type.0.values.%", "5",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.5.type.0.name", "enum",
+					),
 				),
 			},
 			{
@@ -167,7 +185,7 @@ func TestAccProductTypes_basic(t *testing.T) {
 						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
 					),
 					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.#", "4",
+						"commercetools_product_type.acctest_product_type", "attribute.#", "6",
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
@@ -195,6 +213,18 @@ func TestAccProductTypes_basic(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.de", "Mittagessen",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.3.type.0.localized_value.0.key", "ml",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.3.type.0.localized_value.1.key", "cm",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.4.type.0.element_type.0.values.%", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_product_type.acctest_product_type", "attribute.5.type.0.name", "enum",
 					),
 				),
 			},
@@ -303,6 +333,40 @@ resource "commercetools_product_type" "acctest_product_type" {
 		}
 	}
 
+	attribute {
+		label      = {
+			"de-DE" = "stores"
+			"en"    = "stores"
+		}
+		name       = "onSale"
+		type {
+			name   = "set"
+		   	element_type {
+				name   = "enum"
+				values = {
+					"de"		 = "de"
+					"not_de"     = "not_de"
+				}
+			}
+		}
+	}
+
+	attribute {
+		label      = {
+			"de-DE" = "storesOrder"
+			"en"    = "storesOrder"
+		}
+		name       = "storeOrder"
+		type {
+			name   = "enum"
+			values = {
+				"at" = "at"
+				"de" = "de"
+				"pl" = "pl"
+			}
+		}
+	}
+
 }`, name)
 }
 
@@ -400,6 +464,43 @@ resource "commercetools_product_type" "acctest_product_type" {
 				en = "ml"
 				nl = "ml"
 			  }
+			}
+		}
+	}
+
+	attribute {
+		label      = {
+			"de-DE" = "stores"
+			"en"    = "stores"
+		}
+		name       = "onSale"
+		type {
+			name   = "set"
+		   	element_type {
+				name   = "enum"
+				values = {
+					"AT"         = "AT"
+					"DE"         = "DE"
+					"PL"         = "PL"
+					"de"		 = "de"
+					"not_de"     = "not_de"
+				}
+			}
+		}
+	}
+
+	attribute {
+		label      = {
+			"de-DE" = "storesOrder"
+			"en"    = "storesOrder"
+		}
+		name       = "storeOrder"
+		type {
+			name   = "enum"
+			values = {
+				"pl" = "pl"
+				"de" = "de"
+				"at" = "at"
 			}
 		}
 	}

--- a/commercetools/resource_product_type_test.go
+++ b/commercetools/resource_product_type_test.go
@@ -3,6 +3,7 @@ package commercetools
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/labd/commercetools-go-sdk/platform"
@@ -107,6 +108,11 @@ func TestGetAttributeType(t *testing.T) {
 }
 
 func TestAccProductTypes_basic(t *testing.T) {
+
+	if os.Getenv("CTP_CLIENT_ID") == "unittest" {
+		t.Skip("Skipping testing with mock server as the implementation can not handle order of localized enums")
+	}
+
 	name := "acctest_producttype"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -214,6 +220,17 @@ func TestAccProductTypes_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.de", "Mittagessen",
 					),
+
+					func(s *terraform.State) error {
+						if os.Getenv("CTP_CLIENT_ID") == "unittest" {
+							t.Log("Skipping check of order as the mock server does not support this correctly")
+							return nil
+						}
+
+						return resource.TestCheckResourceAttr(
+							"commercetools_product_type.acctest_product_type", "attribute.3.type.0.localized_value.0.key", "ml",
+						)(s)
+					},
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.3.type.0.localized_value.0.key", "ml",
 					),

--- a/commercetools/resource_product_type_test.go
+++ b/commercetools/resource_product_type_test.go
@@ -126,7 +126,7 @@ func TestAccProductTypes_basic(t *testing.T) {
 						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
 					),
 					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.#", "3",
+						"commercetools_product_type.acctest_product_type", "attribute.#", "4",
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
@@ -167,7 +167,7 @@ func TestAccProductTypes_basic(t *testing.T) {
 						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
 					),
 					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.#", "3",
+						"commercetools_product_type.acctest_product_type", "attribute.#", "4",
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
@@ -274,6 +274,35 @@ resource "commercetools_product_type" "acctest_product_type" {
 		}
 	}
 
+	attribute {
+		label      = {
+			"de-DE" = "Maßeinheit"
+			"en"    = "Unit"
+		}
+		name       = "unit"
+		type {
+			name = "lenum"
+            
+			localized_value {
+			  key = "ml"
+
+			  label = {
+				en = "ml"
+				nl = "ml"
+			  }
+			}
+
+			localized_value {
+			  key = "cm"
+
+			  label = {
+				en = "cm"
+				nl = "cm"
+			  }
+			}
+		}
+	}
+
 }`, name)
 }
 
@@ -342,6 +371,35 @@ resource "commercetools_product_type" "acctest_product_type" {
 					en = "Lunch"
 				  }
 				}
+			}
+		}
+	}
+
+	attribute {
+		label      = {
+			"de-DE" = "Maßeinheit"
+			"en"    = "Unit"
+		}
+		name       = "unit"
+		type {
+			name = "lenum"
+            
+			localized_value {
+			  key = "cm"
+
+			  label = {
+				en = "cm"
+				nl = "cm"
+			  }
+			}
+
+			localized_value {
+			  key = "ml"
+
+			  label = {
+				en = "ml"
+				nl = "ml"
+			  }
 			}
 		}
 	}


### PR DESCRIPTION
This pr allows to order localized enum values in product types and also to remove plain enum values. 
I split the enum functions in two for plain and localized to ease the development and the separate the slightly different behavior. In theory we can also order the plain enum but the issue is that the plain enum values are atm TypeMap and would need to be like localized values a TypeList. I did not work yet on upgrading a schema so I left this out. 