### PR TITLE
fix(commercetools_api_client): mark secret field as sensitive

### DIFF
--- a/commercetools/resource_api_client.go
+++ b/commercetools/resource_api_client.go
@@ -38,8 +38,9 @@ func resourceAPIClient() *schema.Resource {
 				ForceNew:    true,
 			},
 			"secret": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
When creating/updating `commercetools_api_client`, the secret get leaked in the change log:

```
  # resource.commercetools_api_client.my-api-client must be replaced
-/+ resource "commercetools_api_client" "my-api-client" {
      ~ id     = "0P8tEhJsQ83kqio3MRSzAMI" -> (known after apply)
      ~ name   = "my-api-client" -> "my-api-client" # forces replacement
      ~ secret = "fptJxOZPHft2_UoSfXqTUjWTs2VXOoxK" -> (known after apply)
        # (1 unchanged attribute hidden)
    }
```