### PR TITLE
Refactor to use the new terraform plugin framework

### DIFF
--- a/commercetools/marshalling.go
+++ b/commercetools/marshalling.go
@@ -1,51 +1,51 @@
 package commercetools
 
-import (
-	"time"
+// import (
+// 	"time"
 
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func marshallTime(val *time.Time) string {
-	if val == nil {
-		return ""
-	}
-	return val.Format(time.RFC3339)
-}
+// func marshallTime(val *time.Time) string {
+// 	if val == nil {
+// 		return ""
+// 	}
+// 	return val.Format(time.RFC3339)
+// }
 
-func unmarshallTime(input string) (time.Time, error) {
-	return time.Parse(time.RFC3339, input)
-}
+// func unmarshallTime(input string) (time.Time, error) {
+// 	return time.Parse(time.RFC3339, input)
+// }
 
-func marshallTypedMoney(val platform.TypedMoney) map[string]interface{} {
-	switch v := val.(type) {
-	case platform.HighPrecisionMoney:
-		return map[string]interface{}{
-			"currency_code": v.CurrencyCode,
-			"cent_amount":   v.CentAmount,
-		}
-	case platform.Money:
-		return map[string]interface{}{
-			"currency_code": v.CurrencyCode,
-			"cent_amount":   v.CentAmount,
-		}
-	}
-	panic("Unknown money type")
-}
+// func marshallTypedMoney(val platform.TypedMoney) map[string]interface{} {
+// 	switch v := val.(type) {
+// 	case platform.HighPrecisionMoney:
+// 		return map[string]interface{}{
+// 			"currency_code": v.CurrencyCode,
+// 			"cent_amount":   v.CentAmount,
+// 		}
+// 	case platform.Money:
+// 		return map[string]interface{}{
+// 			"currency_code": v.CurrencyCode,
+// 			"cent_amount":   v.CentAmount,
+// 		}
+// 	}
+// 	panic("Unknown money type")
+// }
 
-func unmarshallTypedMoney(d map[string]interface{}) []platform.Money {
-	input := d["money"].([]interface{})
-	var result []platform.Money
+// func unmarshallTypedMoney(d map[string]interface{}) []platform.Money {
+// 	input := d["money"].([]interface{})
+// 	var result []platform.Money
 
-	for _, raw := range input {
-		i := raw.(map[string]interface{})
-		priceCurrencyCode := i["currency_code"].(string)
+// 	for _, raw := range input {
+// 		i := raw.(map[string]interface{})
+// 		priceCurrencyCode := i["currency_code"].(string)
 
-		result = append(result, platform.Money{
-			CurrencyCode: priceCurrencyCode,
-			CentAmount:   i["cent_amount"].(int),
-		})
-	}
+// 		result = append(result, platform.Money{
+// 			CurrencyCode: priceCurrencyCode,
+// 			CentAmount:   i["cent_amount"].(int),
+// 		})
+// 	}
 
-	return result
-}
+// 	return result
+// }

--- a/commercetools/provider.go
+++ b/commercetools/provider.go
@@ -1,90 +1,163 @@
 package commercetools
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/labd/commercetools-go-sdk/platform"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
+var stderr = os.Stderr
+
+func New() tfsdk.Provider {
+	return &provider{}
+}
+
+type provider struct {
+	configured bool
+	client     *platform.ByProjectKeyRequestBuilder
+	mutex      *MutexKV
+}
+
 // Provider returns a terraform.ResourceProvider.
-func Provider() *schema.Provider {
-	return &schema.Provider{
-		Schema: map[string]*schema.Schema{
+func (p *provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
 			"client_id": {
-				Type:        schema.TypeString,
+				Type:        types.StringType,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CTP_CLIENT_ID", nil),
 				Description: "The OAuth Client ID for a commercetools platform project. https://docs.commercetools.com/http-api-authorization",
 				Sensitive:   true,
 			},
 			"client_secret": {
-				Type:        schema.TypeString,
+				Type:        types.StringType,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CTP_CLIENT_SECRET", nil),
 				Description: "The OAuth Client Secret for a commercetools platform project. https://docs.commercetools.com/http-api-authorization",
 				Sensitive:   true,
 			},
 			"project_key": {
-				Type:        schema.TypeString,
+				Type:        types.StringType,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CTP_PROJECT_KEY", nil),
 				Description: "The project key of commercetools platform project. https://docs.commercetools.com/getting-started",
 				Sensitive:   true,
 			},
 			"scopes": {
-				Type:        schema.TypeString,
+				Type:        types.StringType,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CTP_SCOPES", nil),
 				Description: "A list as string of OAuth scopes assigned to a project key, to access resources in a commercetools platform project. https://docs.commercetools.com/http-api-authorization",
 			},
 			"api_url": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CTP_API_URL", nil),
+				Type:     types.StringType,
+				Required: true,
+				// DefaultFunc: schema.EnvDefaultFunc("CTP_API_URL", nil),
 				Description: "The API URL of the commercetools platform. https://docs.commercetools.com/http-api",
 			},
 			"token_url": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CTP_AUTH_URL", nil),
+				Type:     types.StringType,
+				Required: true,
+				// DefaultFunc: schema.EnvDefaultFunc("CTP_AUTH_URL", nil),
 				Description: "The authentication URL of the commercetools platform. https://docs.commercetools.com/http-api-authorization",
 			},
 		},
-		ResourcesMap: map[string]*schema.Resource{
-			"commercetools_api_client":         resourceAPIClient(),
-			"commercetools_api_extension":      resourceAPIExtension(),
-			"commercetools_cart_discount":      resourceCartDiscount(),
-			"commercetools_channel":            resourceChannel(),
-			"commercetools_custom_object":      resourceCustomObject(),
-			"commercetools_customer_group":     resourceCustomerGroup(),
-			"commercetools_discount_code":      resourceDiscountCode(),
-			"commercetools_product_type":       resourceProductType(),
-			"commercetools_project_settings":   resourceProjectSettings(),
-			"commercetools_shipping_method":    resourceShippingMethod(),
-			"commercetools_shipping_zone_rate": resourceShippingZoneRate(),
-			"commercetools_shipping_zone":      resourceShippingZone(),
-			"commercetools_state":              resourceState(),
-			"commercetools_store":              resourceStore(),
-			"commercetools_subscription":       resourceSubscription(),
-			"commercetools_tax_category_rate":  resourceTaxCategoryRate(),
-			"commercetools_tax_category":       resourceTaxCategory(),
-			"commercetools_category":           resourceCategory(),
-			"commercetools_type":               resourceType(),
-		},
-		ConfigureFunc: providerConfigure,
-	}
+	}, nil
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	clientID := d.Get("client_id").(string)
-	clientSecret := d.Get("client_secret").(string)
-	projectKey := d.Get("project_key").(string)
-	scopesRaw := d.Get("scopes").(string)
-	apiURL := d.Get("api_url").(string)
-	authURL := d.Get("token_url").(string)
+// GetResources - Defines provider resources
+func (p *provider) GetResources(_ context.Context) (map[string]tfsdk.ResourceType, diag.Diagnostics) {
+	return map[string]tfsdk.ResourceType{}, nil
+	// "commercetools_api_client":         resourceAPIClient(),
+	// "commercetools_api_extension":      resourceAPIExtension(),
+	// "commercetools_cart_discount":      resourceCartDiscount(),
+	// "commercetools_channel":            resourceChannel(),
+	// "commercetools_custom_object":      resourceCustomObject(),
+	// "commercetools_customer_group":     resourceCustomerGroup(),
+	// "commercetools_discount_code":      resourceDiscountCode(),
+	// "commercetools_product_type":       resourceProductType(),
+	// "commercetools_project_settings":   resourceProjectSettings(),
+	// "commercetools_shipping_method":    resourceShippingMethod(),
+	// "commercetools_shipping_zone_rate": resourceShippingZoneRate(),
+	// "commercetools_shipping_zone":      resourceShippingZone(),
+	// "commercetools_state":              resourceState(),
+	// "commercetools_store":              resourceStore(),
+	// "commercetools_subscription":       resourceSubscription(),
+	// "commercetools_tax_category_rate":  resourceTaxCategoryRate(),
+	// "commercetools_tax_category":       resourceTaxCategory(),
+	// "commercetools_category":           resourceCategory(),
+	// "commercetools_type":               resourceType(),
+}
+
+// GetDataSources - Defines provider data sources
+func (p *provider) GetDataSources(_ context.Context) (map[string]tfsdk.DataSourceType, diag.Diagnostics) {
+	return map[string]tfsdk.DataSourceType{}, nil
+}
+
+// Provider schema struct
+type providerData struct {
+	ClientID     types.String `tfsdk:"client_id"`
+	ClientSecret types.String `tfsdk:"client_secret"`
+	ProjectKey   types.String `tfsdk:"project_key"`
+	Scopes       types.String `tfsdk:"scopes"`
+	ApiURL       types.String `tfsdk:"api_url"`
+	TokenURL     types.String `tfsdk:"token_url"`
+}
+
+func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderRequest, resp *tfsdk.ConfigureProviderResponse) {
+	var config providerData
+
+	diags := req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var clientID string
+	if config.ClientID.Null {
+		clientID = os.Getenv("CTP_CLIENT_ID")
+	} else {
+		clientID = config.ClientID.Value
+	}
+
+	var clientSecret string
+	if config.ClientSecret.Null {
+		clientSecret = os.Getenv("CTP_CLIENT_SECRET")
+	} else {
+		clientSecret = config.ClientSecret.Value
+	}
+
+	var projectKey string
+	if config.ProjectKey.Null {
+		projectKey = os.Getenv("CTP_PROJECT_KEY")
+	} else {
+		projectKey = config.ProjectKey.Value
+	}
+
+	var scopesRaw string
+	if config.Scopes.Null {
+		scopesRaw = os.Getenv("CTP_SCOPES")
+	} else {
+		scopesRaw = config.Scopes.Value
+	}
+
+	var apiURL string
+	if config.ApiURL.Null {
+		apiURL = os.Getenv("CTP_API_URL")
+	} else {
+		apiURL = config.ApiURL.Value
+	}
+
+	var authURL string
+	if config.TokenURL.Null {
+		authURL = os.Getenv("CTP_AUTH_URL")
+	} else {
+		authURL = config.TokenURL.Value
+	}
 
 	oauthScopes := strings.Split(scopesRaw, " ")
 
@@ -102,11 +175,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	})
 
 	if err != nil {
-		return nil, err
+		resp.Diagnostics.AddError(
+			"Unable to create client",
+			"Unable to create commercetools client:\n\n"+err.Error(),
+		)
+		return
 	}
 
-	return client.WithProjectKey(projectKey), err
+	p.client = client.WithProjectKey(projectKey)
+	p.configured = true
+	p.mutex = NewMutexKV()
 }
-
-// This is a global MutexKV for use within this plugin.
-var ctMutexKV = NewMutexKV()

--- a/commercetools/provider.go
+++ b/commercetools/provider.go
@@ -71,26 +71,27 @@ func (p *provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 
 // GetResources - Defines provider resources
 func (p *provider) GetResources(_ context.Context) (map[string]tfsdk.ResourceType, diag.Diagnostics) {
-	return map[string]tfsdk.ResourceType{}, nil
-	// "commercetools_api_client":         resourceAPIClient(),
-	// "commercetools_api_extension":      resourceAPIExtension(),
-	// "commercetools_cart_discount":      resourceCartDiscount(),
-	// "commercetools_channel":            resourceChannel(),
-	// "commercetools_custom_object":      resourceCustomObject(),
-	// "commercetools_customer_group":     resourceCustomerGroup(),
-	// "commercetools_discount_code":      resourceDiscountCode(),
-	// "commercetools_product_type":       resourceProductType(),
-	// "commercetools_project_settings":   resourceProjectSettings(),
-	// "commercetools_shipping_method":    resourceShippingMethod(),
-	// "commercetools_shipping_zone_rate": resourceShippingZoneRate(),
-	// "commercetools_shipping_zone":      resourceShippingZone(),
-	// "commercetools_state":              resourceState(),
-	// "commercetools_store":              resourceStore(),
-	// "commercetools_subscription":       resourceSubscription(),
-	// "commercetools_tax_category_rate":  resourceTaxCategoryRate(),
-	// "commercetools_tax_category":       resourceTaxCategory(),
-	// "commercetools_category":           resourceCategory(),
-	// "commercetools_type":               resourceType(),
+	return map[string]tfsdk.ResourceType{
+		// "commercetools_api_client":         resourceAPIClient(),
+		// "commercetools_api_extension":      resourceAPIExtension(),
+		// "commercetools_cart_discount":      resourceCartDiscount(),
+		// "commercetools_channel":            resourceChannel(),
+		// "commercetools_custom_object":      resourceCustomObject(),
+		// "commercetools_customer_group":     resourceCustomerGroup(),
+		// "commercetools_discount_code":      resourceDiscountCode(),
+		// "commercetools_product_type":       resourceProductType(),
+		"commercetools_project_settings": resourceProjectSettingsType{},
+		// "commercetools_shipping_method":    resourceShippingMethod(),
+		// "commercetools_shipping_zone_rate": resourceShippingZoneRate(),
+		// "commercetools_shipping_zone":      resourceShippingZone(),
+		// "commercetools_state":              resourceState(),
+		// "commercetools_store":              resourceStore(),
+		// "commercetools_subscription":       resourceSubscription(),
+		// "commercetools_tax_category_rate":  resourceTaxCategoryRate(),
+		// "commercetools_tax_category":       resourceTaxCategory(),
+		// "commercetools_category":           resourceCategory(),
+		// "commercetools_type":               resourceType(),
+	}, nil
 }
 
 // GetDataSources - Defines provider data sources

--- a/commercetools/provider_test.go
+++ b/commercetools/provider_test.go
@@ -2,6 +2,7 @@ package commercetools
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -52,6 +53,7 @@ func testAccPreCheck(t *testing.T) {
 
 	err := testAccProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(cfg))
 	if err != nil {
+		fmt.Println("FATAAL")
 		t.Fatal(err)
 	}
 }

--- a/commercetools/provider_test.go
+++ b/commercetools/provider_test.go
@@ -1,59 +1,59 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"os"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"os"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-var testAccProviders map[string]*schema.Provider
-var testAccProvider *schema.Provider
+// var testAccProviders map[string]*schema.Provider
+// var testAccProvider *schema.Provider
 
-func init() {
-	testAccProvider = Provider()
-	testAccProviders = map[string]*schema.Provider{
-		"commercetools": testAccProvider,
-	}
-}
+// func init() {
+// 	testAccProvider = Provider()
+// 	testAccProviders = map[string]*schema.Provider{
+// 		"commercetools": testAccProvider,
+// 	}
+// }
 
-func TestProvider(t *testing.T) {
-	if err := Provider().InternalValidate(); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-}
+// func TestProvider(t *testing.T) {
+// 	if err := Provider().InternalValidate(); err != nil {
+// 		t.Fatalf("err: %s", err)
+// 	}
+// }
 
-func TestProvider_impl(t *testing.T) {
-	var _ = Provider()
-}
+// func TestProvider_impl(t *testing.T) {
+// 	var _ = Provider()
+// }
 
-func testAccPreCheck(t *testing.T) {
-	requiredEnvs := []string{
-		"CTP_CLIENT_ID",
-		"CTP_CLIENT_SECRET",
-		"CTP_PROJECT_KEY",
-		"CTP_SCOPES",
-		"CTP_API_URL",
-		"CTP_AUTH_URL",
-	}
-	for _, val := range requiredEnvs {
-		if os.Getenv(val) == "" {
-			t.Fatalf("%v must be set for acceptance tests", val)
-		}
-	}
+// func testAccPreCheck(t *testing.T) {
+// 	requiredEnvs := []string{
+// 		"CTP_CLIENT_ID",
+// 		"CTP_CLIENT_SECRET",
+// 		"CTP_PROJECT_KEY",
+// 		"CTP_SCOPES",
+// 		"CTP_API_URL",
+// 		"CTP_AUTH_URL",
+// 	}
+// 	for _, val := range requiredEnvs {
+// 		if os.Getenv(val) == "" {
+// 			t.Fatalf("%v must be set for acceptance tests", val)
+// 		}
+// 	}
 
-	cfg := map[string]interface{}{
-		"client_id":     "dummy-client-id",
-		"client_secret": "dummy-client-secret",
-		"project_key":   "terraform-provider-commercetools",
-	}
+// 	cfg := map[string]interface{}{
+// 		"client_id":     "dummy-client-id",
+// 		"client_secret": "dummy-client-secret",
+// 		"project_key":   "terraform-provider-commercetools",
+// 	}
 
-	err := testAccProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(cfg))
-	if err != nil {
-		fmt.Println("FATAAL")
-		t.Fatal(err)
-	}
-}
+// 	err := testAccProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(cfg))
+// 	if err != nil {
+// 		fmt.Println("FATAAL")
+// 		t.Fatal(err)
+// 	}
+// }

--- a/commercetools/resource_api_client.go
+++ b/commercetools/resource_api_client.go
@@ -1,118 +1,118 @@
 package commercetools
 
-import (
-	"context"
-	"sort"
-	"strings"
-	"time"
+// import (
+// 	"context"
+// 	"sort"
+// 	"strings"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceAPIClient() *schema.Resource {
-	return &schema.Resource{
-		Description: "Create a new API client. Note that Commercetools might return slightly different scopes, " +
-			"resulting in a new API client being created everytime Terraform is run. In this case, " +
-			"fix your scopes accordingly to match what is returned by Commercetools.\n\n" +
-			"Also see the [API client HTTP API documentation](https://docs.commercetools.com//http-api-projects-api-clients).",
-		Create: resourceAPIClientCreate,
-		Read:   resourceAPIClientRead,
-		Delete: resourceAPIClientDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Description: "Name of the API client",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
-			"scope": {
-				Description: "A list of the [OAuth scopes](https://docs.commercetools.com/http-api-authorization.html#scopes)",
-				Type:        schema.TypeSet,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Required:    true,
-				ForceNew:    true,
-			},
-			"secret": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-		},
-	}
-}
+// func resourceAPIClient() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Create a new API client. Note that Commercetools might return slightly different scopes, " +
+// 			"resulting in a new API client being created everytime Terraform is run. In this case, " +
+// 			"fix your scopes accordingly to match what is returned by Commercetools.\n\n" +
+// 			"Also see the [API client HTTP API documentation](https://docs.commercetools.com//http-api-projects-api-clients).",
+// 		Create: resourceAPIClientCreate,
+// 		Read:   resourceAPIClientRead,
+// 		Delete: resourceAPIClientDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"name": {
+// 				Description: "Name of the API client",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 				ForceNew:    true,
+// 			},
+// 			"scope": {
+// 				Description: "A list of the [OAuth scopes](https://docs.commercetools.com/http-api-authorization.html#scopes)",
+// 				Type:        schema.TypeSet,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 				Required:    true,
+// 				ForceNew:    true,
+// 			},
+// 			"secret": {
+// 				Type:      types.StringType,
+// 				Computed:  true,
+// 				Sensitive: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceAPIClientCreate(d *schema.ResourceData, m interface{}) error {
-	name := d.Get("name").(string)
-	scopes := d.Get("scope").(*schema.Set).List()
+// func resourceAPIClientCreate(d *schema.ResourceData, m interface{}) error {
+// 	name := d.Get("name").(string)
+// 	scopes := d.Get("scope").(*schema.Set).List()
 
-	scopeParts := make([]string, 0)
-	for i := 0; i < len(scopes); i++ {
-		scopeParts = append(scopeParts, scopes[i].(string))
-	}
+// 	scopeParts := make([]string, 0)
+// 	for i := 0; i < len(scopes); i++ {
+// 		scopeParts = append(scopeParts, scopes[i].(string))
+// 	}
 
-	draft := platform.ApiClientDraft{
-		Name:  name,
-		Scope: strings.Join(scopeParts, " "),
-	}
+// 	draft := platform.ApiClientDraft{
+// 		Name:  name,
+// 		Scope: strings.Join(scopeParts, " "),
+// 	}
 
-	client := getClient(m)
+// 	client := getClient(m)
 
-	var apiClient *platform.ApiClient
+// 	var apiClient *platform.ApiClient
 
-	err := resource.Retry(20*time.Second, func() *resource.RetryError {
-		var err error
+// 	err := resource.Retry(20*time.Second, func() *resource.RetryError {
+// 		var err error
 
-		apiClient, err = client.ApiClients().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		apiClient, err = client.ApiClients().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	d.SetId(apiClient.ID)
-	d.Set("secret", apiClient.Secret)
+// 	d.SetId(apiClient.ID)
+// 	d.Set("secret", apiClient.Secret)
 
-	return resourceAPIClientRead(d, m)
-}
+// 	return resourceAPIClientRead(d, m)
+// }
 
-func resourceAPIClientRead(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	apiClient, err := client.ApiClients().WithId(d.Id()).Get().Execute(context.Background())
+// func resourceAPIClientRead(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	apiClient, err := client.ApiClients().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	d.SetId(apiClient.ID)
-	d.Set("name", apiClient.Name)
-	scopes := strings.Split(apiClient.Scope, " ")
-	sort.Strings(scopes)
-	d.Set("scope", scopes)
-	return nil
-}
+// 	d.SetId(apiClient.ID)
+// 	d.Set("name", apiClient.Name)
+// 	scopes := strings.Split(apiClient.Scope, " ")
+// 	sort.Strings(scopes)
+// 	d.Set("scope", scopes)
+// 	return nil
+// }
 
-func resourceAPIClientDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceAPIClientDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	_, err := client.ApiClients().WithId(d.Id()).Delete().Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	_, err := client.ApiClients().WithId(d.Id()).Delete().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }

--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -1,458 +1,458 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"strings"
-	"time"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"log"
+// 	"strings"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceAPIExtension() *schema.Resource {
-	return &schema.Resource{
-		Description: "Create a new API extension to extend the bevahiour of an API with business logic. " +
-			"Note that API extensions affect the performance of the API it is extending. If it fails, the whole API " +
-			"call fails \n\n" +
-			"Also see the [API Extension API Documentation](https://docs.commercetools.com/api/projects/api-extensions)",
-		Create:        resourceAPIExtensionCreate,
-		Read:          resourceAPIExtensionRead,
-		Update:        resourceAPIExtensionUpdate,
-		Delete:        resourceAPIExtensionDelete,
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    resourceAPIExtensionResourceV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: migrateAPIExtensionStateV0toV1,
-				Version: 0,
-			},
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for the extension",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"destination": {
-				Description: "[Destination](https://docs.commercetools.com/api/projects/api-extensions#destination) " +
-					"Details where the extension can be reached",
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateDestinationType,
-						},
-						// HTTP specific fields
-						"url": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"azure_authentication": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"authorization_header": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+// func resourceAPIExtension() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Create a new API extension to extend the bevahiour of an API with business logic. " +
+// 			"Note that API extensions affect the performance of the API it is extending. If it fails, the whole API " +
+// 			"call fails \n\n" +
+// 			"Also see the [API Extension API Documentation](https://docs.commercetools.com/api/projects/api-extensions)",
+// 		Create:        resourceAPIExtensionCreate,
+// 		Read:          resourceAPIExtensionRead,
+// 		Update:        resourceAPIExtensionUpdate,
+// 		Delete:        resourceAPIExtensionDelete,
+// 		SchemaVersion: 1,
+// 		StateUpgraders: []schema.StateUpgrader{
+// 			{
+// 				Type:    resourceAPIExtensionResourceV0().CoreConfigSchema().ImpliedType(),
+// 				Upgrade: migrateAPIExtensionStateV0toV1,
+// 				Version: 0,
+// 			},
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for the extension",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"destination": {
+// 				Description: "[Destination](https://docs.commercetools.com/api/projects/api-extensions#destination) " +
+// 					"Details where the extension can be reached",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				MaxItems: 1,
+// 				Required: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Type:         types.StringType,
+// 							Required:     true,
+// 							ValidateFunc: validateDestinationType,
+// 						},
+// 						// HTTP specific fields
+// 						"url": {
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 						},
+// 						"azure_authentication": {
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 						},
+// 						"authorization_header": {
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 						},
 
-						// AWSLambda specific fields
-						"arn": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"access_key": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"access_secret": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"trigger": {
-				Description: "Array of [Trigger](https://docs.commercetools.com/api/projects/api-extensions#trigger) " +
-					"Describes what triggers the extension",
-				Type:     schema.TypeList,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"resource_type_id": {
-							Description: "Currently, cart, order, payment, and customer are supported",
-							Type:        schema.TypeString,
-							Required:    true,
-						},
-						"actions": {
-							Description: "Currently, Create and Update are supported",
-							Type:        schema.TypeList,
-							Required:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"timeout_in_ms": {
-				Description: "Extension timeout in milliseconds",
-				Type:        schema.TypeInt,
-				Optional:    true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// 						// AWSLambda specific fields
+// 						"arn": {
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 						},
+// 						"access_key": {
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 						},
+// 						"access_secret": {
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"trigger": {
+// 				Description: "Array of [Trigger](https://docs.commercetools.com/api/projects/api-extensions#trigger) " +
+// 					"Describes what triggers the extension",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				Required: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"resource_type_id": {
+// 							Description: "Currently, cart, order, payment, and customer are supported",
+// 							Type:        types.StringType,
+// 							Required:    true,
+// 						},
+// 						"actions": {
+// 							Description: "Currently, Create and Update are supported",
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Required:    true,
+// 							Elem:        &schema.Schema{Type: types.StringType},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"timeout_in_ms": {
+// 				Description: "Extension timeout in milliseconds",
+// 				Type:        types.Int64Type,
+// 				Optional:    true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func validateDestinationType(val interface{}, key string) (warns []string, errs []error) {
-	var v = strings.ToLower(val.(string))
+// func validateDestinationType(val interface{}, key string) (warns []string, errs []error) {
+// 	var v = strings.ToLower(val.(string))
 
-	switch v {
-	case
-		"http",
-		"awslambda":
-		return
-	default:
-		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
-	}
-	return
-}
+// 	switch v {
+// 	case
+// 		"http",
+// 		"awslambda":
+// 		return
+// 	default:
+// 		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
+// 	}
+// 	return
+// }
 
-func resourceAPIExtensionCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var extension *platform.Extension
+// func resourceAPIExtensionCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var extension *platform.Extension
 
-	triggers := unmarshallExtensionTriggers(d)
-	destination, err := unmarshallExtensionDestination(d)
-	if err != nil {
-		return err
-	}
+// 	triggers := unmarshallExtensionTriggers(d)
+// 	destination, err := unmarshallExtensionDestination(d)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	draft := platform.ExtensionDraft{
-		Key:         stringRef(d.Get("key")),
-		Destination: destination,
-		Triggers:    triggers,
-		TimeoutInMs: intRef(d.Get("timeout_in_ms")),
-	}
+// 	draft := platform.ExtensionDraft{
+// 		Key:         stringRef(d.Get("key")),
+// 		Destination: destination,
+// 		Triggers:    triggers,
+// 		TimeoutInMs: intRef(d.Get("timeout_in_ms")),
+// 	}
 
-	err = resource.Retry(20*time.Second, func() *resource.RetryError {
-		var err error
+// 	err = resource.Retry(20*time.Second, func() *resource.RetryError {
+// 		var err error
 
-		extension, err = client.Extensions().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		extension, err = client.Extensions().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	if extension == nil {
-		return fmt.Errorf("Error creating extension")
-	}
+// 	if extension == nil {
+// 		return fmt.Errorf("Error creating extension")
+// 	}
 
-	d.SetId(extension.ID)
-	d.Set("version", extension.Version)
+// 	d.SetId(extension.ID)
+// 	d.Set("version", extension.Version)
 
-	return resourceAPIExtensionRead(d, m)
-}
+// 	return resourceAPIExtensionRead(d, m)
+// }
 
-func resourceAPIExtensionRead(d *schema.ResourceData, m interface{}) error {
-	log.Print("[DEBUG] Reading extensions from commercetools")
-	client := getClient(m)
+// func resourceAPIExtensionRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Print("[DEBUG] Reading extensions from commercetools")
+// 	client := getClient(m)
 
-	extension, err := client.Extensions().WithId(d.Id()).Get().Execute(context.Background())
+// 	extension, err := client.Extensions().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if extension == nil {
-		log.Print("[DEBUG] No extensions found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following extensions:")
-		log.Print(stringFormatObject(extension))
+// 	if extension == nil {
+// 		log.Print("[DEBUG] No extensions found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following extensions:")
+// 		log.Print(stringFormatObject(extension))
 
-		d.Set("version", extension.Version)
-		d.Set("key", extension.Key)
-		d.Set("destination", marshallExtensionDestination(extension.Destination))
-		d.Set("trigger", marshallExtensionTriggers(extension.Triggers))
-		d.Set("timeout_in_ms", extension.TimeoutInMs)
-	}
-	return nil
-}
+// 		d.Set("version", extension.Version)
+// 		d.Set("key", extension.Key)
+// 		d.Set("destination", marshallExtensionDestination(extension.Destination))
+// 		d.Set("trigger", marshallExtensionTriggers(extension.Triggers))
+// 		d.Set("timeout_in_ms", extension.TimeoutInMs)
+// 	}
+// 	return nil
+// }
 
-func resourceAPIExtensionUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceAPIExtensionUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	input := platform.ExtensionUpdate{
-		Version: d.Get("version").(int),
-		Actions: []platform.ExtensionUpdateAction{},
-	}
+// 	input := platform.ExtensionUpdate{
+// 		Version: d.Get("version").(int),
+// 		Actions: []platform.ExtensionUpdateAction{},
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ExtensionSetKeyAction{Key: &newKey})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ExtensionSetKeyAction{Key: &newKey})
+// 	}
 
-	if d.HasChange("trigger") {
-		triggers := unmarshallExtensionTriggers(d)
-		input.Actions = append(
-			input.Actions,
-			&platform.ExtensionChangeTriggersAction{Triggers: triggers})
-	}
+// 	if d.HasChange("trigger") {
+// 		triggers := unmarshallExtensionTriggers(d)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ExtensionChangeTriggersAction{Triggers: triggers})
+// 	}
 
-	if d.HasChange("destination") {
-		destination, err := unmarshallExtensionDestination(d)
-		if err != nil {
-			return err
-		}
-		input.Actions = append(
-			input.Actions,
-			&platform.ExtensionChangeDestinationAction{Destination: destination})
-	}
+// 	if d.HasChange("destination") {
+// 		destination, err := unmarshallExtensionDestination(d)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ExtensionChangeDestinationAction{Destination: destination})
+// 	}
 
-	if d.HasChange("timeout_in_ms") {
-		newTimeout := d.Get("timeout_in_ms").(int)
-		input.Actions = append(
-			input.Actions,
-			&platform.ExtensionSetTimeoutInMsAction{TimeoutInMs: &newTimeout})
-	}
+// 	if d.HasChange("timeout_in_ms") {
+// 		newTimeout := d.Get("timeout_in_ms").(int)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ExtensionSetTimeoutInMsAction{TimeoutInMs: &newTimeout})
+// 	}
 
-	_, err := client.Extensions().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	_, err := client.Extensions().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return resourceAPIExtensionRead(d, m)
-}
+// 	return resourceAPIExtensionRead(d, m)
+// }
 
-func resourceAPIExtensionDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.Extensions().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyExtensionsByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// func resourceAPIExtensionDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.Extensions().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyExtensionsByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
 
-//
-// Helper methods
-//
+// //
+// // Helper methods
+// //
 
-func unmarshallExtensionDestination(d *schema.ResourceData) (platform.Destination, error) {
-	input, err := elementFromList(d, "destination")
-	if err != nil {
-		return nil, err
-	}
+// func unmarshallExtensionDestination(d *schema.ResourceData) (platform.Destination, error) {
+// 	input, err := elementFromList(d, "destination")
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	switch strings.ToLower(input["type"].(string)) {
-	case "http":
-		auth, err := unmarshallExtensionDestinationAuthentication(input)
-		if err != nil {
-			return nil, err
-		}
+// 	switch strings.ToLower(input["type"].(string)) {
+// 	case "http":
+// 		auth, err := unmarshallExtensionDestinationAuthentication(input)
+// 		if err != nil {
+// 			return nil, err
+// 		}
 
-		return platform.ExtensionHttpDestination{
-			Url:            input["url"].(string),
-			Authentication: &auth,
-		}, nil
-	case "awslambda":
-		return platform.ExtensionAWSLambdaDestination{
-			Arn:          input["arn"].(string),
-			AccessKey:    input["access_key"].(string),
-			AccessSecret: input["access_secret"].(string),
-		}, nil
-	default:
-		return nil, fmt.Errorf("Extension type %s not implemented", input["type"])
-	}
-}
+// 		return platform.ExtensionHttpDestination{
+// 			Url:            input["url"].(string),
+// 			Authentication: &auth,
+// 		}, nil
+// 	case "awslambda":
+// 		return platform.ExtensionAWSLambdaDestination{
+// 			Arn:          input["arn"].(string),
+// 			AccessKey:    input["access_key"].(string),
+// 			AccessSecret: input["access_secret"].(string),
+// 		}, nil
+// 	default:
+// 		return nil, fmt.Errorf("Extension type %s not implemented", input["type"])
+// 	}
+// }
 
-func unmarshallExtensionDestinationAuthentication(destInput map[string]interface{}) (platform.ExtensionHttpDestinationAuthentication, error) {
-	authKeys := [2]string{"authorization_header", "azure_authentication"}
-	count := 0
-	for _, key := range authKeys {
-		if value, ok := destInput[key]; ok {
-			if value != "" {
-				count++
-			}
-		}
-	}
-	if count > 1 {
-		return nil, fmt.Errorf(
-			"In the destination only one of the auth values should be definied: %q", authKeys)
-	}
+// func unmarshallExtensionDestinationAuthentication(destInput map[string]interface{}) (platform.ExtensionHttpDestinationAuthentication, error) {
+// 	authKeys := [2]string{"authorization_header", "azure_authentication"}
+// 	count := 0
+// 	for _, key := range authKeys {
+// 		if value, ok := destInput[key]; ok {
+// 			if value != "" {
+// 				count++
+// 			}
+// 		}
+// 	}
+// 	if count > 1 {
+// 		return nil, fmt.Errorf(
+// 			"In the destination only one of the auth values should be definied: %q", authKeys)
+// 	}
 
-	if val, ok := isNotEmpty(destInput, "authorization_header"); ok {
-		return &platform.ExtensionAuthorizationHeaderAuthentication{
-			HeaderValue: val.(string),
-		}, nil
-	}
-	if val, ok := isNotEmpty(destInput, "azure_authentication"); ok {
-		return &platform.ExtensionAzureFunctionsAuthentication{
-			Key: val.(string),
-		}, nil
-	}
+// 	if val, ok := isNotEmpty(destInput, "authorization_header"); ok {
+// 		return &platform.ExtensionAuthorizationHeaderAuthentication{
+// 			HeaderValue: val.(string),
+// 		}, nil
+// 	}
+// 	if val, ok := isNotEmpty(destInput, "azure_authentication"); ok {
+// 		return &platform.ExtensionAzureFunctionsAuthentication{
+// 			Key: val.(string),
+// 		}, nil
+// 	}
 
-	return nil, nil
-}
+// 	return nil, nil
+// }
 
-func marshallExtensionDestination(d platform.Destination) []map[string]string {
-	switch v := d.(type) {
-	case platform.ExtensionHttpDestination:
-		switch a := v.Authentication.(type) {
-		case platform.ExtensionAuthorizationHeaderAuthentication:
-			return []map[string]string{{
-				"type":                 "HTTP",
-				"url":                  v.Url,
-				"authorization_header": a.HeaderValue,
-			}}
-		case platform.ExtensionAzureFunctionsAuthentication:
-			return []map[string]string{{
-				"type":                 "HTTP",
-				"url":                  v.Url,
-				"azure_authentication": a.Key,
-			}}
-		}
-		return []map[string]string{{
-			"type": "HTTP",
-			"url":  v.Url,
-		}}
+// func marshallExtensionDestination(d platform.Destination) []map[string]string {
+// 	switch v := d.(type) {
+// 	case platform.ExtensionHttpDestination:
+// 		switch a := v.Authentication.(type) {
+// 		case platform.ExtensionAuthorizationHeaderAuthentication:
+// 			return []map[string]string{{
+// 				"type":                 "HTTP",
+// 				"url":                  v.Url,
+// 				"authorization_header": a.HeaderValue,
+// 			}}
+// 		case platform.ExtensionAzureFunctionsAuthentication:
+// 			return []map[string]string{{
+// 				"type":                 "HTTP",
+// 				"url":                  v.Url,
+// 				"azure_authentication": a.Key,
+// 			}}
+// 		}
+// 		return []map[string]string{{
+// 			"type": "HTTP",
+// 			"url":  v.Url,
+// 		}}
 
-	case platform.ExtensionAWSLambdaDestination:
-		return []map[string]string{{
-			"type":          "awslambda",
-			"access_key":    v.AccessKey,
-			"access_secret": v.AccessSecret,
-			"arn":           v.Arn,
-		}}
+// 	case platform.ExtensionAWSLambdaDestination:
+// 		return []map[string]string{{
+// 			"type":          "awslambda",
+// 			"access_key":    v.AccessKey,
+// 			"access_secret": v.AccessSecret,
+// 			"arn":           v.Arn,
+// 		}}
 
-	}
-	return []map[string]string{}
-}
+// 	}
+// 	return []map[string]string{}
+// }
 
-func marshallExtensionTriggers(triggers []platform.ExtensionTrigger) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(triggers))
+// func marshallExtensionTriggers(triggers []platform.ExtensionTrigger) []map[string]interface{} {
+// 	result := make([]map[string]interface{}, 0, len(triggers))
 
-	for _, t := range triggers {
-		result = append(result, map[string]interface{}{
-			"resource_type_id": t.ResourceTypeId,
-			"actions":          t.Actions,
-		})
-	}
+// 	for _, t := range triggers {
+// 		result = append(result, map[string]interface{}{
+// 			"resource_type_id": t.ResourceTypeId,
+// 			"actions":          t.Actions,
+// 		})
+// 	}
 
-	return result
-}
+// 	return result
+// }
 
-func unmarshallExtensionTriggers(d *schema.ResourceData) []platform.ExtensionTrigger {
-	input := d.Get("trigger").([]interface{})
-	var result []platform.ExtensionTrigger
+// func unmarshallExtensionTriggers(d *schema.ResourceData) []platform.ExtensionTrigger {
+// 	input := d.Get("trigger").([]interface{})
+// 	var result []platform.ExtensionTrigger
 
-	for _, raw := range input {
-		i := raw.(map[string]interface{})
-		var typeId platform.ExtensionResourceTypeId
+// 	for _, raw := range input {
+// 		i := raw.(map[string]interface{})
+// 		var typeId platform.ExtensionResourceTypeId
 
-		switch i["resource_type_id"].(string) {
-		case "cart":
-			typeId = platform.ExtensionResourceTypeIdCart
-		case "order":
-			typeId = platform.ExtensionResourceTypeIdOrder
-		case "payment":
-			typeId = platform.ExtensionResourceTypeIdPayment
-		case "customer":
-			typeId = platform.ExtensionResourceTypeIdCustomer
-		}
+// 		switch i["resource_type_id"].(string) {
+// 		case "cart":
+// 			typeId = platform.ExtensionResourceTypeIdCart
+// 		case "order":
+// 			typeId = platform.ExtensionResourceTypeIdOrder
+// 		case "payment":
+// 			typeId = platform.ExtensionResourceTypeIdPayment
+// 		case "customer":
+// 			typeId = platform.ExtensionResourceTypeIdCustomer
+// 		}
 
-		rawActions := i["actions"].([]interface{})
-		actions := make([]platform.ExtensionAction, 0, len(rawActions))
-		for _, item := range rawActions {
-			actions = append(actions, platform.ExtensionAction(item.(string)))
-		}
+// 		rawActions := i["actions"].([]interface{})
+// 		actions := make([]platform.ExtensionAction, 0, len(rawActions))
+// 		for _, item := range rawActions {
+// 			actions = append(actions, platform.ExtensionAction(item.(string)))
+// 		}
 
-		result = append(result, platform.ExtensionTrigger{
-			ResourceTypeId: typeId,
-			Actions:        actions,
-		})
-	}
-	return result
-}
+// 		result = append(result, platform.ExtensionTrigger{
+// 			ResourceTypeId: typeId,
+// 			Actions:        actions,
+// 		})
+// 	}
+// 	return result
+// }
 
-func resourceAPIExtensionResourceV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for the extension",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"destination": {
-				Description: "[Destination](https://docs.commercetools.com/api/projects/api-extensions#destination) " +
-					"Details where the extension can be reached",
-				Type:     schema.TypeSet,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"trigger": {
-				Description: "Array of [Trigger](https://docs.commercetools.com/api/projects/api-extensions#trigger) " +
-					"Describes what triggers the extension",
-				Type:     schema.TypeList,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"resource_type_id": {
-							Description: "Currently, cart, order, payment, and customer are supported",
-							Type:        schema.TypeString,
-							Required:    true,
-						},
-						"actions": {
-							Description: "Currently, Create and Update are supported",
-							Type:        schema.TypeList,
-							Required:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"timeout_in_ms": {
-				Description: "Extension timeout in milliseconds",
-				Type:        schema.TypeInt,
-				Optional:    true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceAPIExtensionResourceV0() *schema.Resource {
+// 	return &schema.Resource{
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for the extension",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"destination": {
+// 				Description: "[Destination](https://docs.commercetools.com/api/projects/api-extensions#destination) " +
+// 					"Details where the extension can be reached",
+// 				Type:     schema.TypeSet,
+// 				MaxItems: 1,
+// 				Required: true,
+// 				Elem: &schema.Schema{
+// 					Type: types.StringType,
+// 				},
+// 			},
+// 			"trigger": {
+// 				Description: "Array of [Trigger](https://docs.commercetools.com/api/projects/api-extensions#trigger) " +
+// 					"Describes what triggers the extension",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				Required: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"resource_type_id": {
+// 							Description: "Currently, cart, order, payment, and customer are supported",
+// 							Type:        types.StringType,
+// 							Required:    true,
+// 						},
+// 						"actions": {
+// 							Description: "Currently, Create and Update are supported",
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Required:    true,
+// 							Elem:        &schema.Schema{Type: types.StringType},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"timeout_in_ms": {
+// 				Description: "Extension timeout in milliseconds",
+// 				Type:        types.Int64Type,
+// 				Optional:    true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func migrateAPIExtensionStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	transformToList(rawState, "destination")
-	return rawState, nil
-}
+// func migrateAPIExtensionStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+// 	transformToList(rawState, "destination")
+// 	return rawState, nil
+// }

--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -1,223 +1,223 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"strconv"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"strconv"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/labd/commercetools-go-sdk/platform"
-	"github.com/stretchr/testify/assert"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// 	"github.com/stretchr/testify/assert"
+// )
 
-func TestAPIExtensionUnmarshallExtensionDestination(t *testing.T) {
-	rawDestination := map[string]interface{}{
-		"type":          "AWSLambda",
-		"arn":           "arn:aws:lambda:eu-west-1:111111111:function:api_extensions",
-		"access_key":    "ABCSDF123123123",
-		"access_secret": "****abc/",
-	}
+// func TestAPIExtensionUnmarshallExtensionDestination(t *testing.T) {
+// 	rawDestination := map[string]interface{}{
+// 		"type":          "AWSLambda",
+// 		"arn":           "arn:aws:lambda:eu-west-1:111111111:function:api_extensions",
+// 		"access_key":    "ABCSDF123123123",
+// 		"access_secret": "****abc/",
+// 	}
 
-	resourceDataMap := map[string]interface{}{
-		"id":             "2845b936-e407-4f29-957b-f8deb0fcba97",
-		"version":        1,
-		"createdAt":      "2018-12-03T16:13:03.969Z",
-		"lastModifiedAt": "2018-12-04T09:06:59.491Z",
-		"destination":    []interface{}{rawDestination},
-		"triggers": []interface{}{
-			map[string]interface{}{
-				"triggers": []interface{}{"Create", "Update"},
-			},
-		},
-		"timeout_in_ms": 1,
-		"key":           "create-order",
-	}
+// 	resourceDataMap := map[string]interface{}{
+// 		"id":             "2845b936-e407-4f29-957b-f8deb0fcba97",
+// 		"version":        1,
+// 		"createdAt":      "2018-12-03T16:13:03.969Z",
+// 		"lastModifiedAt": "2018-12-04T09:06:59.491Z",
+// 		"destination":    []interface{}{rawDestination},
+// 		"triggers": []interface{}{
+// 			map[string]interface{}{
+// 				"triggers": []interface{}{"Create", "Update"},
+// 			},
+// 		},
+// 		"timeout_in_ms": 1,
+// 		"key":           "create-order",
+// 	}
 
-	d := schema.TestResourceDataRaw(t, resourceAPIExtension().Schema, resourceDataMap)
-	destination, _ := unmarshallExtensionDestination(d)
-	lambdaDestination, ok := destination.(platform.ExtensionAWSLambdaDestination)
+// 	d := schema.TestResourceDataRaw(t, resourceAPIExtension().Schema, resourceDataMap)
+// 	destination, _ := unmarshallExtensionDestination(d)
+// 	lambdaDestination, ok := destination.(platform.ExtensionAWSLambdaDestination)
 
-	assert.True(t, ok)
-	assert.Equal(t, lambdaDestination.Arn, "arn:aws:lambda:eu-west-1:111111111:function:api_extensions")
-	assert.Equal(t, lambdaDestination.AccessKey, "ABCSDF123123123")
-	assert.Equal(t, lambdaDestination.AccessSecret, "****abc/")
-}
+// 	assert.True(t, ok)
+// 	assert.Equal(t, lambdaDestination.Arn, "arn:aws:lambda:eu-west-1:111111111:function:api_extensions")
+// 	assert.Equal(t, lambdaDestination.AccessKey, "ABCSDF123123123")
+// 	assert.Equal(t, lambdaDestination.AccessSecret, "****abc/")
+// }
 
-func TestAPIExtensionUnmarshallExtensionDestinationAuthentication(t *testing.T) {
-	var input = map[string]interface{}{
-		"authorization_header": "12345",
-		"azure_authentication": "AzureKey",
-	}
+// func TestAPIExtensionUnmarshallExtensionDestinationAuthentication(t *testing.T) {
+// 	var input = map[string]interface{}{
+// 		"authorization_header": "12345",
+// 		"azure_authentication": "AzureKey",
+// 	}
 
-	auth, err := unmarshallExtensionDestinationAuthentication(input)
-	assert.Nil(t, auth)
-	assert.NotNil(t, err)
+// 	auth, err := unmarshallExtensionDestinationAuthentication(input)
+// 	assert.Nil(t, auth)
+// 	assert.NotNil(t, err)
 
-	input = map[string]interface{}{
-		"authorization_header": "12345",
-	}
+// 	input = map[string]interface{}{
+// 		"authorization_header": "12345",
+// 	}
 
-	auth, err = unmarshallExtensionDestinationAuthentication(input)
-	httpAuth, ok := auth.(*platform.ExtensionAuthorizationHeaderAuthentication)
-	assert.True(t, ok)
-	assert.Equal(t, "12345", httpAuth.HeaderValue)
-	assert.NotNil(t, auth)
-	assert.Nil(t, err)
-}
+// 	auth, err = unmarshallExtensionDestinationAuthentication(input)
+// 	httpAuth, ok := auth.(*platform.ExtensionAuthorizationHeaderAuthentication)
+// 	assert.True(t, ok)
+// 	assert.Equal(t, "12345", httpAuth.HeaderValue)
+// 	assert.NotNil(t, auth)
+// 	assert.Nil(t, err)
+// }
 
-func TestUnmarshallExtensionTriggers(t *testing.T) {
-	resourceDataMap := map[string]interface{}{
-		"id":             "2845b936-e407-4f29-957b-f8deb0fcba97",
-		"version":        1,
-		"createdAt":      "2018-12-03T16:13:03.969Z",
-		"lastModifiedAt": "2018-12-04T09:06:59.491Z",
-		"trigger": []interface{}{
-			map[string]interface{}{
-				"resource_type_id": "cart",
-				"actions":          []interface{}{"Create", "Update"},
-			},
-		},
-		"timeout_in_ms": 1,
-		"key":           "create-order",
-	}
+// func TestUnmarshallExtensionTriggers(t *testing.T) {
+// 	resourceDataMap := map[string]interface{}{
+// 		"id":             "2845b936-e407-4f29-957b-f8deb0fcba97",
+// 		"version":        1,
+// 		"createdAt":      "2018-12-03T16:13:03.969Z",
+// 		"lastModifiedAt": "2018-12-04T09:06:59.491Z",
+// 		"trigger": []interface{}{
+// 			map[string]interface{}{
+// 				"resource_type_id": "cart",
+// 				"actions":          []interface{}{"Create", "Update"},
+// 			},
+// 		},
+// 		"timeout_in_ms": 1,
+// 		"key":           "create-order",
+// 	}
 
-	d := schema.TestResourceDataRaw(t, resourceAPIExtension().Schema, resourceDataMap)
-	triggers := unmarshallExtensionTriggers(d)
+// 	d := schema.TestResourceDataRaw(t, resourceAPIExtension().Schema, resourceDataMap)
+// 	triggers := unmarshallExtensionTriggers(d)
 
-	assert.Len(t, triggers, 1)
-	assert.Equal(t, triggers[0].ResourceTypeId, platform.ExtensionResourceTypeIdCart)
-	assert.Len(t, triggers[0].Actions, 2)
-}
+// 	assert.Len(t, triggers, 1)
+// 	assert.Equal(t, triggers[0].ResourceTypeId, platform.ExtensionResourceTypeIdCart)
+// 	assert.Len(t, triggers[0].Actions, 2)
+// }
 
-func TestAccAPIExtension_basic(t *testing.T) {
-	fmt.Println("RUN IT")
-	name := fmt.Sprintf("extension_%s", acctest.RandString(5))
-	timeoutInMs := acctest.RandIntRange(200, 1800)
+// func TestAccAPIExtension_basic(t *testing.T) {
+// 	fmt.Println("RUN IT")
+// 	name := fmt.Sprintf("extension_%s", acctest.RandString(5))
+// 	timeoutInMs := acctest.RandIntRange(200, 1800)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAPIExtensionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAPIExtensionConfig(name, timeoutInMs),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAPIExtensionExists("ext"),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "key", name),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.#", "1"),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
-				),
-			},
-			{
-				Config: testAccAPIExtensionUpdate(name, timeoutInMs),
-				Check: resource.ComposeTestCheckFunc(
-					testAccAPIExtensionExists("ext"),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "key", name),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.#", "2"),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
-					resource.TestCheckResourceAttr(
-						"commercetools_api_extension.ext", "trigger.0.actions.1", "Update"),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckAPIExtensionDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccAPIExtensionConfig(name, timeoutInMs),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccAPIExtensionExists("ext"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "key", name),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "trigger.0.actions.#", "1"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccAPIExtensionUpdate(name, timeoutInMs),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccAPIExtensionExists("ext"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "key", name),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "trigger.0.actions.#", "2"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_api_extension.ext", "trigger.0.actions.1", "Update"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccAPIExtensionConfig(name string, timeoutInMs int) string {
-	return fmt.Sprintf(`
-resource "commercetools_api_extension" "ext" {
-  key = "%s"
-  timeout_in_ms = %d
+// func testAccAPIExtensionConfig(name string, timeoutInMs int) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_api_extension" "ext" {
+//   key = "%s"
+//   timeout_in_ms = %d
 
-  destination {
-    type                 = "HTTP"
-    url                  = "https://example.com"
-    authorization_header = "Basic 12345"
-  }
+//   destination {
+//     type                 = "HTTP"
+//     url                  = "https://example.com"
+//     authorization_header = "Basic 12345"
+//   }
 
-  trigger {
-    resource_type_id = "customer"
-    actions = ["Create"]
-  }
-}
-`, name, timeoutInMs)
-}
+//   trigger {
+//     resource_type_id = "customer"
+//     actions = ["Create"]
+//   }
+// }
+// `, name, timeoutInMs)
+// }
 
-func testAccAPIExtensionUpdate(name string, timeoutInMs int) string {
-	return fmt.Sprintf(`
-resource "commercetools_api_extension" "ext" {
-  key = "%s"
-  timeout_in_ms = %d
+// func testAccAPIExtensionUpdate(name string, timeoutInMs int) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_api_extension" "ext" {
+//   key = "%s"
+//   timeout_in_ms = %d
 
-  destination {
-    type                 = "HTTP"
-    url                  = "https://example.com"
-    authorization_header = "Basic 12345"
-  }
+//   destination {
+//     type                 = "HTTP"
+//     url                  = "https://example.com"
+//     authorization_header = "Basic 12345"
+//   }
 
-  trigger {
-    resource_type_id = "customer"
-    actions = ["Create", "Update"]
-  }
-}
-`, name, timeoutInMs)
-}
+//   trigger {
+//     resource_type_id = "customer"
+//     actions = ["Create", "Update"]
+//   }
+// }
+// `, name, timeoutInMs)
+// }
 
-func testAccAPIExtensionExists(n string) resource.TestCheckFunc {
-	name := fmt.Sprintf("commercetools_api_extension.%s", n)
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
+// func testAccAPIExtensionExists(n string) resource.TestCheckFunc {
+// 	name := fmt.Sprintf("commercetools_api_extension.%s", n)
+// 	return func(s *terraform.State) error {
+// 		rs, ok := s.RootModule().Resources[name]
+// 		if !ok {
+// 			return fmt.Errorf("Not found: %s", name)
+// 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Extension ID is set")
-		}
-		client := getClient(testAccProvider.Meta())
-		result, err := client.Extensions().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err != nil {
-			return err
-		}
-		if result == nil {
-			return fmt.Errorf("Extension not found")
-		}
+// 		if rs.Primary.ID == "" {
+// 			return fmt.Errorf("No Extension ID is set")
+// 		}
+// 		client := getClient(testAccProvider.Meta())
+// 		result, err := client.Extensions().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err != nil {
+// 			return err
+// 		}
+// 		if result == nil {
+// 			return fmt.Errorf("Extension not found")
+// 		}
 
-		return nil
-	}
-}
+// 		return nil
+// 	}
+// }
 
-func testAccCheckAPIExtensionDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckAPIExtensionDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_api_extension" {
-			continue
-		}
-		response, err := client.Extensions().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("api extension (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_api_extension" {
+// 			continue
+// 		}
+// 		response, err := client.Extensions().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("api extension (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_cart_discount.go
+++ b/commercetools/resource_cart_discount.go
@@ -1,762 +1,762 @@
 package commercetools
 
-import (
-	"context"
-	"errors"
-	"fmt"
-	"log"
-	"time"
+// import (
+// 	"context"
+// 	"errors"
+// 	"fmt"
+// 	"log"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/ctutils"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/ctutils"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceCartDiscount() *schema.Resource {
-	return &schema.Resource{
-		Description: "Cart discounts are used to change the prices of different elements within a cart.\n\n" +
-			"See also the [Cart Discount API Documentation](https://docs.commercetools.com/api/projects/cartDiscounts)",
-		Create: resourceCartDiscountCreate,
-		Read:   resourceCartDiscountRead,
-		Update: resourceCartDiscountUpdate,
-		Delete: resourceCartDiscountDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    resourceCartDiscountResourceV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: migrateCartDiscountStateV0toV1,
-				Version: 0,
-			},
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for a cart discount. Must be unique across a project",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"name": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Required:    true,
-			},
-			"description": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"value": {
-				Description: "Defines the effect the discount will have. " +
-					"[CartDiscountValue](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscountvalue)",
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Description:  "Currently supports absolute/relative/giftLineItem",
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateValueType,
-						},
-						"permyriad": {
-							Description: "Relative discount specific fields",
-							Type:        schema.TypeInt,
-							Optional:    true,
-						},
-						"money": {
-							Description: "Absolute discount specific fields",
-							Type:        schema.TypeList,
-							Optional:    true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"currency_code": {
-										Description:  "The currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: ValidateCurrencyCode,
-									},
-									"cent_amount": {
-										Description: "The amount in cents (the smallest indivisible unit of the currency)",
-										Type:        schema.TypeInt,
-										Required:    true,
-									},
-								},
-							},
-						},
-						"product_id": {
-							Description: "Gift Line Item discount specific field",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"variant": {
-							Description: "Gift Line Item discount specific field",
-							Type:        schema.TypeInt,
-							Optional:    true,
-						},
-						"supply_channel_id": {
-							Description: "Gift Line Item discount specific field",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"distribution_channel_id": {
-							Description: "Gift Line Item discount specific field",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-					},
-				},
-			},
-			"predicate": {
-				Description: "A valid [Cart Predicate](https://docs.commercetools.com/api/projects/predicates#cart-predicates)",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"target": {
-				Description: "Empty when the value has type giftLineItem, otherwise a " +
-					"[CartDiscountTarget](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscounttarget)",
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Description:  "Supports lineItems/customLineItems/shipping",
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateTargetType,
-						},
-						"predicate": {
-							Description: "LineItems/CustomLineItems target specific fields",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-					},
-				},
-			},
-			"sort_order": {
-				Description: "The string must contain a number between 0 and 1. All matching cart discounts are " +
-					"applied to a cart in the order defined by this field. A discount with greater sort order is " +
-					"prioritized higher than a discount with lower sort order. The sort order is unambiguous among all cart discounts",
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"is_active": {
-				Description: "Only active discount can be applied to the cart",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-			},
-			"valid_from": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"valid_until": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"requires_discount_code": {
-				Description: "States whether the discount can only be used in a connection with a " +
-					"[DiscountCode](https://docs.commercetools.com/api/projects/discountCodes#discountcode)",
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"stacking_mode": {
-				Description:  "Specifies whether the application of this discount causes the following discounts to be ignored",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateStackingMode,
-				Default:      "Stacking",
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceCartDiscount() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Cart discounts are used to change the prices of different elements within a cart.\n\n" +
+// 			"See also the [Cart Discount API Documentation](https://docs.commercetools.com/api/projects/cartDiscounts)",
+// 		Create: resourceCartDiscountCreate,
+// 		Read:   resourceCartDiscountRead,
+// 		Update: resourceCartDiscountUpdate,
+// 		Delete: resourceCartDiscountDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		SchemaVersion: 1,
+// 		StateUpgraders: []schema.StateUpgrader{
+// 			{
+// 				Type:    resourceCartDiscountResourceV0().CoreConfigSchema().ImpliedType(),
+// 				Upgrade: migrateCartDiscountStateV0toV1,
+// 				Version: 0,
+// 			},
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for a cart discount. Must be unique across a project",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"name": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Required:    true,
+// 			},
+// 			"description": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"value": {
+// 				Description: "Defines the effect the discount will have. " +
+// 					"[CartDiscountValue](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscountvalue)",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				MaxItems: 1,
+// 				Required: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Description:  "Currently supports absolute/relative/giftLineItem",
+// 							Type:         types.StringType,
+// 							Required:     true,
+// 							ValidateFunc: validateValueType,
+// 						},
+// 						"permyriad": {
+// 							Description: "Relative discount specific fields",
+// 							Type:        types.Int64Type,
+// 							Optional:    true,
+// 						},
+// 						"money": {
+// 							Description: "Absolute discount specific fields",
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Optional:    true,
+// 							Elem: &schema.Resource{
+// 								Schema: map[string]*schema.Schema{
+// 									"currency_code": {
+// 										Description:  "The currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
+// 										Type:         types.StringType,
+// 										Required:     true,
+// 										ValidateFunc: ValidateCurrencyCode,
+// 									},
+// 									"cent_amount": {
+// 										Description: "The amount in cents (the smallest indivisible unit of the currency)",
+// 										Type:        types.Int64Type,
+// 										Required:    true,
+// 									},
+// 								},
+// 							},
+// 						},
+// 						"product_id": {
+// 							Description: "Gift Line Item discount specific field",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 						"variant": {
+// 							Description: "Gift Line Item discount specific field",
+// 							Type:        types.Int64Type,
+// 							Optional:    true,
+// 						},
+// 						"supply_channel_id": {
+// 							Description: "Gift Line Item discount specific field",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 						"distribution_channel_id": {
+// 							Description: "Gift Line Item discount specific field",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"predicate": {
+// 				Description: "A valid [Cart Predicate](https://docs.commercetools.com/api/projects/predicates#cart-predicates)",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"target": {
+// 				Description: "Empty when the value has type giftLineItem, otherwise a " +
+// 					"[CartDiscountTarget](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscounttarget)",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				MaxItems: 1,
+// 				Optional: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Description:  "Supports lineItems/customLineItems/shipping",
+// 							Type:         types.StringType,
+// 							Required:     true,
+// 							ValidateFunc: validateTargetType,
+// 						},
+// 						"predicate": {
+// 							Description: "LineItems/CustomLineItems target specific fields",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"sort_order": {
+// 				Description: "The string must contain a number between 0 and 1. All matching cart discounts are " +
+// 					"applied to a cart in the order defined by this field. A discount with greater sort order is " +
+// 					"prioritized higher than a discount with lower sort order. The sort order is unambiguous among all cart discounts",
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"is_active": {
+// 				Description: "Only active discount can be applied to the cart",
+// 				Type:        types.BoolType,
+// 				Optional:    true,
+// 				Default:     true,
+// 			},
+// 			"valid_from": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"valid_until": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"requires_discount_code": {
+// 				Description: "States whether the discount can only be used in a connection with a " +
+// 					"[DiscountCode](https://docs.commercetools.com/api/projects/discountCodes#discountcode)",
+// 				Type:     types.BoolType,
+// 				Optional: true,
+// 				Default:  false,
+// 			},
+// 			"stacking_mode": {
+// 				Description:  "Specifies whether the application of this discount causes the following discounts to be ignored",
+// 				Type:         types.StringType,
+// 				Optional:     true,
+// 				ValidateFunc: validateStackingMode,
+// 				Default:      "Stacking",
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func validateValueType(val interface{}, key string) (warns []string, errs []error) {
-	switch val {
-	case
-		"relative",
-		"absolute",
-		"giftLineItem":
-		return
-	default:
-		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
-	}
-	return
-}
+// func validateValueType(val interface{}, key string) (warns []string, errs []error) {
+// 	switch val {
+// 	case
+// 		"relative",
+// 		"absolute",
+// 		"giftLineItem":
+// 		return
+// 	default:
+// 		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
+// 	}
+// 	return
+// }
 
-func validateTargetType(val interface{}, key string) (warns []string, errs []error) {
-	switch val {
-	case
-		"lineItems",
-		"customLineItems",
-		"shipping":
-		return
-	default:
-		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
-	}
-	return
-}
+// func validateTargetType(val interface{}, key string) (warns []string, errs []error) {
+// 	switch val {
+// 	case
+// 		"lineItems",
+// 		"customLineItems",
+// 		"shipping":
+// 		return
+// 	default:
+// 		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
+// 	}
+// 	return
+// }
 
-func validateStackingMode(val interface{}, key string) (warns []string, errs []error) {
-	switch val {
-	case
-		"Stacking",
-		"StopAfterThisDiscount":
-		return
-	default:
-		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
-	}
-	return
-}
+// func validateStackingMode(val interface{}, key string) (warns []string, errs []error) {
+// 	switch val {
+// 	case
+// 		"Stacking",
+// 		"StopAfterThisDiscount":
+// 		return
+// 	default:
+// 		errs = append(errs, fmt.Errorf("%q not a valid value for %q", val, key))
+// 	}
+// 	return
+// }
 
-func resourceCartDiscountCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var cartDiscount *platform.CartDiscount
+// func resourceCartDiscountCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var cartDiscount *platform.CartDiscount
 
-	name := platform.LocalizedString(
-		expandStringMap(d.Get("name").(map[string]interface{})))
-	description := platform.LocalizedString(
-		expandStringMap(d.Get("description").(map[string]interface{})))
+// 	name := platform.LocalizedString(
+// 		expandStringMap(d.Get("name").(map[string]interface{})))
+// 	description := platform.LocalizedString(
+// 		expandStringMap(d.Get("description").(map[string]interface{})))
 
-	value, err := unmarshallCartDiscountValue(d)
-	if err != nil {
-		return err
-	}
+// 	value, err := unmarshallCartDiscountValue(d)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	stackingMode, err := unmarshallCartDiscountStackingMode(d)
-	if err != nil {
-		return err
-	}
+// 	stackingMode, err := unmarshallCartDiscountStackingMode(d)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	draft := platform.CartDiscountDraft{
-		Key:                  stringRef(d.Get("key")),
-		Name:                 name,
-		Description:          &description,
-		Value:                &value,
-		CartPredicate:        d.Get("predicate").(string),
-		SortOrder:            d.Get("sort_order").(string),
-		IsActive:             boolRef(d.Get("is_active")),
-		RequiresDiscountCode: ctutils.BoolRef(d.Get("requires_discount_code").(bool)),
-		StackingMode:         &stackingMode,
-	}
+// 	draft := platform.CartDiscountDraft{
+// 		Key:                  stringRef(d.Get("key")),
+// 		Name:                 name,
+// 		Description:          &description,
+// 		Value:                &value,
+// 		CartPredicate:        d.Get("predicate").(string),
+// 		SortOrder:            d.Get("sort_order").(string),
+// 		IsActive:             boolRef(d.Get("is_active")),
+// 		RequiresDiscountCode: ctutils.BoolRef(d.Get("requires_discount_code").(bool)),
+// 		StackingMode:         &stackingMode,
+// 	}
 
-	if val, err := unmarshallCartDiscountTarget(d); err == nil {
-		draft.Target = val
-	} else {
-		return err
-	}
+// 	if val, err := unmarshallCartDiscountTarget(d); err == nil {
+// 		draft.Target = val
+// 	} else {
+// 		return err
+// 	}
 
-	if val := d.Get("valid_from").(string); len(val) > 0 {
-		validFrom, err := expandDate(val)
-		if err != nil {
-			return err
-		}
-		draft.ValidFrom = &validFrom
-	}
-	if val := d.Get("valid_until").(string); len(val) > 0 {
-		validUntil, err := expandDate(val)
-		if err != nil {
-			return err
-		}
-		draft.ValidUntil = &validUntil
-	}
+// 	if val := d.Get("valid_from").(string); len(val) > 0 {
+// 		validFrom, err := expandDate(val)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		draft.ValidFrom = &validFrom
+// 	}
+// 	if val := d.Get("valid_until").(string); len(val) > 0 {
+// 		validUntil, err := expandDate(val)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		draft.ValidUntil = &validUntil
+// 	}
 
-	errorResponse := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
+// 	errorResponse := resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
 
-		cartDiscount, err = client.CartDiscounts().Post(draft).Execute(context.Background())
+// 		cartDiscount, err = client.CartDiscounts().Post(draft).Execute(context.Background())
 
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if errorResponse != nil {
-		return errorResponse
-	}
+// 	if errorResponse != nil {
+// 		return errorResponse
+// 	}
 
-	if cartDiscount == nil {
-		log.Fatal("No cart discount created")
-	}
+// 	if cartDiscount == nil {
+// 		log.Fatal("No cart discount created")
+// 	}
 
-	d.SetId(cartDiscount.ID)
-	d.Set("version", cartDiscount.Version)
+// 	d.SetId(cartDiscount.ID)
+// 	d.Set("version", cartDiscount.Version)
 
-	return resourceCartDiscountRead(d, m)
-}
+// 	return resourceCartDiscountRead(d, m)
+// }
 
-func resourceCartDiscountRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Reading cart discount from commercetools, with cartDiscount id: %s", d.Id())
+// func resourceCartDiscountRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Printf("[DEBUG] Reading cart discount from commercetools, with cartDiscount id: %s", d.Id())
 
-	client := getClient(m)
+// 	client := getClient(m)
 
-	cartDiscount, err := client.CartDiscounts().WithId(d.Id()).Get().Execute(context.Background())
+// 	cartDiscount, err := client.CartDiscounts().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if cartDiscount == nil {
-		log.Print("[DEBUG] No cart discount found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following cart discount:")
-		log.Print(stringFormatObject(cartDiscount))
+// 	if cartDiscount == nil {
+// 		log.Print("[DEBUG] No cart discount found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following cart discount:")
+// 		log.Print(stringFormatObject(cartDiscount))
 
-		d.Set("version", cartDiscount.Version)
-		d.Set("key", cartDiscount.Key)
-		d.Set("name", cartDiscount.Name)
-		d.Set("description", cartDiscount.Description)
-		d.Set("value", marshallCartDiscountValue(cartDiscount.Value))
-		d.Set("predicate", cartDiscount.CartPredicate)
-		d.Set("target", marshallCartDiscountTarget(cartDiscount.Target))
-		d.Set("sort_order", cartDiscount.SortOrder)
-		d.Set("is_active", cartDiscount.IsActive)
-		d.Set("valid_from", marshallTime(cartDiscount.ValidFrom))
-		d.Set("valid_until", marshallTime(cartDiscount.ValidUntil))
-		d.Set("requires_discount_code", cartDiscount.RequiresDiscountCode)
-		d.Set("stacking_mode", cartDiscount.StackingMode)
-	}
+// 		d.Set("version", cartDiscount.Version)
+// 		d.Set("key", cartDiscount.Key)
+// 		d.Set("name", cartDiscount.Name)
+// 		d.Set("description", cartDiscount.Description)
+// 		d.Set("value", marshallCartDiscountValue(cartDiscount.Value))
+// 		d.Set("predicate", cartDiscount.CartPredicate)
+// 		d.Set("target", marshallCartDiscountTarget(cartDiscount.Target))
+// 		d.Set("sort_order", cartDiscount.SortOrder)
+// 		d.Set("is_active", cartDiscount.IsActive)
+// 		d.Set("valid_from", marshallTime(cartDiscount.ValidFrom))
+// 		d.Set("valid_until", marshallTime(cartDiscount.ValidUntil))
+// 		d.Set("requires_discount_code", cartDiscount.RequiresDiscountCode)
+// 		d.Set("stacking_mode", cartDiscount.StackingMode)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func resourceCartDiscountUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	cartDiscount, err := client.CartDiscounts().WithId(d.Id()).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// func resourceCartDiscountUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	cartDiscount, err := client.CartDiscounts().WithId(d.Id()).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	input := platform.CartDiscountUpdate{
-		Version: cartDiscount.Version,
-		Actions: []platform.CartDiscountUpdateAction{},
-	}
+// 	input := platform.CartDiscountUpdate{
+// 		Version: cartDiscount.Version,
+// 		Actions: []platform.CartDiscountUpdateAction{},
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountSetKeyAction{Key: &newKey})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountSetKeyAction{Key: &newKey})
+// 	}
 
-	if d.HasChange("name") {
-		newName := platform.LocalizedString(
-			expandStringMap(d.Get("name").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountChangeNameAction{Name: newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := platform.LocalizedString(
+// 			expandStringMap(d.Get("name").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountChangeNameAction{Name: newName})
+// 	}
 
-	if d.HasChange("description") {
-		newDescription := platform.LocalizedString(
-			expandStringMap(d.Get("description").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountSetDescriptionAction{Description: &newDescription})
-	}
+// 	if d.HasChange("description") {
+// 		newDescription := platform.LocalizedString(
+// 			expandStringMap(d.Get("description").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountSetDescriptionAction{Description: &newDescription})
+// 	}
 
-	if d.HasChange("value") {
-		value, err := unmarshallCartDiscountValue(d)
-		if err != nil {
-			return err
-		}
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountChangeValueAction{Value: value})
-	}
+// 	if d.HasChange("value") {
+// 		value, err := unmarshallCartDiscountValue(d)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountChangeValueAction{Value: value})
+// 	}
 
-	if d.HasChange("predicate") {
-		newPredicate := d.Get("predicate").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountChangeCartPredicateAction{CartPredicate: newPredicate})
-	}
+// 	if d.HasChange("predicate") {
+// 		newPredicate := d.Get("predicate").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountChangeCartPredicateAction{CartPredicate: newPredicate})
+// 	}
 
-	if d.HasChange("target") {
-		if val, err := unmarshallCartDiscountTarget(d); err == nil {
-			if val != nil {
-				input.Actions = append(
-					input.Actions,
-					&platform.CartDiscountChangeTargetAction{Target: val})
-			} else {
-				return errors.New("Cannot change target to empty")
-			}
-		} else {
-			return err
-		}
+// 	if d.HasChange("target") {
+// 		if val, err := unmarshallCartDiscountTarget(d); err == nil {
+// 			if val != nil {
+// 				input.Actions = append(
+// 					input.Actions,
+// 					&platform.CartDiscountChangeTargetAction{Target: val})
+// 			} else {
+// 				return errors.New("Cannot change target to empty")
+// 			}
+// 		} else {
+// 			return err
+// 		}
 
-	}
+// 	}
 
-	if d.HasChange("sort_order") {
-		newSortOrder := d.Get("sort_order").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountChangeSortOrderAction{SortOrder: newSortOrder})
-	}
+// 	if d.HasChange("sort_order") {
+// 		newSortOrder := d.Get("sort_order").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountChangeSortOrderAction{SortOrder: newSortOrder})
+// 	}
 
-	if d.HasChange("is_active") {
-		newIsActive := d.Get("is_active").(bool)
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountChangeIsActiveAction{IsActive: newIsActive})
-	}
+// 	if d.HasChange("is_active") {
+// 		newIsActive := d.Get("is_active").(bool)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountChangeIsActiveAction{IsActive: newIsActive})
+// 	}
 
-	if d.HasChange("valid_from") {
-		if val := d.Get("valid_from").(string); len(val) > 0 {
-			newValidFrom, err := expandDate(d.Get("valid_from").(string))
-			if err != nil {
-				return err
-			}
-			input.Actions = append(
-				input.Actions,
-				&platform.CartDiscountSetValidFromAction{ValidFrom: &newValidFrom})
-		} else {
-			input.Actions = append(
-				input.Actions,
-				&platform.CartDiscountSetValidFromAction{})
-		}
-	}
+// 	if d.HasChange("valid_from") {
+// 		if val := d.Get("valid_from").(string); len(val) > 0 {
+// 			newValidFrom, err := expandDate(d.Get("valid_from").(string))
+// 			if err != nil {
+// 				return err
+// 			}
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.CartDiscountSetValidFromAction{ValidFrom: &newValidFrom})
+// 		} else {
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.CartDiscountSetValidFromAction{})
+// 		}
+// 	}
 
-	if d.HasChange("valid_until") {
-		if val := d.Get("valid_until").(string); len(val) > 0 {
-			newValidUntil, err := expandDate(d.Get("valid_until").(string))
-			if err != nil {
-				return err
-			}
-			input.Actions = append(
-				input.Actions,
-				&platform.CartDiscountSetValidUntilAction{ValidUntil: &newValidUntil})
-		} else {
-			input.Actions = append(
-				input.Actions,
-				&platform.CartDiscountSetValidUntilAction{})
-		}
-	}
+// 	if d.HasChange("valid_until") {
+// 		if val := d.Get("valid_until").(string); len(val) > 0 {
+// 			newValidUntil, err := expandDate(d.Get("valid_until").(string))
+// 			if err != nil {
+// 				return err
+// 			}
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.CartDiscountSetValidUntilAction{ValidUntil: &newValidUntil})
+// 		} else {
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.CartDiscountSetValidUntilAction{})
+// 		}
+// 	}
 
-	if d.HasChange("requires_discount_code") {
-		newRequiresDiscountCode := d.Get("requires_discount_code").(bool)
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountChangeRequiresDiscountCodeAction{RequiresDiscountCode: newRequiresDiscountCode})
-	}
+// 	if d.HasChange("requires_discount_code") {
+// 		newRequiresDiscountCode := d.Get("requires_discount_code").(bool)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountChangeRequiresDiscountCodeAction{RequiresDiscountCode: newRequiresDiscountCode})
+// 	}
 
-	if d.HasChange("stacking_mode") {
-		newStackingMode, err := unmarshallCartDiscountStackingMode(d)
-		if err != nil {
-			return err
-		}
-		input.Actions = append(
-			input.Actions,
-			&platform.CartDiscountChangeStackingModeAction{StackingMode: newStackingMode})
-	}
+// 	if d.HasChange("stacking_mode") {
+// 		newStackingMode, err := unmarshallCartDiscountStackingMode(d)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CartDiscountChangeStackingModeAction{StackingMode: newStackingMode})
+// 	}
 
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
 
-	_, err = client.CartDiscounts().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
+// 	_, err = client.CartDiscounts().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
 
-	return resourceCartDiscountRead(d, m)
-}
+// 	return resourceCartDiscountRead(d, m)
+// }
 
-func resourceCartDiscountDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.CartDiscounts().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyCartDiscountsByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// func resourceCartDiscountDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.CartDiscounts().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyCartDiscountsByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
 
-func marshallCartDiscountValue(val platform.CartDiscountValue) []map[string]interface{} {
-	if val == nil {
-		return []map[string]interface{}{}
-	}
+// func marshallCartDiscountValue(val platform.CartDiscountValue) []map[string]interface{} {
+// 	if val == nil {
+// 		return []map[string]interface{}{}
+// 	}
 
-	switch v := val.(type) {
-	case platform.CartDiscountValueAbsolute:
-		return []map[string]interface{}{{
-			"type":  "absolute",
-			"money": marshallTypedMoney(v.Money),
-		}}
-	case platform.CartDiscountValueFixed:
-		return []map[string]interface{}{{
-			"type":  "fixed",
-			"money": marshallTypedMoney(v.Money),
-		}}
-	case platform.CartDiscountValueGiftLineItem:
-		return []map[string]interface{}{{
-			"type":                    "giftLineItem",
-			"supply_channel_id":       v.SupplyChannel.ID,
-			"distribution_channel_id": v.DistributionChannel.ID,
-			"product_id":              v.Product.ID,
-		}}
-	case platform.CartDiscountValueRelative:
-		return []map[string]interface{}{{
-			"type":      "relative",
-			"permyriad": v.Permyriad,
-		}}
-	}
-	panic("Unable to marshall cart discount value")
-}
+// 	switch v := val.(type) {
+// 	case platform.CartDiscountValueAbsolute:
+// 		return []map[string]interface{}{{
+// 			"type":  "absolute",
+// 			"money": marshallTypedMoney(v.Money),
+// 		}}
+// 	case platform.CartDiscountValueFixed:
+// 		return []map[string]interface{}{{
+// 			"type":  "fixed",
+// 			"money": marshallTypedMoney(v.Money),
+// 		}}
+// 	case platform.CartDiscountValueGiftLineItem:
+// 		return []map[string]interface{}{{
+// 			"type":                    "giftLineItem",
+// 			"supply_channel_id":       v.SupplyChannel.ID,
+// 			"distribution_channel_id": v.DistributionChannel.ID,
+// 			"product_id":              v.Product.ID,
+// 		}}
+// 	case platform.CartDiscountValueRelative:
+// 		return []map[string]interface{}{{
+// 			"type":      "relative",
+// 			"permyriad": v.Permyriad,
+// 		}}
+// 	}
+// 	panic("Unable to marshall cart discount value")
+// }
 
-func unmarshallCartDiscountValue(d *schema.ResourceData) (platform.CartDiscountValueDraft, error) {
-	value := d.Get("value").([]interface{})[0].(map[string]interface{})
-	switch value["type"].(string) {
-	case "relative":
-		return platform.CartDiscountValueRelativeDraft{
-			Permyriad: value["permyriad"].(int),
-		}, nil
-	case "absolute":
-		money := unmarshallTypedMoney(value)
-		return platform.CartDiscountValueAbsoluteDraft{
-			Money: money,
-		}, nil
-	case "giftLineItem":
-		draft := &platform.CartDiscountValueGiftLineItemDraft{}
+// func unmarshallCartDiscountValue(d *schema.ResourceData) (platform.CartDiscountValueDraft, error) {
+// 	value := d.Get("value").([]interface{})[0].(map[string]interface{})
+// 	switch value["type"].(string) {
+// 	case "relative":
+// 		return platform.CartDiscountValueRelativeDraft{
+// 			Permyriad: value["permyriad"].(int),
+// 		}, nil
+// 	case "absolute":
+// 		money := unmarshallTypedMoney(value)
+// 		return platform.CartDiscountValueAbsoluteDraft{
+// 			Money: money,
+// 		}, nil
+// 	case "giftLineItem":
+// 		draft := &platform.CartDiscountValueGiftLineItemDraft{}
 
-		if val := value["supply_channel_id"].(string); len(val) > 0 {
-			draft.SupplyChannel = &platform.ChannelResourceIdentifier{ID: &val}
-		}
-		if val := value["product_id"].(string); len(val) > 0 {
-			draft.Product = platform.ProductResourceIdentifier{ID: &val}
-		}
-		if val := value["distribution_channel_id"].(string); len(val) > 0 {
-			draft.DistributionChannel = &platform.ChannelResourceIdentifier{ID: &val}
-		}
+// 		if val := value["supply_channel_id"].(string); len(val) > 0 {
+// 			draft.SupplyChannel = &platform.ChannelResourceIdentifier{ID: &val}
+// 		}
+// 		if val := value["product_id"].(string); len(val) > 0 {
+// 			draft.Product = platform.ProductResourceIdentifier{ID: &val}
+// 		}
+// 		if val := value["distribution_channel_id"].(string); len(val) > 0 {
+// 			draft.DistributionChannel = &platform.ChannelResourceIdentifier{ID: &val}
+// 		}
 
-		draft.VariantId = value["variant"].(int)
+// 		draft.VariantId = value["variant"].(int)
 
-		return draft, nil
+// 		return draft, nil
 
-	default:
-		return nil, fmt.Errorf("Value type %s not implemented", value["type"])
-	}
-}
+// 	default:
+// 		return nil, fmt.Errorf("Value type %s not implemented", value["type"])
+// 	}
+// }
 
-func marshallCartDiscountTarget(val platform.CartDiscountTarget) []map[string]interface{} {
-	switch v := val.(type) {
-	case platform.CartDiscountLineItemsTarget:
-		return []map[string]interface{}{{
-			"type":      "lineItems",
-			"predicate": v.Predicate,
-		}}
-	case platform.CartDiscountCustomLineItemsTarget:
-		return []map[string]interface{}{{
-			"type":      "customLineItems",
-			"predicate": v.Predicate,
-		}}
-	case platform.CartDiscountShippingCostTarget:
-		return []map[string]interface{}{{
-			"type": "shipping",
-		}}
-	}
+// func marshallCartDiscountTarget(val platform.CartDiscountTarget) []map[string]interface{} {
+// 	switch v := val.(type) {
+// 	case platform.CartDiscountLineItemsTarget:
+// 		return []map[string]interface{}{{
+// 			"type":      "lineItems",
+// 			"predicate": v.Predicate,
+// 		}}
+// 	case platform.CartDiscountCustomLineItemsTarget:
+// 		return []map[string]interface{}{{
+// 			"type":      "customLineItems",
+// 			"predicate": v.Predicate,
+// 		}}
+// 	case platform.CartDiscountShippingCostTarget:
+// 		return []map[string]interface{}{{
+// 			"type": "shipping",
+// 		}}
+// 	}
 
-	panic("Unable to marshall cart discount target")
-}
+// 	panic("Unable to marshall cart discount target")
+// }
 
-func unmarshallCartDiscountTarget(d *schema.ResourceData) (platform.CartDiscountTarget, error) {
-	input, err := elementFromList(d, "target")
-	if err != nil {
-		return nil, err
-	}
+// func unmarshallCartDiscountTarget(d *schema.ResourceData) (platform.CartDiscountTarget, error) {
+// 	input, err := elementFromList(d, "target")
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	if input == nil {
-		return nil, nil
-	}
+// 	if input == nil {
+// 		return nil, nil
+// 	}
 
-	switch input["type"].(string) {
-	case "lineItems":
-		return platform.CartDiscountLineItemsTarget{
-			Predicate: input["predicate"].(string),
-		}, nil
-	case "customLineItems":
-		return platform.CartDiscountCustomLineItemsTarget{
-			Predicate: input["predicate"].(string),
-		}, nil
-	case "shipping":
-		return platform.CartDiscountShippingCostTarget{}, nil
-	default:
-		return nil, fmt.Errorf("Target type %s not implemented", input["type"])
-	}
+// 	switch input["type"].(string) {
+// 	case "lineItems":
+// 		return platform.CartDiscountLineItemsTarget{
+// 			Predicate: input["predicate"].(string),
+// 		}, nil
+// 	case "customLineItems":
+// 		return platform.CartDiscountCustomLineItemsTarget{
+// 			Predicate: input["predicate"].(string),
+// 		}, nil
+// 	case "shipping":
+// 		return platform.CartDiscountShippingCostTarget{}, nil
+// 	default:
+// 		return nil, fmt.Errorf("Target type %s not implemented", input["type"])
+// 	}
 
-}
+// }
 
-func unmarshallCartDiscountStackingMode(d *schema.ResourceData) (platform.StackingMode, error) {
-	switch d.Get("stacking_mode").(string) {
-	case "Stacking":
-		return platform.StackingModeStacking, nil
-	case "StopAfterThisDiscount":
-		return platform.StackingModeStopAfterThisDiscount, nil
-	default:
-		return "", fmt.Errorf("Stacking mode %s not implemented", d.Get("stacking_mode").(string))
-	}
-}
+// func unmarshallCartDiscountStackingMode(d *schema.ResourceData) (platform.StackingMode, error) {
+// 	switch d.Get("stacking_mode").(string) {
+// 	case "Stacking":
+// 		return platform.StackingModeStacking, nil
+// 	case "StopAfterThisDiscount":
+// 		return platform.StackingModeStopAfterThisDiscount, nil
+// 	default:
+// 		return "", fmt.Errorf("Stacking mode %s not implemented", d.Get("stacking_mode").(string))
+// 	}
+// }
 
-func resourceCartDiscountResourceV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for a cart discount. Must be unique across a project",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"name": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Required:    true,
-			},
-			"description": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"value": {
-				Description: "Defines the effect the discount will have. " +
-					"[CartDiscountValue](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscountvalue)",
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Description:  "Currently supports absolute/relative/giftLineItem",
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validateValueType,
-						},
-						"permyriad": {
-							Description: "Relative discount specific fields",
-							Type:        schema.TypeInt,
-							Optional:    true,
-						},
-						"money": {
-							Description: "Absolute discount specific fields",
-							Type:        schema.TypeList,
-							Optional:    true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"currency_code": {
-										Description:  "The currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: ValidateCurrencyCode,
-									},
-									"cent_amount": {
-										Description: "The amount in cents (the smallest indivisible unit of the currency)",
-										Type:        schema.TypeInt,
-										Required:    true,
-									},
-								},
-							},
-						},
-						"product_id": {
-							Description: "Gift Line Item discount specific field",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"variant": {
-							Description: "Gift Line Item discount specific field",
-							Type:        schema.TypeInt,
-							Optional:    true,
-						},
-						"supply_channel_id": {
-							Description: "Gift Line Item discount specific field",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"distribution_channel_id": {
-							Description: "Gift Line Item discount specific field",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-					},
-				},
-			},
-			"predicate": {
-				Description: "A valid [Cart Predicate](https://docs.commercetools.com/api/projects/predicates#cart-predicates)",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"target": {
-				Description: "Empty when the value has type giftLineItem, otherwise a " +
-					"[CartDiscountTarget](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscounttarget)",
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"sort_order": {
-				Description: "The string must contain a number between 0 and 1. All matching cart discounts are " +
-					"applied to a cart in the order defined by this field. A discount with greater sort order is " +
-					"prioritized higher than a discount with lower sort order. The sort order is unambiguous among all cart discounts",
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"is_active": {
-				Description: "Only active discount can be applied to the cart",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-			},
-			"valid_from": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"valid_until": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"requires_discount_code": {
-				Description: "States whether the discount can only be used in a connection with a " +
-					"[DiscountCode](https://docs.commercetools.com/api/projects/discountCodes#discountcode)",
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"stacking_mode": {
-				Description:  "Specifies whether the application of this discount causes the following discounts to be ignored",
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateStackingMode,
-				Default:      "Stacking",
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceCartDiscountResourceV0() *schema.Resource {
+// 	return &schema.Resource{
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for a cart discount. Must be unique across a project",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"name": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Required:    true,
+// 			},
+// 			"description": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"value": {
+// 				Description: "Defines the effect the discount will have. " +
+// 					"[CartDiscountValue](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscountvalue)",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				MaxItems: 1,
+// 				Required: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Description:  "Currently supports absolute/relative/giftLineItem",
+// 							Type:         types.StringType,
+// 							Required:     true,
+// 							ValidateFunc: validateValueType,
+// 						},
+// 						"permyriad": {
+// 							Description: "Relative discount specific fields",
+// 							Type:        types.Int64Type,
+// 							Optional:    true,
+// 						},
+// 						"money": {
+// 							Description: "Absolute discount specific fields",
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Optional:    true,
+// 							Elem: &schema.Resource{
+// 								Schema: map[string]*schema.Schema{
+// 									"currency_code": {
+// 										Description:  "The currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
+// 										Type:         types.StringType,
+// 										Required:     true,
+// 										ValidateFunc: ValidateCurrencyCode,
+// 									},
+// 									"cent_amount": {
+// 										Description: "The amount in cents (the smallest indivisible unit of the currency)",
+// 										Type:        types.Int64Type,
+// 										Required:    true,
+// 									},
+// 								},
+// 							},
+// 						},
+// 						"product_id": {
+// 							Description: "Gift Line Item discount specific field",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 						"variant": {
+// 							Description: "Gift Line Item discount specific field",
+// 							Type:        types.Int64Type,
+// 							Optional:    true,
+// 						},
+// 						"supply_channel_id": {
+// 							Description: "Gift Line Item discount specific field",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 						"distribution_channel_id": {
+// 							Description: "Gift Line Item discount specific field",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"predicate": {
+// 				Description: "A valid [Cart Predicate](https://docs.commercetools.com/api/projects/predicates#cart-predicates)",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"target": {
+// 				Description: "Empty when the value has type giftLineItem, otherwise a " +
+// 					"[CartDiscountTarget](https://docs.commercetools.com/api/projects/cartDiscounts#cartdiscounttarget)",
+// 				Type:     schema.TypeMap,
+// 				Optional: true,
+// 				Elem: &schema.Schema{
+// 					Type: types.StringType,
+// 				},
+// 			},
+// 			"sort_order": {
+// 				Description: "The string must contain a number between 0 and 1. All matching cart discounts are " +
+// 					"applied to a cart in the order defined by this field. A discount with greater sort order is " +
+// 					"prioritized higher than a discount with lower sort order. The sort order is unambiguous among all cart discounts",
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"is_active": {
+// 				Description: "Only active discount can be applied to the cart",
+// 				Type:        types.BoolType,
+// 				Optional:    true,
+// 				Default:     true,
+// 			},
+// 			"valid_from": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"valid_until": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"requires_discount_code": {
+// 				Description: "States whether the discount can only be used in a connection with a " +
+// 					"[DiscountCode](https://docs.commercetools.com/api/projects/discountCodes#discountcode)",
+// 				Type:     types.BoolType,
+// 				Optional: true,
+// 				Default:  false,
+// 			},
+// 			"stacking_mode": {
+// 				Description:  "Specifies whether the application of this discount causes the following discounts to be ignored",
+// 				Type:         types.StringType,
+// 				Optional:     true,
+// 				ValidateFunc: validateStackingMode,
+// 				Default:      "Stacking",
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func migrateCartDiscountStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	transformToList(rawState, "target")
-	return rawState, nil
-}
+// func migrateCartDiscountStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+// 	transformToList(rawState, "target")
+// 	return rawState, nil
+// }

--- a/commercetools/resource_cart_discount_test.go
+++ b/commercetools/resource_cart_discount_test.go
@@ -1,268 +1,268 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccCartDiscountCreate_basic(t *testing.T) {
+// func TestAccCartDiscountCreate_basic(t *testing.T) {
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCartDiscountDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCartDiscountConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "key", "standard",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "name.en", "standard name",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "description.en", "Standard description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "sort_order", "0.9",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "predicate", "1=1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "requires_discount_code", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "valid_from", "2018-01-02T15:04:05Z",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "valid_until", "2019-01-02T15:04:05Z",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "target.0.type", "lineItems",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "target.0.predicate", "1=1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "value.0.type", "relative",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "is_active", "true",
-					),
-				),
-			},
-			{
-				Config: testAccCartDiscountUpdate(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "key", "standard_new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "name.en", "standard name",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "description.en", "Standard description new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "sort_order", "0.8",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "predicate", "1=1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "requires_discount_code", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "valid_from", "2018-01-02T15:04:05Z",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "valid_until", "2019-01-02T15:04:05Z",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "target.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "target.0.type", "lineItems",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "target.0.predicate", "1=1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "value.0.type", "relative",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "is_active", "false",
-					),
-				),
-			},
-			{
-				Config: testAccCartDiscountRemoveProperties(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "key", "standard_new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "name.en", "standard name",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_cart_discount.standard", "description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "sort_order", "0.8",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "predicate", "1=1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "requires_discount_code", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "valid_from", "",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "valid_until", "",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "target.0.type", "lineItems",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "target.0.predicate", "1=1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "value.0.type", "relative",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_cart_discount.standard", "is_active", "true",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckCartDiscountDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCartDiscountConfig(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "key", "standard",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "name.en", "standard name",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "description.en", "Standard description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "sort_order", "0.9",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "predicate", "1=1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "requires_discount_code", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "valid_from", "2018-01-02T15:04:05Z",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "valid_until", "2019-01-02T15:04:05Z",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "target.0.type", "lineItems",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "target.0.predicate", "1=1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "value.0.type", "relative",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "is_active", "true",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCartDiscountUpdate(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "key", "standard_new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "name.en", "standard name",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "description.en", "Standard description new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "sort_order", "0.8",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "predicate", "1=1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "requires_discount_code", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "valid_from", "2018-01-02T15:04:05Z",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "valid_until", "2019-01-02T15:04:05Z",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "target.#", "1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "target.0.type", "lineItems",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "target.0.predicate", "1=1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "value.0.type", "relative",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "is_active", "false",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCartDiscountRemoveProperties(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "key", "standard_new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "name.en", "standard name",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_cart_discount.standard", "description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "sort_order", "0.8",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "predicate", "1=1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "stacking_mode", "Stacking",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "requires_discount_code", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "valid_from", "",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "valid_until", "",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "target.0.type", "lineItems",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "target.0.predicate", "1=1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "value.0.type", "relative",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "value.0.permyriad", "1000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_cart_discount.standard", "is_active", "true",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccCartDiscountConfig() string {
-	return `
-	resource "commercetools_cart_discount" "standard" {
-		key = "standard"
-		name = {
-		  en = "standard name"
-		}
-		description = {
-			en = "Standard description"
-		  }
-		sort_order             = "0.9"
-		predicate              = "1=1"
-		stacking_mode          = "Stacking"
-		requires_discount_code = true
-		valid_from             = "2018-01-02T15:04:05Z"
-		valid_until            = "2019-01-02T15:04:05Z"
-		target {
-		  type      = "lineItems"
-		  predicate = "1=1"
-		}
+// func testAccCartDiscountConfig() string {
+// 	return `
+// 	resource "commercetools_cart_discount" "standard" {
+// 		key = "standard"
+// 		name = {
+// 		  en = "standard name"
+// 		}
+// 		description = {
+// 			en = "Standard description"
+// 		  }
+// 		sort_order             = "0.9"
+// 		predicate              = "1=1"
+// 		stacking_mode          = "Stacking"
+// 		requires_discount_code = true
+// 		valid_from             = "2018-01-02T15:04:05Z"
+// 		valid_until            = "2019-01-02T15:04:05Z"
+// 		target {
+// 		  type      = "lineItems"
+// 		  predicate = "1=1"
+// 		}
 
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
-	  }
-	  `
-}
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
+// 	  }
+// 	  `
+// }
 
-func testAccCartDiscountUpdate() string {
-	return `
-	resource "commercetools_cart_discount" "standard" {
-		key = "standard_new"
-		name = {
-		  en = "standard name"
-		}
-		description = {
-			en = "Standard description new"
-		  }
-		sort_order             = "0.8"
-		predicate              = "1=1"
-		stacking_mode          = "Stacking"
-		requires_discount_code = true
-		valid_from             = "2018-01-02T15:04:05Z"
-		valid_until            = "2019-01-02T15:04:05Z"
-		target {
-			type      = "lineItems"
-			predicate = "1=1"
-		}
+// func testAccCartDiscountUpdate() string {
+// 	return `
+// 	resource "commercetools_cart_discount" "standard" {
+// 		key = "standard_new"
+// 		name = {
+// 		  en = "standard name"
+// 		}
+// 		description = {
+// 			en = "Standard description new"
+// 		  }
+// 		sort_order             = "0.8"
+// 		predicate              = "1=1"
+// 		stacking_mode          = "Stacking"
+// 		requires_discount_code = true
+// 		valid_from             = "2018-01-02T15:04:05Z"
+// 		valid_until            = "2019-01-02T15:04:05Z"
+// 		target {
+// 			type      = "lineItems"
+// 			predicate = "1=1"
+// 		}
 
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
 
-		is_active = false
-	  }
-	  `
-}
+// 		is_active = false
+// 	  }
+// 	  `
+// }
 
-func testAccCartDiscountRemoveProperties() string {
-	return `
-	resource "commercetools_cart_discount" "standard" {
-		key = "standard_new"
-		name = {
-		  en = "standard name"
-		}
-		sort_order             = "0.8"
-		predicate              = "1=1"
-		requires_discount_code = true
-		target {
-			type      = "lineItems"
-			predicate = "1=1"
-		}
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
-	  }
-	  `
-}
+// func testAccCartDiscountRemoveProperties() string {
+// 	return `
+// 	resource "commercetools_cart_discount" "standard" {
+// 		key = "standard_new"
+// 		name = {
+// 		  en = "standard name"
+// 		}
+// 		sort_order             = "0.8"
+// 		predicate              = "1=1"
+// 		requires_discount_code = true
+// 		target {
+// 			type      = "lineItems"
+// 			predicate = "1=1"
+// 		}
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
+// 	  }
+// 	  `
+// }
 
-func testAccCheckCartDiscountDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckCartDiscountDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_cart_discount" {
-			continue
-		}
-		response, err := client.CartDiscounts().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("cart discount (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_cart_discount" {
+// 			continue
+// 		}
+// 		response, err := client.CartDiscounts().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("cart discount (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -1,579 +1,579 @@
 package commercetools
 
-import (
-	"context"
-	"log"
-	"time"
+// import (
+// 	"context"
+// 	"log"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceCategory() *schema.Resource {
-	return &schema.Resource{
-		Description: "Categories allow you to organize products into hierarchical structures.\n\n" +
-			"Also see the [Categories HTTP API documentation](https://docs.commercetools.com/api/projects/categories).",
-		Create: resourceCategoryCreate,
-		Read:   resourceCategoryRead,
-		Update: resourceCategoryUpdate,
-		Delete: resourceCategoryDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    resourceCategoryResourceV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: migrateCategoryStateV0toV1,
-				Version: 0,
-			},
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Category-specific unique identifier. Must be unique across a project",
-			},
-			"name": {
-				Type:     TypeLocalizedString,
-				Required: true,
-				ForceNew: true,
-			},
-			"description": {
-				Type:     TypeLocalizedString,
-				Optional: true,
-			},
-			"slug": {
-				Type:        TypeLocalizedString,
-				Required:    true,
-				Description: "Human readable identifiers, needs to be unique",
-			},
-			"parent": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "A category that is the parent of this category in the category tree",
-			},
-			"order_hint": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "An attribute as base for a custom category order in one level, filled with random value when left empty",
-			},
-			"meta_title": {
-				Type:     TypeLocalizedString,
-				Optional: true,
-			},
-			"meta_description": {
-				Type:     TypeLocalizedString,
-				Optional: true,
-			},
-			"meta_keywords": {
-				Type:     TypeLocalizedString,
-				Optional: true,
-			},
-			"assets": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Can be used to store images, icons or movies related to this category",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Optional User-defined identifier for the asset. Asset keys are unique inside their container (in this case the category)",
-						},
-						"name": {
-							Type:     TypeLocalizedString,
-							Required: true,
-						},
-						"description": {
-							Type:     TypeLocalizedString,
-							Optional: true,
-						},
-						"sources": {
-							Type:        schema.TypeList,
-							Optional:    true,
-							MinItems:    1,
-							Description: "Array of AssetSource, Has at least one entry",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"uri": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"key": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "Unique identifier, must be unique within the Asset",
-									},
-									"dimensions": {
-										Type:     schema.TypeList,
-										MaxItems: 1,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"w": {
-													Type:        schema.TypeInt,
-													Required:    true,
-													Description: "The width of the asset source",
-												},
-												"h": {
-													Type:        schema.TypeInt,
-													Required:    true,
-													Description: "The height of the asset source",
-												},
-											},
-										},
-									},
-									"content_type": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-								},
-							},
-						},
-						"tags": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceCategory() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Categories allow you to organize products into hierarchical structures.\n\n" +
+// 			"Also see the [Categories HTTP API documentation](https://docs.commercetools.com/api/projects/categories).",
+// 		Create: resourceCategoryCreate,
+// 		Read:   resourceCategoryRead,
+// 		Update: resourceCategoryUpdate,
+// 		Delete: resourceCategoryDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		SchemaVersion: 1,
+// 		StateUpgraders: []schema.StateUpgrader{
+// 			{
+// 				Type:    resourceCategoryResourceV0().CoreConfigSchema().ImpliedType(),
+// 				Upgrade: migrateCategoryStateV0toV1,
+// 				Version: 0,
+// 			},
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 				ForceNew:    true,
+// 				Description: "Category-specific unique identifier. Must be unique across a project",
+// 			},
+// 			"name": {
+// 				Type:     TypeLocalizedString,
+// 				Required: true,
+// 				ForceNew: true,
+// 			},
+// 			"description": {
+// 				Type:     TypeLocalizedString,
+// 				Optional: true,
+// 			},
+// 			"slug": {
+// 				Type:        TypeLocalizedString,
+// 				Required:    true,
+// 				Description: "Human readable identifiers, needs to be unique",
+// 			},
+// 			"parent": {
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 				Description: "A category that is the parent of this category in the category tree",
+// 			},
+// 			"order_hint": {
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 				Description: "An attribute as base for a custom category order in one level, filled with random value when left empty",
+// 			},
+// 			"meta_title": {
+// 				Type:     TypeLocalizedString,
+// 				Optional: true,
+// 			},
+// 			"meta_description": {
+// 				Type:     TypeLocalizedString,
+// 				Optional: true,
+// 			},
+// 			"meta_keywords": {
+// 				Type:     TypeLocalizedString,
+// 				Optional: true,
+// 			},
+// 			"assets": {
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Description: "Can be used to store images, icons or movies related to this category",
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"key": {
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 							Description: "Optional User-defined identifier for the asset. Asset keys are unique inside their container (in this case the category)",
+// 						},
+// 						"name": {
+// 							Type:     TypeLocalizedString,
+// 							Required: true,
+// 						},
+// 						"description": {
+// 							Type:     TypeLocalizedString,
+// 							Optional: true,
+// 						},
+// 						"sources": {
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Optional:    true,
+// 							MinItems:    1,
+// 							Description: "Array of AssetSource, Has at least one entry",
+// 							Elem: &schema.Resource{
+// 								Schema: map[string]*schema.Schema{
+// 									"uri": {
+// 										Type:     types.StringType,
+// 										Required: true,
+// 									},
+// 									"key": {
+// 										Type:        types.StringType,
+// 										Optional:    true,
+// 										Description: "Unique identifier, must be unique within the Asset",
+// 									},
+// 									"dimensions": {
+// 										Type:     types.ListType{ElemType: types.StringType},
+// 										MaxItems: 1,
+// 										Optional: true,
+// 										Elem: &schema.Resource{
+// 											Schema: map[string]*schema.Schema{
+// 												"w": {
+// 													Type:        types.Int64Type,
+// 													Required:    true,
+// 													Description: "The width of the asset source",
+// 												},
+// 												"h": {
+// 													Type:        types.Int64Type,
+// 													Required:    true,
+// 													Description: "The height of the asset source",
+// 												},
+// 											},
+// 										},
+// 									},
+// 									"content_type": {
+// 										Type:     types.StringType,
+// 										Optional: true,
+// 									},
+// 								},
+// 							},
+// 						},
+// 						"tags": {
+// 							Type:     types.ListType{ElemType: types.StringType},
+// 							Optional: true,
+// 							Elem:     &schema.Schema{Type: types.StringType},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceCategoryCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var category *platform.Category
+// func resourceCategoryCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var category *platform.Category
 
-	name := platform.LocalizedString(expandStringMap(d.Get("name").(map[string]interface{})))
-	slug := platform.LocalizedString(expandStringMap(d.Get("slug").(map[string]interface{})))
+// 	name := platform.LocalizedString(expandStringMap(d.Get("name").(map[string]interface{})))
+// 	slug := platform.LocalizedString(expandStringMap(d.Get("slug").(map[string]interface{})))
 
-	draft := platform.CategoryDraft{
-		Key:       stringRef(d.Get("key")),
-		Name:      name,
-		Slug:      slug,
-		OrderHint: stringRef(d.Get("order_hint")),
-	}
+// 	draft := platform.CategoryDraft{
+// 		Key:       stringRef(d.Get("key")),
+// 		Name:      name,
+// 		Slug:      slug,
+// 		OrderHint: stringRef(d.Get("order_hint")),
+// 	}
 
-	if d.Get("description") != nil {
-		desc := platform.LocalizedString(expandStringMap(d.Get("description").(map[string]interface{})))
-		draft.Description = &desc
-	}
+// 	if d.Get("description") != nil {
+// 		desc := platform.LocalizedString(expandStringMap(d.Get("description").(map[string]interface{})))
+// 		draft.Description = &desc
+// 	}
 
-	if d.Get("meta_title") != nil {
-		metaTitle := platform.LocalizedString(expandStringMap(d.Get("meta_title").(map[string]interface{})))
-		draft.MetaTitle = &metaTitle
-	}
+// 	if d.Get("meta_title") != nil {
+// 		metaTitle := platform.LocalizedString(expandStringMap(d.Get("meta_title").(map[string]interface{})))
+// 		draft.MetaTitle = &metaTitle
+// 	}
 
-	if d.Get("meta_description") != nil {
-		metaDescription := platform.LocalizedString(expandStringMap(d.Get("meta_description").(map[string]interface{})))
-		draft.MetaDescription = &metaDescription
-	}
+// 	if d.Get("meta_description") != nil {
+// 		metaDescription := platform.LocalizedString(expandStringMap(d.Get("meta_description").(map[string]interface{})))
+// 		draft.MetaDescription = &metaDescription
+// 	}
 
-	if d.Get("meta_keywords") != nil {
-		metaKeywords := platform.LocalizedString(expandStringMap(d.Get("meta_keywords").(map[string]interface{})))
-		draft.MetaKeywords = &metaKeywords
-	}
+// 	if d.Get("meta_keywords") != nil {
+// 		metaKeywords := platform.LocalizedString(expandStringMap(d.Get("meta_keywords").(map[string]interface{})))
+// 		draft.MetaKeywords = &metaKeywords
+// 	}
 
-	if d.Get("parent").(string) != "" {
-		parent := platform.CategoryResourceIdentifier{}
-		parent.ID = stringRef(d.Get("parent"))
-		draft.Parent = &parent
-	}
+// 	if d.Get("parent").(string) != "" {
+// 		parent := platform.CategoryResourceIdentifier{}
+// 		parent.ID = stringRef(d.Get("parent"))
+// 		draft.Parent = &parent
+// 	}
 
-	if len(d.Get("assets").([]interface{})) != 0 {
-		assets := unmarshallCategoryAssets(d)
-		draft.Assets = assets
-	}
+// 	if len(d.Get("assets").([]interface{})) != 0 {
+// 		assets := unmarshallCategoryAssets(d)
+// 		draft.Assets = assets
+// 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
+// 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
 
-		category, err = client.Categories().Post(draft).Execute(context.Background())
+// 		category, err = client.Categories().Post(draft).Execute(context.Background())
 
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	if category == nil {
-		log.Fatal("No  category created?")
-	}
+// 	if category == nil {
+// 		log.Fatal("No  category created?")
+// 	}
 
-	d.SetId(category.ID)
-	_ = d.Set("version", category.Version)
+// 	d.SetId(category.ID)
+// 	_ = d.Set("version", category.Version)
 
-	return resourceCategoryRead(d, m)
-}
+// 	return resourceCategoryRead(d, m)
+// }
 
-func resourceCategoryRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Reading category from commercetools, with category id: %s", d.Id())
-	client := getClient(m)
+// func resourceCategoryRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Printf("[DEBUG] Reading category from commercetools, with category id: %s", d.Id())
+// 	client := getClient(m)
 
-	category, err := client.Categories().WithId(d.Id()).Get().Execute(context.Background())
+// 	category, err := client.Categories().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if category == nil {
-		log.Print("[DEBUG] No category found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following category:")
-		log.Print(stringFormatObject(category))
+// 	if category == nil {
+// 		log.Print("[DEBUG] No category found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following category:")
+// 		log.Print(stringFormatObject(category))
 
-		d.Set("version", category.Version)
-		d.Set("key", category.Key)
-		d.Set("name", category.Name)
-		if category.Parent != nil {
-			d.Set("parent", category.Parent.ID)
-		} else {
-			d.Set("parent", "")
-		}
-		d.Set("order_hint", category.OrderHint)
-		if category.Description != nil {
-			d.Set("description", *category.Description)
-		}
-		if category.MetaTitle != nil {
-			d.Set("meta_title", *category.MetaTitle)
-		}
-		if category.MetaDescription != nil {
-			d.Set("meta_description", *category.MetaDescription)
-		}
-		if category.MetaKeywords != nil {
-			d.Set("meta_keywords", *category.MetaKeywords)
-		}
-		if category.Assets != nil {
-			d.Set("assets", category.Assets)
-		}
-	}
-	return nil
-}
+// 		d.Set("version", category.Version)
+// 		d.Set("key", category.Key)
+// 		d.Set("name", category.Name)
+// 		if category.Parent != nil {
+// 			d.Set("parent", category.Parent.ID)
+// 		} else {
+// 			d.Set("parent", "")
+// 		}
+// 		d.Set("order_hint", category.OrderHint)
+// 		if category.Description != nil {
+// 			d.Set("description", *category.Description)
+// 		}
+// 		if category.MetaTitle != nil {
+// 			d.Set("meta_title", *category.MetaTitle)
+// 		}
+// 		if category.MetaDescription != nil {
+// 			d.Set("meta_description", *category.MetaDescription)
+// 		}
+// 		if category.MetaKeywords != nil {
+// 			d.Set("meta_keywords", *category.MetaKeywords)
+// 		}
+// 		if category.Assets != nil {
+// 			d.Set("assets", category.Assets)
+// 		}
+// 	}
+// 	return nil
+// }
 
-func resourceCategoryUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	category, err := client.Categories().WithId(d.Id()).Get().Execute(context.Background())
+// func resourceCategoryUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	category, err := client.Categories().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	input := platform.CategoryUpdate{
-		Version: category.Version,
-		Actions: []platform.CategoryUpdateAction{},
-	}
+// 	input := platform.CategoryUpdate{
+// 		Version: category.Version,
+// 		Actions: []platform.CategoryUpdateAction{},
+// 	}
 
-	if d.HasChange("name") {
-		newName := platform.LocalizedString(expandStringMap(d.Get("name").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.CategoryChangeNameAction{Name: newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := platform.LocalizedString(expandStringMap(d.Get("name").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategoryChangeNameAction{Name: newName})
+// 	}
 
-	if d.HasChange("slug") {
-		newSlug := platform.LocalizedString(expandStringMap(d.Get("slug").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.CategoryChangeSlugAction{Slug: newSlug})
-	}
+// 	if d.HasChange("slug") {
+// 		newSlug := platform.LocalizedString(expandStringMap(d.Get("slug").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategoryChangeSlugAction{Slug: newSlug})
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.CategorySetKeyAction{Key: &newKey})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategorySetKeyAction{Key: &newKey})
+// 	}
 
-	if d.HasChange("order_hint") {
-		newVal := d.Get("order_hint").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.CategoryChangeOrderHintAction{OrderHint: newVal})
-	}
+// 	if d.HasChange("order_hint") {
+// 		newVal := d.Get("order_hint").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategoryChangeOrderHintAction{OrderHint: newVal})
+// 	}
 
-	if d.HasChange("description") {
-		newDescription := platform.LocalizedString(expandStringMap(d.Get("description").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.CategorySetDescriptionAction{Description: &newDescription})
-	}
+// 	if d.HasChange("description") {
+// 		newDescription := platform.LocalizedString(expandStringMap(d.Get("description").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategorySetDescriptionAction{Description: &newDescription})
+// 	}
 
-	if d.HasChange("parent") {
-		newParentCategoryId := d.Get("parent").(string)
-		parentId := platform.CategoryResourceIdentifier{ID: &newParentCategoryId}
-		input.Actions = append(
-			input.Actions,
-			&platform.CategoryChangeParentAction{Parent: parentId})
-	}
+// 	if d.HasChange("parent") {
+// 		newParentCategoryId := d.Get("parent").(string)
+// 		parentId := platform.CategoryResourceIdentifier{ID: &newParentCategoryId}
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategoryChangeParentAction{Parent: parentId})
+// 	}
 
-	if d.HasChange("meta_title") {
-		newMetaTitle := platform.LocalizedString(expandStringMap(d.Get("meta_title").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.CategorySetMetaTitleAction{MetaTitle: &newMetaTitle})
-	}
+// 	if d.HasChange("meta_title") {
+// 		newMetaTitle := platform.LocalizedString(expandStringMap(d.Get("meta_title").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategorySetMetaTitleAction{MetaTitle: &newMetaTitle})
+// 	}
 
-	if d.HasChange("meta_description") {
-		newMetaDescription := platform.LocalizedString(expandStringMap(d.Get("meta_description").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.CategorySetMetaDescriptionAction{MetaDescription: &newMetaDescription})
-	}
+// 	if d.HasChange("meta_description") {
+// 		newMetaDescription := platform.LocalizedString(expandStringMap(d.Get("meta_description").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategorySetMetaDescriptionAction{MetaDescription: &newMetaDescription})
+// 	}
 
-	if d.HasChange("meta_keywords") {
-		newMetaKeywords := platform.LocalizedString(expandStringMap(d.Get("meta_keywords").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.CategorySetMetaKeywordsAction{MetaKeywords: &newMetaKeywords})
-	}
+// 	if d.HasChange("meta_keywords") {
+// 		newMetaKeywords := platform.LocalizedString(expandStringMap(d.Get("meta_keywords").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CategorySetMetaKeywordsAction{MetaKeywords: &newMetaKeywords})
+// 	}
 
-	if d.HasChange("assets") {
-		assets := unmarshallCategoryAssets(d)
-		for _, asset := range assets {
-			input.Actions = append(
-				input.Actions,
-				&platform.CategoryChangeAssetNameAction{Name: asset.Name, AssetKey: asset.Key},
-				&platform.CategorySetAssetDescriptionAction{Description: asset.Description, AssetKey: asset.Key},
-				&platform.CategorySetAssetSourcesAction{Sources: asset.Sources, AssetKey: asset.Key},
-			)
-			if len(asset.Tags) > 0 {
-				input.Actions = append(
-					input.Actions,
-					&platform.CategorySetAssetTagsAction{Tags: asset.Tags, AssetKey: asset.Key},
-				)
-			}
-		}
-	}
+// 	if d.HasChange("assets") {
+// 		assets := unmarshallCategoryAssets(d)
+// 		for _, asset := range assets {
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.CategoryChangeAssetNameAction{Name: asset.Name, AssetKey: asset.Key},
+// 				&platform.CategorySetAssetDescriptionAction{Description: asset.Description, AssetKey: asset.Key},
+// 				&platform.CategorySetAssetSourcesAction{Sources: asset.Sources, AssetKey: asset.Key},
+// 			)
+// 			if len(asset.Tags) > 0 {
+// 				input.Actions = append(
+// 					input.Actions,
+// 					&platform.CategorySetAssetTagsAction{Tags: asset.Tags, AssetKey: asset.Key},
+// 				)
+// 			}
+// 		}
+// 	}
 
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
 
-	_, err = client.Categories().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
+// 	_, err = client.Categories().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
 
-	return resourceCategoryRead(d, m)
-}
+// 	return resourceCategoryRead(d, m)
+// }
 
-func resourceCategoryDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceCategoryDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	version := d.Get("version").(int)
-	_, err := client.Categories().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyCategoriesByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	version := d.Get("version").(int)
+// 	_, err := client.Categories().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyCategoriesByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func unmarshallCategoryAssets(d *schema.ResourceData) []platform.AssetDraft {
-	input := d.Get("assets").([]interface{})
-	var result []platform.AssetDraft
+// func unmarshallCategoryAssets(d *schema.ResourceData) []platform.AssetDraft {
+// 	input := d.Get("assets").([]interface{})
+// 	var result []platform.AssetDraft
 
-	for _, raw := range input {
-		i := raw.(map[string]interface{})
+// 	for _, raw := range input {
+// 		i := raw.(map[string]interface{})
 
-		name := platform.LocalizedString(expandStringMap(i["name"].(map[string]interface{})))
-		description := platform.LocalizedString(expandStringMap(i["description"].(map[string]interface{})))
-		sources := unmarshallCategoryAssetSources(i)
+// 		name := platform.LocalizedString(expandStringMap(i["name"].(map[string]interface{})))
+// 		description := platform.LocalizedString(expandStringMap(i["description"].(map[string]interface{})))
+// 		sources := unmarshallCategoryAssetSources(i)
 
-		key := i["key"].(string)
-		result = append(result, platform.AssetDraft{
-			Key:         &key,
-			Name:        name,
-			Description: &description,
-			Sources:     sources,
-		})
-	}
+// 		key := i["key"].(string)
+// 		result = append(result, platform.AssetDraft{
+// 			Key:         &key,
+// 			Name:        name,
+// 			Description: &description,
+// 			Sources:     sources,
+// 		})
+// 	}
 
-	return result
-}
+// 	return result
+// }
 
-func unmarshallCategoryAssetSources(i map[string]interface{}) []platform.AssetSource {
-	var sources []platform.AssetSource
-	for _, item := range i["sources"].([]interface{}) {
-		s := item.(map[string]interface{})
-		key := s["key"].(string)
-		contentType := s["content_type"].(string)
+// func unmarshallCategoryAssetSources(i map[string]interface{}) []platform.AssetSource {
+// 	var sources []platform.AssetSource
+// 	for _, item := range i["sources"].([]interface{}) {
+// 		s := item.(map[string]interface{})
+// 		key := s["key"].(string)
+// 		contentType := s["content_type"].(string)
 
-		source := platform.AssetSource{
-			Uri:         s["uri"].(string),
-			Key:         &key,
-			ContentType: &contentType,
-		}
+// 		source := platform.AssetSource{
+// 			Uri:         s["uri"].(string),
+// 			Key:         &key,
+// 			ContentType: &contentType,
+// 		}
 
-		if _, ok := s["dimensions"]; ok {
-			assetDimensions := unmarshallCategoryAssetSourceDimensions(s)
-			source.Dimensions = &assetDimensions
-		}
+// 		if _, ok := s["dimensions"]; ok {
+// 			assetDimensions := unmarshallCategoryAssetSourceDimensions(s)
+// 			source.Dimensions = &assetDimensions
+// 		}
 
-		sources = append(sources, source)
-	}
-	return sources
-}
+// 		sources = append(sources, source)
+// 	}
+// 	return sources
+// }
 
-func unmarshallCategoryAssetSourceDimensions(s map[string]interface{}) platform.AssetDimensions {
-	var dimensions platform.AssetDimensions
-	data, err := elementFromSlice(s, "dimensions")
-	if err != nil {
-		return dimensions
-	}
+// func unmarshallCategoryAssetSourceDimensions(s map[string]interface{}) platform.AssetDimensions {
+// 	var dimensions platform.AssetDimensions
+// 	data, err := elementFromSlice(s, "dimensions")
+// 	if err != nil {
+// 		return dimensions
+// 	}
 
-	for _, item := range data {
-		d := item.(map[string]interface{})
+// 	for _, item := range data {
+// 		d := item.(map[string]interface{})
 
-		dimensions = platform.AssetDimensions{
-			W: d["w"].(int),
-			H: d["h"].(int),
-		}
-	}
-	return dimensions
-}
+// 		dimensions = platform.AssetDimensions{
+// 			W: d["w"].(int),
+// 			H: d["h"].(int),
+// 		}
+// 	}
+// 	return dimensions
+// }
 
-func resourceCategoryResourceV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Category-specific unique identifier. Must be unique across a project",
-			},
-			"name": {
-				Type:     TypeLocalizedString,
-				Required: true,
-				ForceNew: true,
-			},
-			"description": {
-				Type:     TypeLocalizedString,
-				Optional: true,
-			},
-			"slug": {
-				Type:        TypeLocalizedString,
-				Required:    true,
-				Description: "Human readable identifiers, needs to be unique",
-			},
-			"parent": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "A category that is the parent of this category in the category tree",
-			},
-			"order_hint": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "An attribute as base for a custom category order in one level, filled with random value when left empty",
-			},
-			"meta_title": {
-				Type:     TypeLocalizedString,
-				Optional: true,
-			},
-			"meta_description": {
-				Type:     TypeLocalizedString,
-				Optional: true,
-			},
-			"meta_keywords": {
-				Type:     TypeLocalizedString,
-				Optional: true,
-			},
-			"assets": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Can be used to store images, icons or movies related to this category",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: "Optional User-defined identifier for the asset. Asset keys are unique inside their container (in this case the category)",
-						},
-						"name": {
-							Type:     TypeLocalizedString,
-							Required: true,
-						},
-						"description": {
-							Type:     TypeLocalizedString,
-							Optional: true,
-						},
-						"sources": {
-							Type:        schema.TypeList,
-							Optional:    true,
-							MinItems:    1,
-							Description: "Array of AssetSource, Has at least one entry",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"uri": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"key": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: "Unique identifier, must be unique within the Asset",
-									},
-									"dimensions": {
-										Type:     schema.TypeMap,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeInt,
-										},
-									},
-									"content_type": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-								},
-							},
-						},
-						"tags": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceCategoryResourceV0() *schema.Resource {
+// 	return &schema.Resource{
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 				ForceNew:    true,
+// 				Description: "Category-specific unique identifier. Must be unique across a project",
+// 			},
+// 			"name": {
+// 				Type:     TypeLocalizedString,
+// 				Required: true,
+// 				ForceNew: true,
+// 			},
+// 			"description": {
+// 				Type:     TypeLocalizedString,
+// 				Optional: true,
+// 			},
+// 			"slug": {
+// 				Type:        TypeLocalizedString,
+// 				Required:    true,
+// 				Description: "Human readable identifiers, needs to be unique",
+// 			},
+// 			"parent": {
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 				Description: "A category that is the parent of this category in the category tree",
+// 			},
+// 			"order_hint": {
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 				Description: "An attribute as base for a custom category order in one level, filled with random value when left empty",
+// 			},
+// 			"meta_title": {
+// 				Type:     TypeLocalizedString,
+// 				Optional: true,
+// 			},
+// 			"meta_description": {
+// 				Type:     TypeLocalizedString,
+// 				Optional: true,
+// 			},
+// 			"meta_keywords": {
+// 				Type:     TypeLocalizedString,
+// 				Optional: true,
+// 			},
+// 			"assets": {
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Description: "Can be used to store images, icons or movies related to this category",
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"key": {
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 							Description: "Optional User-defined identifier for the asset. Asset keys are unique inside their container (in this case the category)",
+// 						},
+// 						"name": {
+// 							Type:     TypeLocalizedString,
+// 							Required: true,
+// 						},
+// 						"description": {
+// 							Type:     TypeLocalizedString,
+// 							Optional: true,
+// 						},
+// 						"sources": {
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Optional:    true,
+// 							MinItems:    1,
+// 							Description: "Array of AssetSource, Has at least one entry",
+// 							Elem: &schema.Resource{
+// 								Schema: map[string]*schema.Schema{
+// 									"uri": {
+// 										Type:     types.StringType,
+// 										Required: true,
+// 									},
+// 									"key": {
+// 										Type:        types.StringType,
+// 										Optional:    true,
+// 										Description: "Unique identifier, must be unique within the Asset",
+// 									},
+// 									"dimensions": {
+// 										Type:     schema.TypeMap,
+// 										Optional: true,
+// 										Elem: &schema.Schema{
+// 											Type: types.Int64Type,
+// 										},
+// 									},
+// 									"content_type": {
+// 										Type:     types.StringType,
+// 										Optional: true,
+// 									},
+// 								},
+// 							},
+// 						},
+// 						"tags": {
+// 							Type:     types.ListType{ElemType: types.StringType},
+// 							Optional: true,
+// 							Elem:     &schema.Schema{Type: types.StringType},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func migrateCategoryStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	for _, asset := range rawState["assets"].([]interface{}) {
-		sources := asset.(map[string]interface{})["sources"]
-		for _, source := range sources.([]interface{}) {
-			transformToList(source.(map[string]interface{}), "dimensions")
-		}
-	}
-	return rawState, nil
-}
+// func migrateCategoryStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+// 	for _, asset := range rawState["assets"].([]interface{}) {
+// 		sources := asset.(map[string]interface{})["sources"]
+// 		for _, source := range sources.([]interface{}) {
+// 			transformToList(source.(map[string]interface{}), "dimensions")
+// 		}
+// 	}
+// 	return rawState, nil
+// }

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -1,322 +1,322 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
 
-func TestAccCategoryCreate_basic(t *testing.T) {
+// func TestAccCategoryCreate_basic(t *testing.T) {
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCategoryDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCategoryConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories_minimal", "name.en", "accessories_m",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "name.en", "accessories",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "key", "accessories",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "description.en", "Standard description",
-					),
-					resource.TestCheckResourceAttrPair(
-						"commercetools_category.accessories", "parent", "commercetools_category.accessories_base", "id",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "slug.en", "accessories",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "meta_title.en", "meta text",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "meta_description.en", "meta description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "meta_keywords.en", "keywords",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "assets.0.name.en", "My Product Video",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "assets.0.description.en", "Description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "assets.0.sources.0.key", "image",
-					),
-				),
-			},
-			{
-				Config: testAccCategoryUpdate(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "name.en", "accessories",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "key", "accessories",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "description.en", "Updated description",
-					),
-					resource.TestCheckResourceAttrPair(
-						"commercetools_category.accessories", "parent", "commercetools_category.accessories_base", "id",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "slug.en", "accessories_updated",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "meta_title.en", "updated meta text",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "meta_description.en", "updated meta description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "meta_keywords.en", "keywords, updated",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "assets.0.name.en", "Updated name",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "assets.0.description.en", "Updated description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "assets.0.sources.0.key", "image",
-					),
-				),
-			},
-			{
-				Config: testAccCategoryRemoveProperties(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "name.en", "accessories",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "key", "accessories_2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "description.en", "Updated description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "slug.en", "accessories_updated",
-					),
-					resource.TestCheckResourceAttrPair(
-						"commercetools_category.accessories", "parent", "commercetools_category.accessories_base", "id",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_category.accessories", "meta_title",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_category.accessories", "meta_description",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_category.accessories", "meta_keywords",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_category.accessories", "assets",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCategoryDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCategoryConfig(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories_minimal", "name.en", "accessories_m",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "name.en", "accessories",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "key", "accessories",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "description.en", "Standard description",
+// 					),
+// 					resource.TestCheckResourceAttrPair(
+// 						"commercetools_category.accessories", "parent", "commercetools_category.accessories_base", "id",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "slug.en", "accessories",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "meta_title.en", "meta text",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "meta_description.en", "meta description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "meta_keywords.en", "keywords",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "assets.0.name.en", "My Product Video",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "assets.0.description.en", "Description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "assets.0.sources.0.key", "image",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCategoryUpdate(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "name.en", "accessories",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "key", "accessories",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "description.en", "Updated description",
+// 					),
+// 					resource.TestCheckResourceAttrPair(
+// 						"commercetools_category.accessories", "parent", "commercetools_category.accessories_base", "id",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "slug.en", "accessories_updated",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "meta_title.en", "updated meta text",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "meta_description.en", "updated meta description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "meta_keywords.en", "keywords, updated",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "assets.0.name.en", "Updated name",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "assets.0.description.en", "Updated description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "assets.0.sources.0.key", "image",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCategoryRemoveProperties(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "name.en", "accessories",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "key", "accessories_2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "description.en", "Updated description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "slug.en", "accessories_updated",
+// 					),
+// 					resource.TestCheckResourceAttrPair(
+// 						"commercetools_category.accessories", "parent", "commercetools_category.accessories_base", "id",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_category.accessories", "meta_title",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_category.accessories", "meta_description",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_category.accessories", "meta_keywords",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_category.accessories", "assets",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccCategoryConfig() string {
-	return `
-	resource "commercetools_category" "accessories_base" {
-		name = {
-			en = "accessories_b"
-		}
-		key = "accessories_b"
-		description = {
-			en = "Standard description"
-		}
-		slug = {
-			en = "accessories_b"
-		}
-		order_hint = "0.00001614336548703960465522"
-	}
+// func testAccCategoryConfig() string {
+// 	return `
+// 	resource "commercetools_category" "accessories_base" {
+// 		name = {
+// 			en = "accessories_b"
+// 		}
+// 		key = "accessories_b"
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		slug = {
+// 			en = "accessories_b"
+// 		}
+// 		order_hint = "0.00001614336548703960465522"
+// 	}
 
-	resource "commercetools_category" "accessories_minimal" {
-		name = {
-			en = "accessories_m"
-		}
-		slug = {
-			en = "accessories_m"
-		}
-	}
+// 	resource "commercetools_category" "accessories_minimal" {
+// 		name = {
+// 			en = "accessories_m"
+// 		}
+// 		slug = {
+// 			en = "accessories_m"
+// 		}
+// 	}
 
-	resource "commercetools_category" "accessories" {
-		name = {
-			en = "accessories"
-		}
-		key = "accessories"
-		description = {
-			en = "Standard description"
-		}
-		parent = "${commercetools_category.accessories_base.id}"
-		slug = {
-			en = "accessories"
-		}
-		order_hint = "0.000016143365484621617765232"
-		meta_title = {
-			en = "meta text"
-		}
-		meta_description = {
-			en = "meta description"
-		}
-		meta_keywords = {
-			en = "keywords"
-		}
-		assets {
-			key = "some_key"
-			name = {
-				en = "My Product Video"
-			}
-			description = {
-				en = "Description"
-			}
-			sources {
-				uri = "https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.jpg"
-				key = "image"
-			}
-		}
-		depends_on = [commercetools_category.accessories_base]
-	}  `
-}
+// 	resource "commercetools_category" "accessories" {
+// 		name = {
+// 			en = "accessories"
+// 		}
+// 		key = "accessories"
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		parent = "${commercetools_category.accessories_base.id}"
+// 		slug = {
+// 			en = "accessories"
+// 		}
+// 		order_hint = "0.000016143365484621617765232"
+// 		meta_title = {
+// 			en = "meta text"
+// 		}
+// 		meta_description = {
+// 			en = "meta description"
+// 		}
+// 		meta_keywords = {
+// 			en = "keywords"
+// 		}
+// 		assets {
+// 			key = "some_key"
+// 			name = {
+// 				en = "My Product Video"
+// 			}
+// 			description = {
+// 				en = "Description"
+// 			}
+// 			sources {
+// 				uri = "https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.jpg"
+// 				key = "image"
+// 			}
+// 		}
+// 		depends_on = [commercetools_category.accessories_base]
+// 	}  `
+// }
 
-func testAccCategoryUpdate() string {
-	return `
-	resource "commercetools_category" "accessories_base" {
-		name = {
-			en = "accessories_b"
-		}
-		key = "accessories_b"
-		description = {
-			en = "Standard description"
-		}
-		slug = {
-			en = "accessories_b"
-		}
-		order_hint = "0.00001614336548703960465522"
-	}
+// func testAccCategoryUpdate() string {
+// 	return `
+// 	resource "commercetools_category" "accessories_base" {
+// 		name = {
+// 			en = "accessories_b"
+// 		}
+// 		key = "accessories_b"
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		slug = {
+// 			en = "accessories_b"
+// 		}
+// 		order_hint = "0.00001614336548703960465522"
+// 	}
 
-	resource "commercetools_category" "accessories_minimal" {
-		name = {
-			en = "accessories_m"
-		}
-		slug = {
-			en = "accessories_m"
-		}
-	}
+// 	resource "commercetools_category" "accessories_minimal" {
+// 		name = {
+// 			en = "accessories_m"
+// 		}
+// 		slug = {
+// 			en = "accessories_m"
+// 		}
+// 	}
 
-	resource "commercetools_category" "accessories" {
-		name = {
-			en = "accessories"
-		}
-		key = "accessories"
-		description = {
-			en = "Updated description"
-		}
-		parent = "${commercetools_category.accessories_base.id}"
-		slug = {
-			en = "accessories_updated"
-		}
-		order_hint = "0.000016143365484621617765232"
-		meta_title = {
-			en = "updated meta text"
-		}
-		meta_description = {
-			en = "updated meta description"
-		}
-		meta_keywords = {
-			en = "keywords, updated"
-		}
-		assets {
-			key = "some_key"
-			name = {
-				en = "Updated name"
-			}
-			description = {
-				en = "Updated description"
-			}
-			sources {
-				uri = "https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.jpg"
-				key = "image"
-			}
-		}
-	}  `
-}
+// 	resource "commercetools_category" "accessories" {
+// 		name = {
+// 			en = "accessories"
+// 		}
+// 		key = "accessories"
+// 		description = {
+// 			en = "Updated description"
+// 		}
+// 		parent = "${commercetools_category.accessories_base.id}"
+// 		slug = {
+// 			en = "accessories_updated"
+// 		}
+// 		order_hint = "0.000016143365484621617765232"
+// 		meta_title = {
+// 			en = "updated meta text"
+// 		}
+// 		meta_description = {
+// 			en = "updated meta description"
+// 		}
+// 		meta_keywords = {
+// 			en = "keywords, updated"
+// 		}
+// 		assets {
+// 			key = "some_key"
+// 			name = {
+// 				en = "Updated name"
+// 			}
+// 			description = {
+// 				en = "Updated description"
+// 			}
+// 			sources {
+// 				uri = "https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.jpg"
+// 				key = "image"
+// 			}
+// 		}
+// 	}  `
+// }
 
-func testAccCategoryRemoveProperties() string {
-	return `
-	resource "commercetools_category" "accessories_base" {
-		name = {
-			en = "accessories_b"
-		}
-		key = "accessories_b"
-		description = {
-			en = "Standard description"
-		}
-		slug = {
-			en = "accessories_b"
-		}
-		order_hint = "0.00001614336548703960465522"
-	}
+// func testAccCategoryRemoveProperties() string {
+// 	return `
+// 	resource "commercetools_category" "accessories_base" {
+// 		name = {
+// 			en = "accessories_b"
+// 		}
+// 		key = "accessories_b"
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		slug = {
+// 			en = "accessories_b"
+// 		}
+// 		order_hint = "0.00001614336548703960465522"
+// 	}
 
-	resource "commercetools_category" "accessories" {
-		name = {
-			en = "accessories"
-		}
-		key = "accessories_2"
-		description = {
-			en = "Updated description"
-		}
-		parent = "${commercetools_category.accessories_base.id}"
-		slug = {
-			en = "accessories_updated"
-		}
-		order_hint = "0.000016143365484621617765232"
-	}  `
-}
+// 	resource "commercetools_category" "accessories" {
+// 		name = {
+// 			en = "accessories"
+// 		}
+// 		key = "accessories_2"
+// 		description = {
+// 			en = "Updated description"
+// 		}
+// 		parent = "${commercetools_category.accessories_base.id}"
+// 		slug = {
+// 			en = "accessories_updated"
+// 		}
+// 		order_hint = "0.000016143365484621617765232"
+// 	}  `
+// }
 
-func testAccCategoryDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCategoryDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_category" {
-			continue
-		}
-		response, err := client.Categories().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("category (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_category" {
+// 			continue
+// 		}
+// 		response, err := client.Categories().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("category (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_channel.go
+++ b/commercetools/resource_channel.go
@@ -1,182 +1,182 @@
 package commercetools
 
-import (
-	"context"
-	"time"
+// import (
+// 	"context"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceChannel() *schema.Resource {
-	return &schema.Resource{
-		Description: "Channels represent a source or destination of different entities. They can be used to model " +
-			"warehouses or stores.\n\n" +
-			"See also the [Channels API Documentation](https://docs.commercetools.com/api/projects/channels)",
-		Create: resourceChannelCreate,
-		Read:   resourceChannelRead,
-		Update: resourceChannelUpdate,
-		Delete: resourceChannelDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "Any arbitrary string key that uniquely identifies this channel within the project",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"roles": {
-				Description: "The [roles](https://docs.commercetools.com/api/projects/channels#channelroleenum) " +
-					"of this channel. Each channel must have at least one role",
-				Type:     schema.TypeList,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"name": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"description": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceChannel() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Channels represent a source or destination of different entities. They can be used to model " +
+// 			"warehouses or stores.\n\n" +
+// 			"See also the [Channels API Documentation](https://docs.commercetools.com/api/projects/channels)",
+// 		Create: resourceChannelCreate,
+// 		Read:   resourceChannelRead,
+// 		Update: resourceChannelUpdate,
+// 		Delete: resourceChannelDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "Any arbitrary string key that uniquely identifies this channel within the project",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"roles": {
+// 				Description: "The [roles](https://docs.commercetools.com/api/projects/channels#channelroleenum) " +
+// 					"of this channel. Each channel must have at least one role",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				Required: true,
+// 				Elem:     &schema.Schema{Type: types.StringType},
+// 			},
+// 			"name": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"description": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceChannelCreate(d *schema.ResourceData, m interface{}) error {
-	name := platform.LocalizedString(
-		expandStringMap(d.Get("name").(map[string]interface{})))
-	description := platform.LocalizedString(
-		expandStringMap(d.Get("description").(map[string]interface{})))
+// func resourceChannelCreate(d *schema.ResourceData, m interface{}) error {
+// 	name := platform.LocalizedString(
+// 		expandStringMap(d.Get("name").(map[string]interface{})))
+// 	description := platform.LocalizedString(
+// 		expandStringMap(d.Get("description").(map[string]interface{})))
 
-	roles := []platform.ChannelRoleEnum{}
-	for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
-		roles = append(roles, platform.ChannelRoleEnum(value))
-	}
+// 	roles := []platform.ChannelRoleEnum{}
+// 	for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
+// 		roles = append(roles, platform.ChannelRoleEnum(value))
+// 	}
 
-	draft := platform.ChannelDraft{
-		Key:         d.Get("key").(string),
-		Roles:       roles,
-		Name:        &name,
-		Description: &description,
-	}
+// 	draft := platform.ChannelDraft{
+// 		Key:         d.Get("key").(string),
+// 		Roles:       roles,
+// 		Name:        &name,
+// 		Description: &description,
+// 	}
 
-	client := getClient(m)
-	var channel *platform.Channel
+// 	client := getClient(m)
+// 	var channel *platform.Channel
 
-	err := resource.Retry(20*time.Second, func() *resource.RetryError {
-		var err error
+// 	err := resource.Retry(20*time.Second, func() *resource.RetryError {
+// 		var err error
 
-		channel, err = client.Channels().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		channel, err = client.Channels().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	d.SetId(channel.ID)
-	d.Set("version", channel.Version)
-	return resourceChannelRead(d, m)
-}
+// 	d.SetId(channel.ID)
+// 	d.Set("version", channel.Version)
+// 	return resourceChannelRead(d, m)
+// }
 
-func resourceChannelRead(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	channel, err := client.Channels().WithId(d.Id()).Get().Execute(context.Background())
+// func resourceChannelRead(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	channel, err := client.Channels().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	d.SetId(channel.ID)
-	d.Set("version", channel.Version)
+// 	d.SetId(channel.ID)
+// 	d.Set("version", channel.Version)
 
-	if channel.Name != nil {
-		d.Set("name", *channel.Name)
-	}
-	if channel.Description != nil {
-		d.Set("description", *channel.Description)
-	}
-	d.Set("roles", channel.Roles)
-	return nil
-}
+// 	if channel.Name != nil {
+// 		d.Set("name", *channel.Name)
+// 	}
+// 	if channel.Description != nil {
+// 		d.Set("description", *channel.Description)
+// 	}
+// 	d.Set("roles", channel.Roles)
+// 	return nil
+// }
 
-func resourceChannelUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceChannelUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	input := platform.ChannelUpdate{
-		Version: d.Get("version").(int),
-		Actions: []platform.ChannelUpdateAction{},
-	}
+// 	input := platform.ChannelUpdate{
+// 		Version: d.Get("version").(int),
+// 		Actions: []platform.ChannelUpdateAction{},
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ChannelChangeKeyAction{Key: newKey})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ChannelChangeKeyAction{Key: newKey})
+// 	}
 
-	if d.HasChange("name") {
-		newName := platform.LocalizedString(
-			expandStringMap(d.Get("name").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.ChannelChangeNameAction{Name: newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := platform.LocalizedString(
+// 			expandStringMap(d.Get("name").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ChannelChangeNameAction{Name: newName})
+// 	}
 
-	if d.HasChange("description") {
-		newDescription := platform.LocalizedString(
-			expandStringMap(d.Get("description").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.ChannelChangeDescriptionAction{Description: newDescription})
-	}
+// 	if d.HasChange("description") {
+// 		newDescription := platform.LocalizedString(
+// 			expandStringMap(d.Get("description").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ChannelChangeDescriptionAction{Description: newDescription})
+// 	}
 
-	if d.HasChange("roles") {
-		roles := []platform.ChannelRoleEnum{}
-		for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
-			roles = append(roles, platform.ChannelRoleEnum(value))
-		}
-		input.Actions = append(
-			input.Actions,
-			&platform.ChannelSetRolesAction{Roles: roles})
-	}
+// 	if d.HasChange("roles") {
+// 		roles := []platform.ChannelRoleEnum{}
+// 		for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
+// 			roles = append(roles, platform.ChannelRoleEnum(value))
+// 		}
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ChannelSetRolesAction{Roles: roles})
+// 	}
 
-	_, err := client.Channels().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	_, err := client.Channels().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return resourceChannelRead(d, m)
-}
+// 	return resourceChannelRead(d, m)
+// }
 
-func resourceChannelDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.Channels().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyChannelsByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// func resourceChannelDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.Channels().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyChannelsByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }

--- a/commercetools/resource_custom_object.go
+++ b/commercetools/resource_custom_object.go
@@ -1,203 +1,203 @@
 package commercetools
 
-import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"log"
+// import (
+// 	"context"
+// 	"encoding/json"
+// 	"fmt"
+// 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceCustomObject() *schema.Resource {
-	return &schema.Resource{
-		Description: "Custom objects are a way to store arbitrary JSON-formatted data on the commercetools platform. " +
-			"It allows you to persist data that does not fit the standard data model. This frees your application " +
-			"completely from any third-party persistence solution and means that all your data stays on the " +
-			"commercetools platform.\n\n" +
-			"See also the [Custom Object API Documentation](https://docs.commercetools.com/api/projects/custom-objects)",
-		Create: resourceCustomObjectCreate,
-		Read:   resourceCustomObjectRead,
-		Update: resourceCustomObjectUpdate,
-		Delete: resourceCustomObjectDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"container": {
-				Description: "A namespace to group custom objects matching the pattern '[-_~.a-zA-Z0-9]+'",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"key": {
-				Description: "String matching the pattern '[-_~.a-zA-Z0-9]+'",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"value": {
-				Description: "JSON types Number, String, Boolean, Array, Object",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceCustomObject() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Custom objects are a way to store arbitrary JSON-formatted data on the commercetools platform. " +
+// 			"It allows you to persist data that does not fit the standard data model. This frees your application " +
+// 			"completely from any third-party persistence solution and means that all your data stays on the " +
+// 			"commercetools platform.\n\n" +
+// 			"See also the [Custom Object API Documentation](https://docs.commercetools.com/api/projects/custom-objects)",
+// 		Create: resourceCustomObjectCreate,
+// 		Read:   resourceCustomObjectRead,
+// 		Update: resourceCustomObjectUpdate,
+// 		Delete: resourceCustomObjectDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"container": {
+// 				Description: "A namespace to group custom objects matching the pattern '[-_~.a-zA-Z0-9]+'",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"key": {
+// 				Description: "String matching the pattern '[-_~.a-zA-Z0-9]+'",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"value": {
+// 				Description: "JSON types Number, String, Boolean, Array, Object",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceCustomObjectCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	value := _decodeCustomObjectValue(d.Get("value").(string))
+// func resourceCustomObjectCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	value := _decodeCustomObjectValue(d.Get("value").(string))
 
-	draft := platform.CustomObjectDraft{
-		Container: d.Get("container").(string),
-		Key:       d.Get("key").(string),
-		Value:     value,
-	}
-	customObject, err := client.CustomObjects().Post(draft).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	draft := platform.CustomObjectDraft{
+// 		Container: d.Get("container").(string),
+// 		Key:       d.Get("key").(string),
+// 		Value:     value,
+// 	}
+// 	customObject, err := client.CustomObjects().Post(draft).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	d.SetId(customObject.ID)
-	d.Set("version", customObject.Version)
+// 	d.SetId(customObject.ID)
+// 	d.Set("version", customObject.Version)
 
-	return nil
-}
+// 	return nil
+// }
 
-func resourceCustomObjectRead(d *schema.ResourceData, m interface{}) error {
-	container := d.Get("container").(string)
-	key := d.Get("key").(string)
-	log.Printf("[DEBUG] Reading custom object from commercetools with following values\n Container: %s \n Key: %s", container, key)
-	client := getClient(m)
+// func resourceCustomObjectRead(d *schema.ResourceData, m interface{}) error {
+// 	container := d.Get("container").(string)
+// 	key := d.Get("key").(string)
+// 	log.Printf("[DEBUG] Reading custom object from commercetools with following values\n Container: %s \n Key: %s", container, key)
+// 	client := getClient(m)
 
-	customObject, err := client.CustomObjects().WithContainerAndKey(container, key).Get().Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	customObject, err := client.CustomObjects().WithContainerAndKey(container, key).Get().Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if customObject == nil {
-		log.Print("[DEBUG] No custom object found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following custom object:")
-		log.Print(stringFormatObject(customObject))
-		d.Set("container", customObject.Container)
-		d.Set("key", customObject.Key)
-		d.Set("value", marshallCustomObjectValue(customObject))
-		d.Set("version", customObject.Version)
-	}
-	return nil
-}
+// 	if customObject == nil {
+// 		log.Print("[DEBUG] No custom object found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following custom object:")
+// 		log.Print(stringFormatObject(customObject))
+// 		d.Set("container", customObject.Container)
+// 		d.Set("key", customObject.Key)
+// 		d.Set("value", marshallCustomObjectValue(customObject))
+// 		d.Set("version", customObject.Version)
+// 	}
+// 	return nil
+// }
 
-func resourceCustomObjectUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	value := _decodeCustomObjectValue(d.Get("value").(string))
-	ctx := context.Background()
-	originalKey, newKey := d.GetChange("key")
-	originalContainer, newContainer := d.GetChange("container")
-	originalVersion, _ := d.GetChange("version")
+// func resourceCustomObjectUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	value := _decodeCustomObjectValue(d.Get("value").(string))
+// 	ctx := context.Background()
+// 	originalKey, newKey := d.GetChange("key")
+// 	originalContainer, newContainer := d.GetChange("container")
+// 	originalVersion, _ := d.GetChange("version")
 
-	if d.HasChange("container") || d.HasChange("key") {
-		// If the container or key has changed we need to delete the old object
-		// and create the new object. We first want to create the new vlaue and
-		// then the old one
-		draft := platform.CustomObjectDraft{
-			Container: newContainer.(string),
-			Key:       newKey.(string),
-			Value:     value,
-		}
-		customObject, err := client.CustomObjects().Post(draft).Execute(ctx)
-		if err != nil {
-			return err
-		}
-		d.SetId(customObject.ID)
-		d.Set("version", customObject.Version)
+// 	if d.HasChange("container") || d.HasChange("key") {
+// 		// If the container or key has changed we need to delete the old object
+// 		// and create the new object. We first want to create the new vlaue and
+// 		// then the old one
+// 		draft := platform.CustomObjectDraft{
+// 			Container: newContainer.(string),
+// 			Key:       newKey.(string),
+// 			Value:     value,
+// 		}
+// 		customObject, err := client.CustomObjects().Post(draft).Execute(ctx)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		d.SetId(customObject.ID)
+// 		d.Set("version", customObject.Version)
 
-		_, err = client.
-			CustomObjects().
-			WithContainerAndKey(originalContainer.(string), originalKey.(string)).
-			Delete().
-			Version(originalVersion.(int)).
-			DataErasure(true).
-			Execute(ctx)
+// 		_, err = client.
+// 			CustomObjects().
+// 			WithContainerAndKey(originalContainer.(string), originalKey.(string)).
+// 			Delete().
+// 			Version(originalVersion.(int)).
+// 			DataErasure(true).
+// 			Execute(ctx)
 
-		if err != nil {
-			return err
-		}
-	} else {
-		// Update the value by creating an object with the same key/value.
-		// Commercetools will then update the value of the object if it already
-		// exists
-		draft := platform.CustomObjectDraft{
-			Container: d.Get("container").(string),
-			Key:       d.Get("key").(string),
-			Value:     value,
-			Version:   intRef(d.Get("version")),
-		}
-		customObject, err := client.CustomObjects().Post(draft).Execute(ctx)
-		if err != nil {
-			return err
-		}
+// 		if err != nil {
+// 			return err
+// 		}
+// 	} else {
+// 		// Update the value by creating an object with the same key/value.
+// 		// Commercetools will then update the value of the object if it already
+// 		// exists
+// 		draft := platform.CustomObjectDraft{
+// 			Container: d.Get("container").(string),
+// 			Key:       d.Get("key").(string),
+// 			Value:     value,
+// 			Version:   intRef(d.Get("version")),
+// 		}
+// 		customObject, err := client.CustomObjects().Post(draft).Execute(ctx)
+// 		if err != nil {
+// 			return err
+// 		}
 
-		d.SetId(customObject.ID)
-		d.Set("version", customObject.Version)
+// 		d.SetId(customObject.ID)
+// 		d.Set("version", customObject.Version)
 
-	}
-	return nil
-}
+// 	}
+// 	return nil
+// }
 
-func resourceCustomObjectDelete(d *schema.ResourceData, m interface{}) error {
-	container := d.Get("container").(string)
-	key := d.Get("key").(string)
+// func resourceCustomObjectDelete(d *schema.ResourceData, m interface{}) error {
+// 	container := d.Get("container").(string)
+// 	key := d.Get("key").(string)
 
-	client := getClient(m)
+// 	client := getClient(m)
 
-	// Lock to prevent concurrent updates due to Version number conflicts
-	ctMutexKV.Lock(d.Id())
-	defer ctMutexKV.Unlock(d.Id())
+// 	// Lock to prevent concurrent updates due to Version number conflicts
+// 	ctMutexKV.Lock(d.Id())
+// 	defer ctMutexKV.Unlock(d.Id())
 
-	customObject, err := client.
-		CustomObjects().
-		WithContainerAndKey(container, key).
-		Get().
-		Execute(context.Background())
-	if err != nil {
-		return fmt.Errorf("could not get custom object with container %s and key %s: %w", container, key, err)
-	}
+// 	customObject, err := client.
+// 		CustomObjects().
+// 		WithContainerAndKey(container, key).
+// 		Get().
+// 		Execute(context.Background())
+// 	if err != nil {
+// 		return fmt.Errorf("could not get custom object with container %s and key %s: %w", container, key, err)
+// 	}
 
-	_, err = client.
-		CustomObjects().
-		WithContainerAndKey(container, key).
-		Delete().
-		Version(customObject.Version).
-		DataErasure(false).
-		Execute(context.Background())
-	if err != nil {
-		return fmt.Errorf("could not delete custom object with container %s and key %s: %w", container, key, err)
-	}
-	return nil
-}
+// 	_, err = client.
+// 		CustomObjects().
+// 		WithContainerAndKey(container, key).
+// 		Delete().
+// 		Version(customObject.Version).
+// 		DataErasure(false).
+// 		Execute(context.Background())
+// 	if err != nil {
+// 		return fmt.Errorf("could not delete custom object with container %s and key %s: %w", container, key, err)
+// 	}
+// 	return nil
+// }
 
-func _decodeCustomObjectValue(value string) interface{} {
-	data := make(map[string]interface{})
-	json.Unmarshal([]byte(value), &data)
-	return data
-}
+// func _decodeCustomObjectValue(value string) interface{} {
+// 	data := make(map[string]interface{})
+// 	json.Unmarshal([]byte(value), &data)
+// 	return data
+// }
 
-func marshallCustomObjectValue(o *platform.CustomObject) string {
-	val, err := json.Marshal(o.Value)
-	if err != nil {
-		panic(err)
-	}
-	return string(val)
-}
+// func marshallCustomObjectValue(o *platform.CustomObject) string {
+// 	val, err := json.Marshal(o.Value)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	return string(val)
+// }

--- a/commercetools/resource_custom_object_test.go
+++ b/commercetools/resource_custom_object_test.go
@@ -1,203 +1,203 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
 
-func TestAccCustomObjectCreate_basic(t *testing.T) {
+// func TestAccCustomObjectCreate_basic(t *testing.T) {
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCustomObjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCustomObjectNumber(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "container", "foobar",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "key", "value",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "value", "{\"number\":10}",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "version", "1",
-					),
-				),
-			},
-			{
-				Config: testAccCustomObjectNumberUpdateValue(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "container", "foobar",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "key", "value",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "value", "{\"number\":20}",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "version", "2",
-					),
-				),
-			},
-			{
-				Config: testAccCustomObjectNumberUpdateKey(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "container", "foobar",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "key", "newvalue",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "value", "{\"number\":20}",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "version", "1",
-					),
-				),
-			},
-			{
-				Config: testAccCustomObjectNumberUpdateContainer(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "container", "newbar",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "key", "newvalue",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "value", "{\"number\":20}",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_number", "version", "1",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckCustomObjectDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCustomObjectNumber(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "container", "foobar",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "key", "value",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "value", "{\"number\":10}",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "version", "1",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCustomObjectNumberUpdateValue(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "container", "foobar",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "key", "value",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "value", "{\"number\":20}",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "version", "2",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCustomObjectNumberUpdateKey(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "container", "foobar",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "key", "newvalue",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "value", "{\"number\":20}",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "version", "1",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCustomObjectNumberUpdateContainer(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "container", "newbar",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "key", "newvalue",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "value", "{\"number\":20}",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_number", "version", "1",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func TestAccCustomObjectCreate_object(t *testing.T) {
+// func TestAccCustomObjectCreate_object(t *testing.T) {
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCustomObjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCustomObjectNestedData(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_nested", "container", "foobar",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_nested", "key", "nested",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_nested", "value", "{\"address\":{\"number\":10,\"street\":\"foo\"},\"user\":{\"last_name\":\"Smith\",\"name\":\"John\"}}",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_custom_object.test_nested", "version", "1",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckCustomObjectDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCustomObjectNestedData(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_nested", "container", "foobar",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_nested", "key", "nested",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_nested", "value", "{\"address\":{\"number\":10,\"street\":\"foo\"},\"user\":{\"last_name\":\"Smith\",\"name\":\"John\"}}",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_custom_object.test_nested", "version", "1",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccCustomObjectNumber() string {
-	return `
-	resource "commercetools_custom_object" "test_number" {
-		container = "foobar"
-		key = "value"
-		value = jsonencode({
-			number = 10
-		})
-	  }`
-}
+// func testAccCustomObjectNumber() string {
+// 	return `
+// 	resource "commercetools_custom_object" "test_number" {
+// 		container = "foobar"
+// 		key = "value"
+// 		value = jsonencode({
+// 			number = 10
+// 		})
+// 	  }`
+// }
 
-func testAccCustomObjectNumberUpdateValue() string {
-	return `
-	resource "commercetools_custom_object" "test_number" {
-		container = "foobar"
-		key = "value"
-		value = jsonencode({
-			number = 20
-		})
-	  }`
-}
+// func testAccCustomObjectNumberUpdateValue() string {
+// 	return `
+// 	resource "commercetools_custom_object" "test_number" {
+// 		container = "foobar"
+// 		key = "value"
+// 		value = jsonencode({
+// 			number = 20
+// 		})
+// 	  }`
+// }
 
-func testAccCustomObjectNumberUpdateKey() string {
-	return `
-	resource "commercetools_custom_object" "test_number" {
-		container = "foobar"
-		key = "newvalue"
-		value = jsonencode({
-			number = 20
-		})
-	  }`
-}
+// func testAccCustomObjectNumberUpdateKey() string {
+// 	return `
+// 	resource "commercetools_custom_object" "test_number" {
+// 		container = "foobar"
+// 		key = "newvalue"
+// 		value = jsonencode({
+// 			number = 20
+// 		})
+// 	  }`
+// }
 
-func testAccCustomObjectNumberUpdateContainer() string {
-	return `
-	resource "commercetools_custom_object" "test_number" {
-		container = "newbar"
-		key = "newvalue"
-		value = jsonencode({
-			number = 20
-		})
-	  }`
-}
+// func testAccCustomObjectNumberUpdateContainer() string {
+// 	return `
+// 	resource "commercetools_custom_object" "test_number" {
+// 		container = "newbar"
+// 		key = "newvalue"
+// 		value = jsonencode({
+// 			number = 20
+// 		})
+// 	  }`
+// }
 
-func testAccCustomObjectNestedData() string {
-	return `
-	resource "commercetools_custom_object" "test_nested" {
-		container = "foobar"
-		key = "nested"
-		value = jsonencode({
-			address = {
-				street = "foo"
-				number = 10
-			}
-			user = {
-				name = "John"
-				last_name = "Smith"
-			}
-		})
-	  }`
-}
+// func testAccCustomObjectNestedData() string {
+// 	return `
+// 	resource "commercetools_custom_object" "test_nested" {
+// 		container = "foobar"
+// 		key = "nested"
+// 		value = jsonencode({
+// 			address = {
+// 				street = "foo"
+// 				number = 10
+// 			}
+// 			user = {
+// 				name = "John"
+// 				last_name = "Smith"
+// 			}
+// 		})
+// 	  }`
+// }
 
-func testAccCheckCustomObjectDestroy(s *terraform.State) error {
-	conn := getClient(testAccProvider.Meta())
+// func testAccCheckCustomObjectDestroy(s *terraform.State) error {
+// 	conn := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_custom_object" {
-			continue
-		}
-		container := rs.Primary.Attributes["container"]
-		response, err := conn.CustomObjects().WithContainer(container).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.Count > 0 {
-				return fmt.Errorf("custom object container (%s) still exists", container)
-			}
-			return nil
-		}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_custom_object" {
+// 			continue
+// 		}
+// 		container := rs.Primary.Attributes["container"]
+// 		response, err := conn.CustomObjects().WithContainer(container).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.Count > 0 {
+// 				return fmt.Errorf("custom object container (%s) still exists", container)
+// 			}
+// 			return nil
+// 		}
 
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_customer_group.go
+++ b/commercetools/resource_customer_group.go
@@ -1,162 +1,162 @@
 package commercetools
 
-import (
-	"context"
-	"log"
-	"time"
+// import (
+// 	"context"
+// 	"log"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceCustomerGroup() *schema.Resource {
-	return &schema.Resource{
-		Description: "A Customer can be a member of a customer group (for example reseller, gold member). " +
-			"Special prices can be assigned to specific products based on a customer group.\n\n" +
-			"See also the [Custome Group API Documentation](https://docs.commercetools.com/api/projects/customerGroups)",
-		Create: resourceCustomerGroupCreate,
-		Read:   resourceCustomerGroupRead,
-		Update: resourceCustomerGroupUpdate,
-		Delete: resourceCustomerGroupDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for the customer group",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"name": {
-				Description: "Unique within the project",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-		},
-	}
-}
+// func resourceCustomerGroup() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "A Customer can be a member of a customer group (for example reseller, gold member). " +
+// 			"Special prices can be assigned to specific products based on a customer group.\n\n" +
+// 			"See also the [Custome Group API Documentation](https://docs.commercetools.com/api/projects/customerGroups)",
+// 		Create: resourceCustomerGroupCreate,
+// 		Read:   resourceCustomerGroupRead,
+// 		Update: resourceCustomerGroupUpdate,
+// 		Delete: resourceCustomerGroupDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for the customer group",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 			"name": {
+// 				Description: "Unique within the project",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceCustomerGroupCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var customerGroup *platform.CustomerGroup
+// func resourceCustomerGroupCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var customerGroup *platform.CustomerGroup
 
-	draft := platform.CustomerGroupDraft{
-		GroupName: d.Get("name").(string),
-		Key:       stringRef(d.Get("key")),
-	}
+// 	draft := platform.CustomerGroupDraft{
+// 		GroupName: d.Get("name").(string),
+// 		Key:       stringRef(d.Get("key")),
+// 	}
 
-	errorResponse := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
+// 	errorResponse := resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
 
-		customerGroup, err = client.CustomerGroups().Post(draft).Execute(context.Background())
+// 		customerGroup, err = client.CustomerGroups().Post(draft).Execute(context.Background())
 
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if errorResponse != nil {
-		return errorResponse
-	}
+// 	if errorResponse != nil {
+// 		return errorResponse
+// 	}
 
-	if customerGroup == nil {
-		log.Fatal("No customer group")
-	}
+// 	if customerGroup == nil {
+// 		log.Fatal("No customer group")
+// 	}
 
-	d.SetId(customerGroup.ID)
-	d.Set("version", customerGroup.Version)
+// 	d.SetId(customerGroup.ID)
+// 	d.Set("version", customerGroup.Version)
 
-	return resourceCustomerGroupRead(d, m)
-}
+// 	return resourceCustomerGroupRead(d, m)
+// }
 
-func resourceCustomerGroupRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Reading customer group from commercetools, with customer group id: %s", d.Id())
+// func resourceCustomerGroupRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Printf("[DEBUG] Reading customer group from commercetools, with customer group id: %s", d.Id())
 
-	client := getClient(m)
+// 	client := getClient(m)
 
-	customerGroup, err := client.CustomerGroups().WithId(d.Id()).Get().Execute(context.Background())
+// 	customerGroup, err := client.CustomerGroups().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if customerGroup == nil {
-		log.Print("[DEBUG] No customer group found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following customer group:")
-		log.Print(stringFormatObject(customerGroup))
+// 	if customerGroup == nil {
+// 		log.Print("[DEBUG] No customer group found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following customer group:")
+// 		log.Print(stringFormatObject(customerGroup))
 
-		d.Set("version", customerGroup.Version)
-		d.Set("name", customerGroup.Name)
-		d.Set("key", customerGroup.Key)
-	}
+// 		d.Set("version", customerGroup.Version)
+// 		d.Set("name", customerGroup.Name)
+// 		d.Set("key", customerGroup.Key)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func resourceCustomerGroupUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	customerGroup, err := client.CustomerGroups().WithId(d.Id()).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// func resourceCustomerGroupUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	customerGroup, err := client.CustomerGroups().WithId(d.Id()).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	input := platform.CustomerGroupUpdate{
-		Version: customerGroup.Version,
-		Actions: []platform.CustomerGroupUpdateAction{},
-	}
+// 	input := platform.CustomerGroupUpdate{
+// 		Version: customerGroup.Version,
+// 		Actions: []platform.CustomerGroupUpdateAction{},
+// 	}
 
-	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.CustomerGroupChangeNameAction{Name: newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := d.Get("name").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CustomerGroupChangeNameAction{Name: newName})
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.CustomerGroupSetKeyAction{Key: &newKey})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.CustomerGroupSetKeyAction{Key: &newKey})
+// 	}
 
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
 
-	_, err = client.CustomerGroups().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
+// 	_, err = client.CustomerGroups().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
 
-	return resourceCustomerGroupRead(d, m)
-}
+// 	return resourceCustomerGroupRead(d, m)
+// }
 
-func resourceCustomerGroupDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.CustomerGroups().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyCustomerGroupsByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		log.Printf("[ERROR] Error during deleting customer group resource %s", err)
-		return nil
-	}
-	return nil
-}
+// func resourceCustomerGroupDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.CustomerGroups().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyCustomerGroupsByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		log.Printf("[ERROR] Error during deleting customer group resource %s", err)
+// 		return nil
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_customer_group_test.go
+++ b/commercetools/resource_customer_group_test.go
@@ -1,102 +1,102 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
 
-func TestAccCustomerGroupCreate_basic(t *testing.T) {
+// func TestAccCustomerGroupCreate_basic(t *testing.T) {
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCustomerGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCustomerGroupConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_customer_group.standard", "name", "Standard name",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_customer_group.standard", "key", "standard-key",
-					),
-				),
-			},
-			{
-				Config: testAccCustomerGroupUpdate(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_customer_group.standard", "name", "Standard name new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_customer_group.standard", "key", "standard-key-new",
-					),
-				),
-			},
-			{
-				Config: testAccCustomerGroupRemoveProperties(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_customer_group.standard", "name", "Standard name new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_customer_group.standard", "key", "",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckCustomerGroupDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccCustomerGroupConfig(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_customer_group.standard", "name", "Standard name",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_customer_group.standard", "key", "standard-key",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCustomerGroupUpdate(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_customer_group.standard", "name", "Standard name new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_customer_group.standard", "key", "standard-key-new",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccCustomerGroupRemoveProperties(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_customer_group.standard", "name", "Standard name new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_customer_group.standard", "key", "",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccCustomerGroupConfig() string {
-	return `
-resource "commercetools_customer_group" "standard" {
-	name = "Standard name"
-	key  = "standard-key"
-}
-`
-}
+// func testAccCustomerGroupConfig() string {
+// 	return `
+// resource "commercetools_customer_group" "standard" {
+// 	name = "Standard name"
+// 	key  = "standard-key"
+// }
+// `
+// }
 
-func testAccCustomerGroupUpdate() string {
-	return `
-resource "commercetools_customer_group" "standard" {
-	name = "Standard name new"
-	key  = "standard-key-new"
-}
-`
-}
+// func testAccCustomerGroupUpdate() string {
+// 	return `
+// resource "commercetools_customer_group" "standard" {
+// 	name = "Standard name new"
+// 	key  = "standard-key-new"
+// }
+// `
+// }
 
-func testAccCustomerGroupRemoveProperties() string {
-	return `
-resource "commercetools_customer_group" "standard" {
-	name = "Standard name new"
-}
-`
-}
+// func testAccCustomerGroupRemoveProperties() string {
+// 	return `
+// resource "commercetools_customer_group" "standard" {
+// 	name = "Standard name new"
+// }
+// `
+// }
 
-func testAccCheckCustomerGroupDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckCustomerGroupDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_customer_group" {
-			continue
-		}
-		response, err := client.CustomerGroups().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("customer group (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_customer_group" {
+// 			continue
+// 		}
+// 		response, err := client.CustomerGroups().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("customer group (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_discount_code.go
+++ b/commercetools/resource_discount_code.go
@@ -1,358 +1,358 @@
 package commercetools
 
-import (
-	"context"
-	"log"
-	"time"
+// import (
+// 	"context"
+// 	"log"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceDiscountCode() *schema.Resource {
-	return &schema.Resource{
-		Description: "With discount codes it is possible to give specific cart discounts to an eligible set of users. " +
-			"They are defined by a string value which can be added to a cart so that specific cart discounts " +
-			"can be applied to the cart.\n\n" +
-			"See also the [Discount Code Api Documentation](https://docs.commercetools.com/api/projects/discountCodes)",
-		Create: resourceDiscountCodeCreate,
-		Read:   resourceDiscountCodeRead,
-		Update: resourceDiscountCodeUpdate,
-		Delete: resourceDiscountCodeDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"description": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"code": {
-				Description: "Unique identifier of this discount code. This value is added to the cart to enable " +
-					"the related cart discounts in the cart",
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"valid_from": {
-				Description: "The time from which the discount can be applied on a cart. Before that time the code is invalid",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"valid_until": {
-				Description: "The time until the discount can be applied on a cart. After that time the code is invalid",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"is_active": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"predicate": {
-				Description: "[Cart Predicate](https://docs.commercetools.com/api/projects/predicates#cart-predicates)",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"max_applications_per_customer": {
-				Description: "The discount code can only be applied maxApplicationsPerCustomer times per customer",
-				Type:        schema.TypeInt,
-				Optional:    true,
-			},
-			"max_applications": {
-				Description: "The discount code can only be applied maxApplications times",
-				Type:        schema.TypeInt,
-				Optional:    true,
-			},
-			"groups": {
-				Description: "The groups to which this discount code belong",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			"cart_discounts": {
-				Description: "The referenced matching cart discounts can be applied to the cart once the DiscountCode is added",
-				Type:        schema.TypeList,
-				Required:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceDiscountCode() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "With discount codes it is possible to give specific cart discounts to an eligible set of users. " +
+// 			"They are defined by a string value which can be added to a cart so that specific cart discounts " +
+// 			"can be applied to the cart.\n\n" +
+// 			"See also the [Discount Code Api Documentation](https://docs.commercetools.com/api/projects/discountCodes)",
+// 		Create: resourceDiscountCodeCreate,
+// 		Read:   resourceDiscountCodeRead,
+// 		Update: resourceDiscountCodeUpdate,
+// 		Delete: resourceDiscountCodeDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"name": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"description": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"code": {
+// 				Description: "Unique identifier of this discount code. This value is added to the cart to enable " +
+// 					"the related cart discounts in the cart",
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"valid_from": {
+// 				Description: "The time from which the discount can be applied on a cart. Before that time the code is invalid",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"valid_until": {
+// 				Description: "The time until the discount can be applied on a cart. After that time the code is invalid",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"is_active": {
+// 				Type:     types.BoolType,
+// 				Optional: true,
+// 				Default:  true,
+// 			},
+// 			"predicate": {
+// 				Description: "[Cart Predicate](https://docs.commercetools.com/api/projects/predicates#cart-predicates)",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"max_applications_per_customer": {
+// 				Description: "The discount code can only be applied maxApplicationsPerCustomer times per customer",
+// 				Type:        types.Int64Type,
+// 				Optional:    true,
+// 			},
+// 			"max_applications": {
+// 				Description: "The discount code can only be applied maxApplications times",
+// 				Type:        types.Int64Type,
+// 				Optional:    true,
+// 			},
+// 			"groups": {
+// 				Description: "The groups to which this discount code belong",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 			},
+// 			"cart_discounts": {
+// 				Description: "The referenced matching cart discounts can be applied to the cart once the DiscountCode is added",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Required:    true,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceDiscountCodeCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var discountCode *platform.DiscountCode
+// func resourceDiscountCodeCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var discountCode *platform.DiscountCode
 
-	name := platform.LocalizedString(
-		expandStringMap(d.Get("name").(map[string]interface{})))
-	description := platform.LocalizedString(
-		expandStringMap(d.Get("description").(map[string]interface{})))
+// 	name := platform.LocalizedString(
+// 		expandStringMap(d.Get("name").(map[string]interface{})))
+// 	description := platform.LocalizedString(
+// 		expandStringMap(d.Get("description").(map[string]interface{})))
 
-	draft := platform.DiscountCodeDraft{
-		Name:                       &name,
-		Description:                &description,
-		Code:                       d.Get("code").(string),
-		CartPredicate:              stringRef(d.Get("predicate")),
-		IsActive:                   boolRef(d.Get("is_active")),
-		MaxApplicationsPerCustomer: intRef(d.Get("max_applications_per_customer")),
-		MaxApplications:            intRef(d.Get("max_applications")),
-		Groups:                     unmarshallDiscountCodeGroups(d),
-		CartDiscounts:              unmarshallDiscountCodeCartDiscounts(d),
-	}
+// 	draft := platform.DiscountCodeDraft{
+// 		Name:                       &name,
+// 		Description:                &description,
+// 		Code:                       d.Get("code").(string),
+// 		CartPredicate:              stringRef(d.Get("predicate")),
+// 		IsActive:                   boolRef(d.Get("is_active")),
+// 		MaxApplicationsPerCustomer: intRef(d.Get("max_applications_per_customer")),
+// 		MaxApplications:            intRef(d.Get("max_applications")),
+// 		Groups:                     unmarshallDiscountCodeGroups(d),
+// 		CartDiscounts:              unmarshallDiscountCodeCartDiscounts(d),
+// 	}
 
-	if val := d.Get("valid_from").(string); len(val) > 0 {
-		validFrom, err := expandDate(val)
-		if err != nil {
-			return err
-		}
-		draft.ValidFrom = &validFrom
-	}
-	if val := d.Get("valid_until").(string); len(val) > 0 {
-		validUntil, err := expandDate(val)
-		if err != nil {
-			return err
-		}
-		draft.ValidUntil = &validUntil
-	}
+// 	if val := d.Get("valid_from").(string); len(val) > 0 {
+// 		validFrom, err := expandDate(val)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		draft.ValidFrom = &validFrom
+// 	}
+// 	if val := d.Get("valid_until").(string); len(val) > 0 {
+// 		validUntil, err := expandDate(val)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		draft.ValidUntil = &validUntil
+// 	}
 
-	errorResponse := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
+// 	errorResponse := resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
 
-		discountCode, err = client.DiscountCodes().Post(draft).Execute(context.Background())
+// 		discountCode, err = client.DiscountCodes().Post(draft).Execute(context.Background())
 
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if errorResponse != nil {
-		return errorResponse
-	}
+// 	if errorResponse != nil {
+// 		return errorResponse
+// 	}
 
-	if discountCode == nil {
-		log.Fatal("No discount code created")
-	}
+// 	if discountCode == nil {
+// 		log.Fatal("No discount code created")
+// 	}
 
-	d.SetId(discountCode.ID)
-	d.Set("version", discountCode.Version)
+// 	d.SetId(discountCode.ID)
+// 	d.Set("version", discountCode.Version)
 
-	return resourceDiscountCodeRead(d, m)
-}
+// 	return resourceDiscountCodeRead(d, m)
+// }
 
-func resourceDiscountCodeRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Reading discount code from commercetools, with discount code id: %s", d.Id())
+// func resourceDiscountCodeRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Printf("[DEBUG] Reading discount code from commercetools, with discount code id: %s", d.Id())
 
-	client := getClient(m)
+// 	client := getClient(m)
 
-	discountCode, err := client.DiscountCodes().WithId(d.Id()).Get().Execute(context.Background())
+// 	discountCode, err := client.DiscountCodes().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if discountCode == nil {
-		log.Print("[DEBUG] No discount code found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following discount code:")
-		log.Print(stringFormatObject(discountCode))
+// 	if discountCode == nil {
+// 		log.Print("[DEBUG] No discount code found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following discount code:")
+// 		log.Print(stringFormatObject(discountCode))
 
-		d.Set("version", discountCode.Version)
-		d.Set("code", discountCode.Code)
-		d.Set("name", discountCode.Name)
-		d.Set("description", discountCode.Description)
-		d.Set("predicate", discountCode.CartPredicate)
-		d.Set("cart_discounts", marshallDiscountCodeCartDiscounts(discountCode.CartDiscounts))
-		d.Set("groups", discountCode.Groups)
-		d.Set("is_active", discountCode.IsActive)
-		d.Set("valid_from", marshallTime(discountCode.ValidFrom))
-		d.Set("valid_until", marshallTime(discountCode.ValidUntil))
-		d.Set("max_applications_per_customer", discountCode.MaxApplicationsPerCustomer)
-		d.Set("max_applications", discountCode.MaxApplications)
-	}
+// 		d.Set("version", discountCode.Version)
+// 		d.Set("code", discountCode.Code)
+// 		d.Set("name", discountCode.Name)
+// 		d.Set("description", discountCode.Description)
+// 		d.Set("predicate", discountCode.CartPredicate)
+// 		d.Set("cart_discounts", marshallDiscountCodeCartDiscounts(discountCode.CartDiscounts))
+// 		d.Set("groups", discountCode.Groups)
+// 		d.Set("is_active", discountCode.IsActive)
+// 		d.Set("valid_from", marshallTime(discountCode.ValidFrom))
+// 		d.Set("valid_until", marshallTime(discountCode.ValidUntil))
+// 		d.Set("max_applications_per_customer", discountCode.MaxApplicationsPerCustomer)
+// 		d.Set("max_applications", discountCode.MaxApplications)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func resourceDiscountCodeUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	discountCode, err := client.DiscountCodes().WithId(d.Id()).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// func resourceDiscountCodeUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	discountCode, err := client.DiscountCodes().WithId(d.Id()).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	input := platform.DiscountCodeUpdate{
-		Version: discountCode.Version,
-		Actions: []platform.DiscountCodeUpdateAction{},
-	}
+// 	input := platform.DiscountCodeUpdate{
+// 		Version: discountCode.Version,
+// 		Actions: []platform.DiscountCodeUpdateAction{},
+// 	}
 
-	if d.HasChange("name") {
-		newName := platform.LocalizedString(
-			expandStringMap(d.Get("name").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.DiscountCodeSetNameAction{Name: &newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := platform.LocalizedString(
+// 			expandStringMap(d.Get("name").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.DiscountCodeSetNameAction{Name: &newName})
+// 	}
 
-	if d.HasChange("description") {
-		newDescription := platform.LocalizedString(
-			expandStringMap(d.Get("description").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.DiscountCodeSetDescriptionAction{Description: &newDescription})
-	}
+// 	if d.HasChange("description") {
+// 		newDescription := platform.LocalizedString(
+// 			expandStringMap(d.Get("description").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.DiscountCodeSetDescriptionAction{Description: &newDescription})
+// 	}
 
-	if d.HasChange("predicate") {
-		newPredicate := d.Get("predicate").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.DiscountCodeSetCartPredicateAction{CartPredicate: &newPredicate})
-	}
+// 	if d.HasChange("predicate") {
+// 		newPredicate := d.Get("predicate").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.DiscountCodeSetCartPredicateAction{CartPredicate: &newPredicate})
+// 	}
 
-	if d.HasChange("max_applications") {
-		newMaxApplications := d.Get("max_applications").(int)
-		input.Actions = append(
-			input.Actions,
-			&platform.DiscountCodeSetMaxApplicationsAction{MaxApplications: &newMaxApplications})
-	}
+// 	if d.HasChange("max_applications") {
+// 		newMaxApplications := d.Get("max_applications").(int)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.DiscountCodeSetMaxApplicationsAction{MaxApplications: &newMaxApplications})
+// 	}
 
-	if d.HasChange("max_applications_per_customer") {
-		newMaxApplications := d.Get("max_applications_per_customer").(int)
-		input.Actions = append(
-			input.Actions,
-			&platform.DiscountCodeSetMaxApplicationsPerCustomerAction{MaxApplicationsPerCustomer: &newMaxApplications})
-	}
+// 	if d.HasChange("max_applications_per_customer") {
+// 		newMaxApplications := d.Get("max_applications_per_customer").(int)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.DiscountCodeSetMaxApplicationsPerCustomerAction{MaxApplicationsPerCustomer: &newMaxApplications})
+// 	}
 
-	if d.HasChange("cart_discounts") {
-		newCartDiscounts := unmarshallDiscountCodeCartDiscounts(d)
-		input.Actions = append(
-			input.Actions,
-			&platform.DiscountCodeChangeCartDiscountsAction{CartDiscounts: newCartDiscounts})
-	}
+// 	if d.HasChange("cart_discounts") {
+// 		newCartDiscounts := unmarshallDiscountCodeCartDiscounts(d)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.DiscountCodeChangeCartDiscountsAction{CartDiscounts: newCartDiscounts})
+// 	}
 
-	if d.HasChange("groups") {
-		newGroups := unmarshallDiscountCodeGroups(d)
-		if len(newGroups) > 0 {
-			input.Actions = append(
-				input.Actions,
-				&platform.DiscountCodeChangeGroupsAction{Groups: newGroups})
-		} else {
-			input.Actions = append(
-				input.Actions,
-				&platform.DiscountCodeChangeGroupsAction{Groups: []string{}})
-		}
-	}
+// 	if d.HasChange("groups") {
+// 		newGroups := unmarshallDiscountCodeGroups(d)
+// 		if len(newGroups) > 0 {
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.DiscountCodeChangeGroupsAction{Groups: newGroups})
+// 		} else {
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.DiscountCodeChangeGroupsAction{Groups: []string{}})
+// 		}
+// 	}
 
-	if d.HasChange("is_active") {
-		newIsActive := d.Get("is_active").(bool)
-		input.Actions = append(
-			input.Actions,
-			&platform.DiscountCodeChangeIsActiveAction{IsActive: newIsActive})
-	}
+// 	if d.HasChange("is_active") {
+// 		newIsActive := d.Get("is_active").(bool)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.DiscountCodeChangeIsActiveAction{IsActive: newIsActive})
+// 	}
 
-	if d.HasChange("valid_from") {
-		if val := d.Get("valid_from").(string); len(val) > 0 {
-			newValidFrom, err := expandDate(d.Get("valid_from").(string))
-			if err != nil {
-				return err
-			}
-			input.Actions = append(
-				input.Actions,
-				&platform.DiscountCodeSetValidFromAction{ValidFrom: &newValidFrom})
-		} else {
-			input.Actions = append(
-				input.Actions,
-				&platform.DiscountCodeSetValidFromAction{})
-		}
-	}
+// 	if d.HasChange("valid_from") {
+// 		if val := d.Get("valid_from").(string); len(val) > 0 {
+// 			newValidFrom, err := expandDate(d.Get("valid_from").(string))
+// 			if err != nil {
+// 				return err
+// 			}
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.DiscountCodeSetValidFromAction{ValidFrom: &newValidFrom})
+// 		} else {
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.DiscountCodeSetValidFromAction{})
+// 		}
+// 	}
 
-	if d.HasChange("valid_until") {
-		if val := d.Get("valid_until").(string); len(val) > 0 {
-			newValidUntil, err := expandDate(d.Get("valid_until").(string))
-			if err != nil {
-				return err
-			}
-			input.Actions = append(
-				input.Actions,
-				&platform.DiscountCodeSetValidUntilAction{ValidUntil: &newValidUntil})
-		} else {
-			input.Actions = append(
-				input.Actions,
-				&platform.DiscountCodeSetValidUntilAction{})
-		}
-	}
+// 	if d.HasChange("valid_until") {
+// 		if val := d.Get("valid_until").(string); len(val) > 0 {
+// 			newValidUntil, err := expandDate(d.Get("valid_until").(string))
+// 			if err != nil {
+// 				return err
+// 			}
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.DiscountCodeSetValidUntilAction{ValidUntil: &newValidUntil})
+// 		} else {
+// 			input.Actions = append(
+// 				input.Actions,
+// 				&platform.DiscountCodeSetValidUntilAction{})
+// 		}
+// 	}
 
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
 
-	_, err = client.DiscountCodes().WithId(discountCode.ID).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
+// 	_, err = client.DiscountCodes().WithId(discountCode.ID).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
 
-	return resourceDiscountCodeRead(d, m)
-}
+// 	return resourceDiscountCodeRead(d, m)
+// }
 
-func resourceDiscountCodeDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.DiscountCodes().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyDiscountCodesByIDRequestMethodDeleteInput{
-		Version:     version,
-		DataErasure: boolRef(true),
-	}).Execute(context.Background())
+// func resourceDiscountCodeDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.DiscountCodes().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyDiscountCodesByIDRequestMethodDeleteInput{
+// 		Version:     version,
+// 		DataErasure: boolRef(true),
+// 	}).Execute(context.Background())
 
-	if err != nil {
-		log.Printf("[ERROR] Error during deleting discount code resource %s", err)
-		return nil
-	}
-	return nil
-}
+// 	if err != nil {
+// 		log.Printf("[ERROR] Error during deleting discount code resource %s", err)
+// 		return nil
+// 	}
+// 	return nil
+// }
 
-func unmarshallDiscountCodeGroups(d *schema.ResourceData) []string {
-	var groups []string
-	for _, group := range expandStringArray(d.Get("groups").([]interface{})) {
-		groups = append(groups, group)
-	}
-	return groups
-}
+// func unmarshallDiscountCodeGroups(d *schema.ResourceData) []string {
+// 	var groups []string
+// 	for _, group := range expandStringArray(d.Get("groups").([]interface{})) {
+// 		groups = append(groups, group)
+// 	}
+// 	return groups
+// }
 
-func unmarshallDiscountCodeCartDiscounts(d *schema.ResourceData) []platform.CartDiscountResourceIdentifier {
-	discounts := d.Get("cart_discounts").([]interface{})
+// func unmarshallDiscountCodeCartDiscounts(d *schema.ResourceData) []platform.CartDiscountResourceIdentifier {
+// 	discounts := d.Get("cart_discounts").([]interface{})
 
-	cartDiscounts := make([]platform.CartDiscountResourceIdentifier, len(discounts))
-	for i := range discounts {
-		id := discounts[i].(string)
-		cartDiscounts[i] = platform.CartDiscountResourceIdentifier{ID: &id}
-	}
-	return cartDiscounts
-}
+// 	cartDiscounts := make([]platform.CartDiscountResourceIdentifier, len(discounts))
+// 	for i := range discounts {
+// 		id := discounts[i].(string)
+// 		cartDiscounts[i] = platform.CartDiscountResourceIdentifier{ID: &id}
+// 	}
+// 	return cartDiscounts
+// }
 
-func marshallDiscountCodeCartDiscounts(values []platform.CartDiscountReference) []string {
-	result := make([]string, 0, len(values))
-	for _, obj := range values {
-		result = append(result, string(obj.ID))
-	}
-	return result
-}
+// func marshallDiscountCodeCartDiscounts(values []platform.CartDiscountReference) []string {
+// 	result := make([]string, 0, len(values))
+// 	for _, obj := range values {
+// 		result = append(result, string(obj.ID))
+// 	}
+// 	return result
+// }

--- a/commercetools/resource_discount_code_test.go
+++ b/commercetools/resource_discount_code_test.go
@@ -1,369 +1,369 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
 
-func TestAccDiscountCodeCreate_basic(t *testing.T) {
+// func TestAccDiscountCodeCreate_basic(t *testing.T) {
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDiscountCodeDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDiscountCodeConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "name.en", "Standard name",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "description.en", "Standard description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "code", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "valid_from", "2020-01-02T15:04:05Z",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "valid_until", "2021-01-02T15:04:05Z",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "is_active", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "predicate", "1=1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "max_applications_per_customer", "10",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "max_applications", "100",
-					),
-				),
-			},
-			{
-				Config: testAccDiscountCodeUpdate(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "name.en", "Standard name new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "description.en", "Standard description new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "code", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "valid_from", "2018-01-02T15:04:05Z",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "valid_until", "2019-01-02T15:04:05Z",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "is_active", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "predicate", "1=2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "max_applications_per_customer", "5",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "max_applications", "50",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_discount_code.standard", "cart_discounts.1",
-					),
-				),
-			},
-			{
-				Config: testAccDiscountCodeRemoveProperties(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr(
-						"commercetools_discount_code.standard", "name.en",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_discount_code.standard", "description.en",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "code", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "valid_from", "",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "valid_until", "",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "is_active", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "predicate", "",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "max_applications_per_customer", "0",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_discount_code.standard", "max_applications", "0",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_discount_code.standard", "cart_discounts.1",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckDiscountCodeDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccDiscountCodeConfig(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "name.en", "Standard name",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "description.en", "Standard description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "code", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "valid_from", "2020-01-02T15:04:05Z",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "valid_until", "2021-01-02T15:04:05Z",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "is_active", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "predicate", "1=1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "max_applications_per_customer", "10",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "max_applications", "100",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccDiscountCodeUpdate(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "name.en", "Standard name new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "description.en", "Standard description new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "code", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "valid_from", "2018-01-02T15:04:05Z",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "valid_until", "2019-01-02T15:04:05Z",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "is_active", "false",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "predicate", "1=2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "max_applications_per_customer", "5",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "max_applications", "50",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_discount_code.standard", "cart_discounts.1",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccDiscountCodeRemoveProperties(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_discount_code.standard", "name.en",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_discount_code.standard", "description.en",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "code", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "valid_from", "",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "valid_until", "",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "is_active", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "predicate", "",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "max_applications_per_customer", "0",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_discount_code.standard", "max_applications", "0",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_discount_code.standard", "cart_discounts.1",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccDiscountCodeConfig() string {
-	return `
-	resource "commercetools_cart_discount" "standard" {
-		key = "test_key"
-		name = {
-			en = "best cart discount"
-		}
-		description = {
-			en = "Standard description"
-		}
-		sort_order             = "0.9123"
-		predicate              = "1=1"
-		stacking_mode          = "Stacking"
-		requires_discount_code = true
-		valid_from             = "2020-01-02T15:04:05Z"
-		valid_until            = "2021-01-02T15:04:05Z"
+// func testAccDiscountCodeConfig() string {
+// 	return `
+// 	resource "commercetools_cart_discount" "standard" {
+// 		key = "test_key"
+// 		name = {
+// 			en = "best cart discount"
+// 		}
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		sort_order             = "0.9123"
+// 		predicate              = "1=1"
+// 		stacking_mode          = "Stacking"
+// 		requires_discount_code = true
+// 		valid_from             = "2020-01-02T15:04:05Z"
+// 		valid_until            = "2021-01-02T15:04:05Z"
 
-		target {
-			type      = "lineItems"
-			predicate = "1=1"
-		}
+// 		target {
+// 			type      = "lineItems"
+// 			predicate = "1=1"
+// 		}
 
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
-	  }
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
+// 	  }
 
-	resource "commercetools_cart_discount" "standard_2" {
-		key = "another_test_key"
-		name = {
-			en = "best cart discount the second"
-		}
-		description = {
-			en = "Standard description"
-		}
-		sort_order             = "0.9321"
-		predicate              = "1=1"
-		stacking_mode          = "Stacking"
-		requires_discount_code = true
-		valid_from             = "2020-01-02T15:04:05Z"
-		valid_until            = "2021-01-02T15:04:05Z"
+// 	resource "commercetools_cart_discount" "standard_2" {
+// 		key = "another_test_key"
+// 		name = {
+// 			en = "best cart discount the second"
+// 		}
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		sort_order             = "0.9321"
+// 		predicate              = "1=1"
+// 		stacking_mode          = "Stacking"
+// 		requires_discount_code = true
+// 		valid_from             = "2020-01-02T15:04:05Z"
+// 		valid_until            = "2021-01-02T15:04:05Z"
 
-		target {
-			type      = "lineItems"
-			predicate = "1=1"
-		}
+// 		target {
+// 			type      = "lineItems"
+// 			predicate = "1=1"
+// 		}
 
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
-	  }
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
+// 	  }
 
-	resource "commercetools_discount_code" "standard" {
-		name = {
-			en = "Standard name"
-		}
-		description = {
-			en = "Standard description"
-		}
-		code        = "2"
-		valid_from  = "2020-01-02T15:04:05Z"
-		valid_until = "2021-01-02T15:04:05Z"
-		is_active   = true
-        predicate   = "1=1"
+// 	resource "commercetools_discount_code" "standard" {
+// 		name = {
+// 			en = "Standard name"
+// 		}
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		code        = "2"
+// 		valid_from  = "2020-01-02T15:04:05Z"
+// 		valid_until = "2021-01-02T15:04:05Z"
+// 		is_active   = true
+//         predicate   = "1=1"
 
-        max_applications_per_customer = 10
-        max_applications              = 100
+//         max_applications_per_customer = 10
+//         max_applications              = 100
 
-		cart_discounts = [commercetools_cart_discount.standard.id, commercetools_cart_discount.standard_2.id]
-	  }`
-}
+// 		cart_discounts = [commercetools_cart_discount.standard.id, commercetools_cart_discount.standard_2.id]
+// 	  }`
+// }
 
-func testAccDiscountCodeUpdate() string {
-	return `
-	resource "commercetools_cart_discount" "standard" {
-		key = "test_key"
-		name = {
-			en = "best cart discount"
-		}
-		description = {
-			en = "Standard description"
-		}
-		sort_order             = "0.9123"
-		predicate              = "1=1"
-		stacking_mode          = "Stacking"
-		requires_discount_code = true
-		valid_from             = "2020-01-02T15:04:05Z"
-		valid_until            = "2021-01-02T15:04:05Z"
-		target {
-		  type      = "lineItems"
-		  predicate = "1=1"
-		}
+// func testAccDiscountCodeUpdate() string {
+// 	return `
+// 	resource "commercetools_cart_discount" "standard" {
+// 		key = "test_key"
+// 		name = {
+// 			en = "best cart discount"
+// 		}
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		sort_order             = "0.9123"
+// 		predicate              = "1=1"
+// 		stacking_mode          = "Stacking"
+// 		requires_discount_code = true
+// 		valid_from             = "2020-01-02T15:04:05Z"
+// 		valid_until            = "2021-01-02T15:04:05Z"
+// 		target {
+// 		  type      = "lineItems"
+// 		  predicate = "1=1"
+// 		}
 
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
-	}
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
+// 	}
 
-	resource "commercetools_cart_discount" "standard_2" {
-		key = "another_test_key"
-		name = {
-			en = "best cart discount the second"
-		}
-		description = {
-			en = "Standard description"
-		}
-		sort_order             = "0.9321"
-		predicate              = "1=1"
-		stacking_mode          = "Stacking"
-		requires_discount_code = true
-		valid_from             = "2020-01-02T15:04:05Z"
-		valid_until            = "2021-01-02T15:04:05Z"
+// 	resource "commercetools_cart_discount" "standard_2" {
+// 		key = "another_test_key"
+// 		name = {
+// 			en = "best cart discount the second"
+// 		}
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		sort_order             = "0.9321"
+// 		predicate              = "1=1"
+// 		stacking_mode          = "Stacking"
+// 		requires_discount_code = true
+// 		valid_from             = "2020-01-02T15:04:05Z"
+// 		valid_until            = "2021-01-02T15:04:05Z"
 
-		target {
-			type      = "lineItems"
-			predicate = "1=1"
-		}
+// 		target {
+// 			type      = "lineItems"
+// 			predicate = "1=1"
+// 		}
 
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
-	}
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
+// 	}
 
-	resource "commercetools_discount_code" "standard" {
-		name = {
-			en = "Standard name new"
-		}
-		description = {
-			en = "Standard description new"
-		}
-		code           = "2"
-		valid_from     = "2018-01-02T15:04:05Z"
-		valid_until    = "2019-01-02T15:04:05Z"
-		is_active      = false
-        predicate      = "1=2"
+// 	resource "commercetools_discount_code" "standard" {
+// 		name = {
+// 			en = "Standard name new"
+// 		}
+// 		description = {
+// 			en = "Standard description new"
+// 		}
+// 		code           = "2"
+// 		valid_from     = "2018-01-02T15:04:05Z"
+// 		valid_until    = "2019-01-02T15:04:05Z"
+// 		is_active      = false
+//         predicate      = "1=2"
 
-        max_applications_per_customer = 5
-        max_applications              = 50
+//         max_applications_per_customer = 5
+//         max_applications              = 50
 
-		cart_discounts = [commercetools_cart_discount.standard.id]
-	  }  `
-}
+// 		cart_discounts = [commercetools_cart_discount.standard.id]
+// 	  }  `
+// }
 
-func testAccDiscountCodeRemoveProperties() string {
-	return `
-		resource "commercetools_cart_discount" "standard" {
-		key = "test_key"
-		name = {
-			en = "best cart discount"
-		}
-		description = {
-			en = "Standard description"
-		}
-		sort_order             = "0.9123"
-		predicate              = "1=1"
-		stacking_mode          = "Stacking"
-		requires_discount_code = true
-		valid_from             = "2020-01-02T15:04:05Z"
-		valid_until            = "2021-01-02T15:04:05Z"
+// func testAccDiscountCodeRemoveProperties() string {
+// 	return `
+// 		resource "commercetools_cart_discount" "standard" {
+// 		key = "test_key"
+// 		name = {
+// 			en = "best cart discount"
+// 		}
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		sort_order             = "0.9123"
+// 		predicate              = "1=1"
+// 		stacking_mode          = "Stacking"
+// 		requires_discount_code = true
+// 		valid_from             = "2020-01-02T15:04:05Z"
+// 		valid_until            = "2021-01-02T15:04:05Z"
 
-		target {
-		  type      = "lineItems"
-		  predicate = "1=1"
-		}
+// 		target {
+// 		  type      = "lineItems"
+// 		  predicate = "1=1"
+// 		}
 
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
-	  }
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
+// 	  }
 
-	resource "commercetools_cart_discount" "standard_2" {
-		key = "another_test_key"
-		name = {
-			en = "best cart discount the second"
-		}
-		description = {
-			en = "Standard description"
-		}
-		sort_order             = "0.9321"
-		predicate              = "1=1"
-		stacking_mode          = "Stacking"
-		requires_discount_code = true
-		valid_from             = "2020-01-02T15:04:05Z"
-		valid_until            = "2021-01-02T15:04:05Z"
+// 	resource "commercetools_cart_discount" "standard_2" {
+// 		key = "another_test_key"
+// 		name = {
+// 			en = "best cart discount the second"
+// 		}
+// 		description = {
+// 			en = "Standard description"
+// 		}
+// 		sort_order             = "0.9321"
+// 		predicate              = "1=1"
+// 		stacking_mode          = "Stacking"
+// 		requires_discount_code = true
+// 		valid_from             = "2020-01-02T15:04:05Z"
+// 		valid_until            = "2021-01-02T15:04:05Z"
 
-		target {
-		  type      = "lineItems"
-		  predicate = "1=1"
-		}
+// 		target {
+// 		  type      = "lineItems"
+// 		  predicate = "1=1"
+// 		}
 
-		value {
-			type      = "relative"
-			permyriad = 1000
-		}
-	  }
+// 		value {
+// 			type      = "relative"
+// 			permyriad = 1000
+// 		}
+// 	  }
 
-	resource "commercetools_discount_code" "standard" {
-		code           = "2"
-		cart_discounts = [commercetools_cart_discount.standard.id]
-	  }`
-}
+// 	resource "commercetools_discount_code" "standard" {
+// 		code           = "2"
+// 		cart_discounts = [commercetools_cart_discount.standard.id]
+// 	  }`
+// }
 
-func testAccCheckDiscountCodeDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckDiscountCodeDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		switch rs.Type {
-		case "commercetools_cart_discount":
-			{
-				response, err := client.CartDiscounts().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
-						return fmt.Errorf("cart discount (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		case "commercetools_discount_code":
-			{
-				response, err := client.CartDiscounts().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
-						return fmt.Errorf("discount code (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		default:
-			continue
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		switch rs.Type {
+// 		case "commercetools_cart_discount":
+// 			{
+// 				response, err := client.CartDiscounts().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
+// 						return fmt.Errorf("cart discount (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		case "commercetools_discount_code":
+// 			{
+// 				response, err := client.CartDiscounts().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
+// 						return fmt.Errorf("discount code (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		default:
+// 			continue
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_product_type.go
+++ b/commercetools/resource_product_type.go
@@ -1,815 +1,815 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"reflect"
-	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
-
-var constraintMap = map[string]platform.AttributeConstraintEnum{
-	"Unique":            platform.AttributeConstraintEnumUnique,
-	"CombinationUnique": platform.AttributeConstraintEnumCombinationUnique,
-	"SameForAll":        platform.AttributeConstraintEnumSameForAll,
-	"None":              platform.AttributeConstraintEnumNone,
-}
-
-func resourceProductType() *schema.Resource {
-	return &schema.Resource{
-		Description: "Product types are used to describe common characteristics, most importantly common custom " +
-			"attributes, of many concrete products. Please note: to customize other resources than products, " +
-			"please refer to resource_type.\n\n" +
-			"See also the [Product Type API Documentation](https://docs.commercetools.com/api/projects/productTypes)",
-		Create: resourceProductTypeCreate,
-		Read:   resourceProductTypeRead,
-		Update: resourceProductTypeUpdate,
-		Delete: resourceProductTypeDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"key": {
-				Description: "User-specific unique identifier for the product type (max. 256 characters)",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"attribute": {
-				Description: "[Product attribute fefinition](https://docs.commercetools.com/api/projects/productTypes#attributedefinition)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Description: "[AttributeType](https://docs.commercetools.com/api/projects/productTypes#attributetype)",
-							Type:        schema.TypeList,
-							MaxItems:    1,
-							Required:    true,
-							Elem:        attributeTypeElement(true),
-						},
-						"name": {
-							Description: "The unique name of the attribute used in the API. The name must be between " +
-								"two and 256 characters long and can contain the ASCII letters A to Z in lowercase or " +
-								"uppercase, digits, underscores (_) and the hyphen-minus (-).\n" +
-								"When using the same name for an attribute in two or more product types all fields " +
-								"of the AttributeDefinition of this attribute need to be the same across the product " +
-								"types, otherwise an AttributeDefinitionAlreadyExists error code will be returned. " +
-								"An exception to this are the values of an enum or lenum type and sets thereof",
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"label": {
-							Description: "A human-readable label for the attribute",
-							Type:        TypeLocalizedString,
-							Required:    true,
-						},
-						"required": {
-							Description: "Whether the attribute is required to have a value",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
-						},
-						"constraint": {
-							Description: "Describes how an attribute or a set of attributes should be validated " +
-								"across all variants of a product. " +
-								"See also [Attribute Constraint](https://docs.commercetools.com/api/projects/productTypes#attributeconstraint-enum)",
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  platform.AttributeConstraintEnumNone,
-							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-								v := val.(string)
-
-								if _, ok := constraintMap[v]; !ok {
-									allowedConstraints := []string{}
-									for key := range constraintMap {
-										allowedConstraints = append(allowedConstraints, key)
-									}
-									errs = append(errs, fmt.Errorf(
-										"Unkown attribute constraint '%v'. Possible values are %v", v, allowedConstraints))
-								}
-								return
-							},
-						},
-						"input_tip": {
-							Description: "Additional information about the attribute that aids content managers " +
-								"when setting product details",
-							Type:     TypeLocalizedString,
-							Optional: true,
-						},
-						"input_hint": {
-							Description: "Provides a visual representation type for this attribute. " +
-								"only relevant for text-based attribute types like TextType and LocalizableTextType",
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  platform.TextInputHintSingleLine,
-						},
-						"searchable": {
-							Description: "Whether the attribute's values should generally be activated in product search",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
-						},
-					},
-				},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-		CustomizeDiff: customdiff.All(
-			customdiff.ValidateChange("attribute", func(ctx context.Context, old, new, meta interface{}) error {
-				log.Printf("[DEBUG] Start attribute validation")
-				oldLookup := createLookup(old.([]interface{}), "name")
-				newV := new.([]interface{})
-
-				for _, field := range newV {
-					newF := field.(map[string]interface{})
-					name := newF["name"].(string)
-					oldF, ok := oldLookup[name].(map[string]interface{})
-					if !ok {
-						// It means this is a new field, that's ok.
-						log.Printf("[DEBUG] Found new attribute: %s", name)
-						continue
-					}
-
-					log.Printf("[DEBUG] Checking %s", oldF["name"])
-					oldType := oldF["type"].([]interface{})[0].(map[string]interface{})
-					newType := newF["type"].([]interface{})[0].(map[string]interface{})
-
-					if oldType["name"] != newType["name"] {
-						if oldType["name"] != "" || newType["name"] == "" {
-							continue
-						}
-						return fmt.Errorf(
-							"Field '%s' type changed from %s to %s. Changing types is not supported; please remove the attribute first and re-define it later",
-							name, oldType["name"], newType["name"])
-					}
-
-					if oldF["required"] != newF["required"] {
-						return fmt.Errorf(
-							"Error on the '%s' attribute: Updating the 'required' attribute is not supported. Consider removing the attribute first and then re-adding it",
-							name)
-					}
-				}
-				return nil
-			}),
-		),
-	}
-}
-
-func attributeTypeElement(setsAllowed bool) *schema.Resource {
-	result := map[string]*schema.Schema{
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-				v := val.(string)
-				if !setsAllowed && v == "set" {
-					errs = append(errs, fmt.Errorf("Sets in another Set are not allowed"))
-				}
-				return
-			},
-		},
-		"values": {
-			Type:     schema.TypeMap,
-			Optional: true,
-		},
-		"localized_value": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem:     localizedValueElement(),
-		},
-		"reference_type_id": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"type_reference": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-	}
-
-	if setsAllowed {
-		result["element_type"] = &schema.Schema{
-			Type:     schema.TypeList,
-			MaxItems: 1,
-			Optional: true,
-			Elem:     attributeTypeElement(false),
-		}
-	}
-
-	return &schema.Resource{Schema: result}
-}
-
-func resourceProductTypeCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var ctType *platform.ProductType
-
-	attributes, err := resourceProductTypeGetAttributeDefinitions(d)
-
-	if err != nil {
-		return err
-	}
-
-	draft := platform.ProductTypeDraft{
-		Key:         stringRef(d.Get("key")),
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		Attributes:  attributes,
-	}
-
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
-
-		ctType, err = client.ProductTypes().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
-
-	if err != nil {
-		return err
-	}
-
-	if ctType == nil {
-		log.Fatal("No type created?")
-	}
-
-	d.SetId(ctType.ID)
-	d.Set("version", ctType.Version)
-
-	return resourceProductTypeRead(d, m)
-}
-
-func resourceProductTypeRead(d *schema.ResourceData, m interface{}) error {
-	log.Print("[DEBUG] Reading product type from commercetools")
-	client := getClient(m)
-
-	ctType, err := client.ProductTypes().WithId(d.Id()).Get().Execute(context.Background())
-
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
-
-	if ctType == nil {
-		log.Print("[DEBUG] No product type found")
-		d.SetId("")
-	} else {
-		log.Printf("[DEBUG] Found following product type: %#v", ctType)
-		log.Print(stringFormatObject(ctType))
-
-		attributes := make([]map[string]interface{}, len(ctType.Attributes))
-		for i, fieldDef := range ctType.Attributes {
-			fieldData := make(map[string]interface{})
-			log.Printf("[DEBUG] reading field: %s: %#v", fieldDef.Name, fieldDef)
-			fieldType, err := resourceProductTypeReadAttributeType(fieldDef.Type, true)
-			if err != nil {
-				return err
-			}
-
-			fieldData["type"] = fieldType
-			fieldData["name"] = fieldDef.Name
-			fieldData["label"] = fieldDef.Label
-			fieldData["required"] = fieldDef.IsRequired
-			fieldData["input_hint"] = fieldDef.InputHint
-			if fieldDef.InputTip != nil {
-				fieldData["input_tip"] = *fieldDef.InputTip
-			}
-			fieldData["constraint"] = fieldDef.AttributeConstraint
-			fieldData["searchable"] = fieldDef.IsSearchable
-
-			attributes[i] = fieldData
-		}
-
-		log.Printf("[DEBUG] Created attributes %#v", attributes)
-		d.Set("version", ctType.Version)
-		d.Set("key", ctType.Key)
-		d.Set("name", ctType.Name)
-		d.Set("description", ctType.Description)
-		err = d.Set("attribute", attributes)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func resourceProductTypeReadAttributeType(attrType platform.AttributeType, setsAllowed bool) ([]interface{}, error) {
-	typeData := make(map[string]interface{})
-
-	if _, ok := attrType.(platform.AttributeBooleanType); ok {
-		typeData["name"] = "boolean"
-	} else if _, ok := attrType.(platform.AttributeTextType); ok {
-		typeData["name"] = "text"
-	} else if _, ok := attrType.(platform.AttributeLocalizableTextType); ok {
-		typeData["name"] = "ltext"
-	} else if f, ok := attrType.(platform.AttributeEnumType); ok {
-		enumValues := make(map[string]interface{}, len(f.Values))
-		for _, value := range f.Values {
-			enumValues[value.Key] = value.Label
-		}
-		typeData["name"] = "enum"
-		typeData["values"] = enumValues
-	} else if f, ok := attrType.(platform.AttributeLocalizedEnumType); ok {
-		typeData["name"] = "lenum"
-		typeData["localized_value"] = readAttributeLocalizedEnum(f.Values)
-	} else if _, ok := attrType.(platform.AttributeNumberType); ok {
-		typeData["name"] = "number"
-	} else if _, ok := attrType.(platform.AttributeMoneyType); ok {
-		typeData["name"] = "money"
-	} else if _, ok := attrType.(platform.AttributeDateType); ok {
-		typeData["name"] = "date"
-	} else if _, ok := attrType.(platform.AttributeTimeType); ok {
-		typeData["name"] = "time"
-	} else if _, ok := attrType.(platform.AttributeDateTimeType); ok {
-		typeData["name"] = "datetime"
-	} else if f, ok := attrType.(platform.AttributeReferenceType); ok {
-		typeData["name"] = "reference"
-		typeData["reference_type_id"] = f.ReferenceTypeId
-	} else if f, ok := attrType.(platform.AttributeNestedType); ok {
-		typeData["name"] = "nested"
-		typeData["type_reference"] = f.TypeReference.ID
-	} else if f, ok := attrType.(platform.AttributeSetType); ok {
-		typeData["name"] = "set"
-		if setsAllowed {
-			elemType, err := resourceProductTypeReadAttributeType(f.ElementType, false)
-			if err != nil {
-				return nil, err
-			}
-			typeData["element_type"] = elemType
-		}
-	} else {
-		return nil, fmt.Errorf("Unknown resource Type %T", attrType)
-	}
-
-	return []interface{}{typeData}, nil
-}
-
-func resourceProductTypeUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-
-	input := platform.ProductTypeUpdate{
-		Version: d.Get("version").(int),
-		Actions: []platform.ProductTypeUpdateAction{},
-	}
-
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ProductTypeSetKeyAction{Key: &newKey})
-	}
-
-	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ProductTypeChangeNameAction{Name: newName})
-	}
-
-	if d.HasChange("description") {
-		newDescr := d.Get("description").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ProductTypeChangeDescriptionAction{Description: newDescr})
-	}
-
-	if d.HasChange("attribute") {
-		old, new := d.GetChange("attribute")
-		attributeChangeActions, err := resourceProductTypeAttributeChangeActions(
-			old.([]interface{}), new.([]interface{}))
-		if err != nil {
-			return err
-		}
-
-		input.Actions = append(input.Actions, attributeChangeActions...)
-	}
-
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
-
-	_, err := client.ProductTypes().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
-
-	return resourceProductTypeRead(d, m)
-}
-
-func resourceProductTypeDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.ProductTypes().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyProductTypesByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func resourceProductTypeAttributeChangeActions(oldValues []interface{}, newValues []interface{}) ([]platform.ProductTypeUpdateAction, error) {
-	oldLookup := createLookup(oldValues, "name")
-	newLookup := createLookup(newValues, "name")
-	newAttrDefinitions := []platform.AttributeDefinition{}
-	actions := []platform.ProductTypeUpdateAction{}
-	checkAttributeOrder := true
-
-	for name := range oldLookup {
-		if _, ok := newLookup[name]; !ok {
-			log.Printf("[DEBUG] Attribute deleted: %s", name)
-			actions = append(actions, platform.ProductTypeRemoveAttributeDefinitionAction{Name: name})
-			checkAttributeOrder = false
-		}
-	}
-
-	for _, value := range newValues {
-		newV := value.(map[string]interface{})
-		name := newV["name"].(string)
-		oldValue, existingField := oldLookup[name]
-
-		var attrDef platform.AttributeDefinition
-		if output, err := resourceProductTypeGetAttributeDefinition(newV, false); err == nil {
-			attrDef = output.(platform.AttributeDefinition)
-		} else {
-			return nil, err
-		}
-
-		var attrDefDraft platform.AttributeDefinitionDraft
-		if output, err := resourceProductTypeGetAttributeDefinition(newV, true); err == nil {
-			attrDefDraft = output.(platform.AttributeDefinitionDraft)
-		} else {
-			return nil, err
-		}
-
-		newAttrDefinitions = append(newAttrDefinitions, attrDef)
-
-		if !existingField {
-			log.Printf("[DEBUG] Attribute added: %s", name)
-			actions = append(
-				actions,
-				platform.ProductTypeAddAttributeDefinitionAction{Attribute: attrDefDraft})
-			checkAttributeOrder = false
-			continue
-		}
-
-		oldV := oldValue.(map[string]interface{})
-		if !reflect.DeepEqual(oldV["label"], newV["label"]) {
-			actions = append(
-				actions,
-				platform.ProductTypeChangeLabelAction{
-					AttributeName: name, Label: attrDef.Label})
-		}
-		if oldV["name"] != newV["name"] {
-			actions = append(
-				actions,
-				platform.ProductTypeChangeAttributeNameAction{
-					AttributeName: name, NewAttributeName: attrDef.Name})
-		}
-		if oldV["searchable"] != newV["searchable"] {
-			actions = append(
-				actions,
-				platform.ProductTypeChangeIsSearchableAction{
-					AttributeName: name, IsSearchable: attrDef.IsSearchable})
-		}
-		if oldV["input_hint"] != newV["input_hint"] {
-			actions = append(
-				actions,
-				platform.ProductTypeChangeInputHintAction{
-					AttributeName: name, NewValue: attrDef.InputHint})
-		}
-		if !reflect.DeepEqual(oldV["input_tip"], newV["input_tip"]) {
-			actions = append(
-				actions,
-				platform.ProductTypeSetInputTipAction{
-					AttributeName: name,
-					InputTip:      attrDef.InputTip,
-				})
-		}
-		if oldV["constraint"] != newV["constraint"] {
-			actions = append(
-				actions,
-				platform.ProductTypeChangeAttributeConstraintAction{
-					AttributeName: name,
-					NewValue:      platform.AttributeConstraintEnumDraft(attrDef.AttributeConstraint),
-				})
-		}
-
-		newFieldType := attrDef.Type
-		oldFieldType := oldV["type"].([]interface{})[0].(map[string]interface{})
-		oldEnumKeys := make(map[string]interface{})
-		newEnumKeys := make(map[string]interface{})
-
-		actions = handleEnumTypeChanges(newFieldType, oldFieldType, newEnumKeys, actions, name, oldEnumKeys)
-
-		if enumType, ok := newFieldType.(platform.AttributeSetType); ok {
-
-			myOldFieldType := oldFieldType["element_type"].([]interface{})[0].(map[string]interface{})
-			actions = handleEnumTypeChanges(enumType.ElementType, myOldFieldType, newEnumKeys, actions, name, oldEnumKeys)
-
-			log.Printf("[DEBUG] Set detected: %s", name)
-			log.Print(len(myOldFieldType))
-		}
-
-		removeEnumKeys := []string{}
-		for key := range oldEnumKeys {
-			if _, ok := newEnumKeys[key]; !ok {
-				removeEnumKeys = append(removeEnumKeys, key)
-			}
-		}
-
-		if len(removeEnumKeys) > 0 {
-			actions = append(
-				actions,
-				platform.ProductTypeRemoveEnumValuesAction{
-					AttributeName: name,
-					Keys:          removeEnumKeys,
-				})
-		}
-
-	}
-
-	oldNames := make([]string, len(oldValues))
-	newNames := make([]string, len(newValues))
-
-	for i, value := range oldValues {
-		v := value.(map[string]interface{})
-		oldNames[i] = v["name"].(string)
-	}
-	for i, value := range newValues {
-		v := value.(map[string]interface{})
-		newNames[i] = v["name"].(string)
-	}
-
-	if checkAttributeOrder && !reflect.DeepEqual(oldNames, newNames) {
-		actions = append(
-			actions,
-			platform.ProductTypeChangeAttributeOrderAction{
-				Attributes: newAttrDefinitions,
-			})
-	}
-
-	log.Printf("[DEBUG] Construction Attribute change actions")
-
-	return actions, nil
-}
-
-func handleEnumTypeChanges(newFieldType platform.AttributeType, oldFieldType map[string]interface{}, newEnumKeys map[string]interface{}, actions []platform.ProductTypeUpdateAction, name string, oldEnumKeys map[string]interface{}) []platform.ProductTypeUpdateAction {
-	if enumType, ok := newFieldType.(platform.AttributeEnumType); ok {
-		oldEnumV := oldFieldType["values"].(map[string]interface{})
-
-		for i, enumValue := range enumType.Values {
-			newEnumKeys[enumValue.Key] = enumValue
-			if _, ok := oldEnumV[enumValue.Key]; !ok {
-				// Key does not appear in old enum values, so we'll add it
-				actions = append(
-					actions,
-					platform.ProductTypeAddPlainEnumValueAction{
-						AttributeName: name,
-						Value:         enumType.Values[i],
-					})
-			}
-		}
-
-		return actions
-		// Action: changePlainEnumValueOrder
-		// TODO: Change the order of EnumValues: https://docs.commercetools.com/http-api-projects-productTypes.html#change-the-order-of-enumvalues
-
-	}
-
-	if enumType, ok := newFieldType.(platform.AttributeLocalizedEnumType); ok {
-		oldEnumV := oldFieldType["localized_value"].([]interface{})
-
-		for _, value := range oldEnumV {
-			v := value.(map[string]interface{})
-			oldEnumKeys[v["key"].(string)] = v
-		}
-
-		for i, enumValue := range enumType.Values {
-			newEnumKeys[enumValue.Key] = enumValue
-			if _, ok := oldEnumKeys[enumValue.Key]; !ok {
-				// Key does not appear in old enum values, so we'll add it
-				actions = append(
-					actions,
-					platform.ProductTypeAddLocalizedEnumValueAction{
-						AttributeName: name,
-						Value:         enumType.Values[i],
-					})
-			} else {
-				oldEnumValue := oldEnumKeys[enumValue.Key].(map[string]interface{})
-				oldLocalizedLabel := oldEnumValue["label"].(map[string]interface{})
-				labelChanged := !localizedStringCompare(enumValue.Label, oldLocalizedLabel)
-				if labelChanged {
-					actions = append(
-						actions,
-						platform.ProductTypeChangeLocalizedEnumValueLabelAction{
-							AttributeName: name,
-							NewValue:      enumType.Values[i],
-						})
-				}
-			}
-		}
-
-		return actions
-		// Action: changeLocalizedEnumValueOrder
-		// TODO: Change the order of LocalizedEnumValues: https://docs.commercetools.com/http-api-projects-productTypes.html#change-the-order-of-localizedenumvalues
-	}
-	return actions
-}
-
-func resourceProductTypeGetAttributeDefinitions(d *schema.ResourceData) ([]platform.AttributeDefinitionDraft, error) {
-	input := d.Get("attribute").([]interface{})
-	var result []platform.AttributeDefinitionDraft
-
-	for _, raw := range input {
-		fieldDef, err := resourceProductTypeGetAttributeDefinition(raw.(map[string]interface{}), true)
-
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, fieldDef.(platform.AttributeDefinitionDraft))
-	}
-
-	return result, nil
-}
-
-func resourceProductTypeGetAttributeDefinition(input map[string]interface{}, draft bool) (interface{}, error) {
-	attrTypes := input["type"].([]interface{})
-	attrType, err := getAttributeType(attrTypes[0])
-	if err != nil {
-		return nil, err
-	}
-
-	label := platform.LocalizedString(
-		expandStringMap(input["label"].(map[string]interface{})))
-
-	var inputTip platform.LocalizedString
-	if inputTipRaw, ok := input["input_tip"]; ok {
-		inputTip = platform.LocalizedString(
-			expandStringMap(inputTipRaw.(map[string]interface{})))
-	}
-
-	constraint := platform.AttributeConstraintEnumNone
-	constraint, ok := constraintMap[input["constraint"].(string)]
-	if !ok {
-		constraint = platform.AttributeConstraintEnumNone
-	}
-
-	inputHint := platform.TextInputHint(input["input_hint"].(string))
-	if draft {
-		return platform.AttributeDefinitionDraft{
-			Type:                attrType,
-			Name:                input["name"].(string),
-			Label:               label,
-			AttributeConstraint: &constraint,
-			IsRequired:          input["required"].(bool),
-			IsSearchable:        boolRef(input["searchable"]),
-			InputHint:           &inputHint,
-			InputTip:            &inputTip,
-		}, nil
-	}
-	return platform.AttributeDefinition{
-		Type:                attrType,
-		Name:                input["name"].(string),
-		Label:               label,
-		AttributeConstraint: constraint,
-		IsRequired:          input["required"].(bool),
-		IsSearchable:        input["searchable"].(bool),
-		InputHint:           inputHint,
-		InputTip:            &inputTip,
-	}, nil
-}
-
-func getAttributeType(input interface{}) (platform.AttributeType, error) {
-	config := input.(map[string]interface{})
-	typeName, ok := config["name"].(string)
-
-	if !ok {
-		return nil, fmt.Errorf("No 'name' for type object given")
-	}
-
-	switch typeName {
-	case "boolean":
-		return platform.AttributeBooleanType{}, nil
-	case "text":
-		return platform.AttributeTextType{}, nil
-	case "ltext":
-		return platform.AttributeLocalizableTextType{}, nil
-	case "enum":
-		valuesInput, valuesOk := config["values"].(map[string]interface{})
-		if !valuesOk {
-			return nil, fmt.Errorf("No values specified for Enum type: %+v", valuesInput)
-		}
-		var values []platform.AttributePlainEnumValue
-		for k, v := range valuesInput {
-			values = append(values, platform.AttributePlainEnumValue{
-				Key:   k,
-				Label: v.(string),
-			})
-		}
-		return platform.AttributeEnumType{Values: values}, nil
-	case "lenum":
-		valuesInput, valuesOk := config["localized_value"]
-		if !valuesOk {
-			return nil, fmt.Errorf("No localized_value elements specified for LocalizedEnum type")
-		}
-		var values []platform.AttributeLocalizedEnumValue
-		for _, value := range valuesInput.([]interface{}) {
-			v := value.(map[string]interface{})
-			labels := platform.LocalizedString(
-				expandStringMap(v["label"].(map[string]interface{})))
-
-			values = append(values, platform.AttributeLocalizedEnumValue{
-				Key:   v["key"].(string),
-				Label: labels,
-			})
-		}
-		log.Printf("[DEBUG] GetAttributeType localized enum values: %#v", values)
-		return platform.AttributeLocalizedEnumType{Values: values}, nil
-	case "number":
-		return platform.AttributeNumberType{}, nil
-	case "money":
-		return platform.AttributeMoneyType{}, nil
-	case "date":
-		return platform.AttributeDateType{}, nil
-	case "time":
-		return platform.AttributeTimeType{}, nil
-	case "datetime":
-		return platform.AttributeDateTimeType{}, nil
-	case "reference":
-		refTypeID, refTypeIDOk := config["reference_type_id"].(string)
-		if !refTypeIDOk {
-			return nil, fmt.Errorf("No reference_type_id specified for Reference type")
-		}
-		return platform.AttributeReferenceType{
-			ReferenceTypeId: platform.ReferenceTypeId(refTypeID),
-		}, nil
-	case "nested":
-		typeReference, typeReferenceOk := config["type_reference"].(string)
-		if !typeReferenceOk {
-			return nil, fmt.Errorf("No type_reference specified for Nested type")
-		}
-		return platform.AttributeNestedType{
-			TypeReference: platform.ProductTypeReference{ID: typeReference},
-		}, nil
-	case "set":
-		elementTypes, elementTypesOk := config["element_type"]
-		if !elementTypesOk {
-			return nil, fmt.Errorf("No element_type specified for Set type")
-		}
-		elementTypeList := elementTypes.([]interface{})
-		if len(elementTypeList) == 0 {
-			return nil, fmt.Errorf("No element_type specified for Set type")
-		}
-
-		setAttrType, err := getAttributeType(elementTypeList[0])
-		if err != nil {
-			return nil, err
-		}
-
-		return platform.AttributeSetType{
-			ElementType: setAttrType,
-		}, nil
-	}
-
-	return nil, fmt.Errorf("Unknown AttributeType %s", typeName)
-}
-
-func readAttributeLocalizedEnum(values []platform.AttributeLocalizedEnumValue) []interface{} {
-	enumValues := make([]interface{}, len(values))
-	for i, value := range values {
-		enumValues[i] = map[string]interface{}{
-			"key":   value.Key,
-			"label": value.Label,
-		}
-	}
-	log.Printf("[DEBUG] readLocalizedEnum values: %#v", enumValues)
-	return enumValues
-}
+// import (
+// 	"context"
+// 	"fmt"
+// 	"log"
+// 	"reflect"
+// 	"time"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
+
+// var constraintMap = map[string]platform.AttributeConstraintEnum{
+// 	"Unique":            platform.AttributeConstraintEnumUnique,
+// 	"CombinationUnique": platform.AttributeConstraintEnumCombinationUnique,
+// 	"SameForAll":        platform.AttributeConstraintEnumSameForAll,
+// 	"None":              platform.AttributeConstraintEnumNone,
+// }
+
+// func resourceProductType() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Product types are used to describe common characteristics, most importantly common custom " +
+// 			"attributes, of many concrete products. Please note: to customize other resources than products, " +
+// 			"please refer to resource_type.\n\n" +
+// 			"See also the [Product Type API Documentation](https://docs.commercetools.com/api/projects/productTypes)",
+// 		Create: resourceProductTypeCreate,
+// 		Read:   resourceProductTypeRead,
+// 		Update: resourceProductTypeUpdate,
+// 		Delete: resourceProductTypeDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"name": {
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"description": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"key": {
+// 				Description: "User-specific unique identifier for the product type (max. 256 characters)",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"attribute": {
+// 				Description: "[Product attribute fefinition](https://docs.commercetools.com/api/projects/productTypes#attributedefinition)",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Description: "[AttributeType](https://docs.commercetools.com/api/projects/productTypes#attributetype)",
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							MaxItems:    1,
+// 							Required:    true,
+// 							Elem:        attributeTypeElement(true),
+// 						},
+// 						"name": {
+// 							Description: "The unique name of the attribute used in the API. The name must be between " +
+// 								"two and 256 characters long and can contain the ASCII letters A to Z in lowercase or " +
+// 								"uppercase, digits, underscores (_) and the hyphen-minus (-).\n" +
+// 								"When using the same name for an attribute in two or more product types all fields " +
+// 								"of the AttributeDefinition of this attribute need to be the same across the product " +
+// 								"types, otherwise an AttributeDefinitionAlreadyExists error code will be returned. " +
+// 								"An exception to this are the values of an enum or lenum type and sets thereof",
+// 							Type:     types.StringType,
+// 							Required: true,
+// 						},
+// 						"label": {
+// 							Description: "A human-readable label for the attribute",
+// 							Type:        TypeLocalizedString,
+// 							Required:    true,
+// 						},
+// 						"required": {
+// 							Description: "Whether the attribute is required to have a value",
+// 							Type:        types.BoolType,
+// 							Optional:    true,
+// 							Default:     false,
+// 						},
+// 						"constraint": {
+// 							Description: "Describes how an attribute or a set of attributes should be validated " +
+// 								"across all variants of a product. " +
+// 								"See also [Attribute Constraint](https://docs.commercetools.com/api/projects/productTypes#attributeconstraint-enum)",
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 							Default:  platform.AttributeConstraintEnumNone,
+// 							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+// 								v := val.(string)
+
+// 								if _, ok := constraintMap[v]; !ok {
+// 									allowedConstraints := []string{}
+// 									for key := range constraintMap {
+// 										allowedConstraints = append(allowedConstraints, key)
+// 									}
+// 									errs = append(errs, fmt.Errorf(
+// 										"Unkown attribute constraint '%v'. Possible values are %v", v, allowedConstraints))
+// 								}
+// 								return
+// 							},
+// 						},
+// 						"input_tip": {
+// 							Description: "Additional information about the attribute that aids content managers " +
+// 								"when setting product details",
+// 							Type:     TypeLocalizedString,
+// 							Optional: true,
+// 						},
+// 						"input_hint": {
+// 							Description: "Provides a visual representation type for this attribute. " +
+// 								"only relevant for text-based attribute types like TextType and LocalizableTextType",
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 							Default:  platform.TextInputHintSingleLine,
+// 						},
+// 						"searchable": {
+// 							Description: "Whether the attribute's values should generally be activated in product search",
+// 							Type:        types.BoolType,
+// 							Optional:    true,
+// 							Default:     false,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 		CustomizeDiff: customdiff.All(
+// 			customdiff.ValidateChange("attribute", func(ctx context.Context, old, new, meta interface{}) error {
+// 				log.Printf("[DEBUG] Start attribute validation")
+// 				oldLookup := createLookup(old.([]interface{}), "name")
+// 				newV := new.([]interface{})
+
+// 				for _, field := range newV {
+// 					newF := field.(map[string]interface{})
+// 					name := newF["name"].(string)
+// 					oldF, ok := oldLookup[name].(map[string]interface{})
+// 					if !ok {
+// 						// It means this is a new field, that's ok.
+// 						log.Printf("[DEBUG] Found new attribute: %s", name)
+// 						continue
+// 					}
+
+// 					log.Printf("[DEBUG] Checking %s", oldF["name"])
+// 					oldType := oldF["type"].([]interface{})[0].(map[string]interface{})
+// 					newType := newF["type"].([]interface{})[0].(map[string]interface{})
+
+// 					if oldType["name"] != newType["name"] {
+// 						if oldType["name"] != "" || newType["name"] == "" {
+// 							continue
+// 						}
+// 						return fmt.Errorf(
+// 							"Field '%s' type changed from %s to %s. Changing types is not supported; please remove the attribute first and re-define it later",
+// 							name, oldType["name"], newType["name"])
+// 					}
+
+// 					if oldF["required"] != newF["required"] {
+// 						return fmt.Errorf(
+// 							"Error on the '%s' attribute: Updating the 'required' attribute is not supported. Consider removing the attribute first and then re-adding it",
+// 							name)
+// 					}
+// 				}
+// 				return nil
+// 			}),
+// 		),
+// 	}
+// }
+
+// func attributeTypeElement(setsAllowed bool) *schema.Resource {
+// 	result := map[string]*schema.Schema{
+// 		"name": {
+// 			Type:     types.StringType,
+// 			Required: true,
+// 			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+// 				v := val.(string)
+// 				if !setsAllowed && v == "set" {
+// 					errs = append(errs, fmt.Errorf("Sets in another Set are not allowed"))
+// 				}
+// 				return
+// 			},
+// 		},
+// 		"values": {
+// 			Type:     schema.TypeMap,
+// 			Optional: true,
+// 		},
+// 		"localized_value": {
+// 			Type:     types.ListType{ElemType: types.StringType},
+// 			Optional: true,
+// 			Elem:     localizedValueElement(),
+// 		},
+// 		"reference_type_id": {
+// 			Type:     types.StringType,
+// 			Optional: true,
+// 		},
+// 		"type_reference": {
+// 			Type:     types.StringType,
+// 			Optional: true,
+// 		},
+// 	}
+
+// 	if setsAllowed {
+// 		result["element_type"] = &schema.Schema{
+// 			Type:     types.ListType{ElemType: types.StringType},
+// 			MaxItems: 1,
+// 			Optional: true,
+// 			Elem:     attributeTypeElement(false),
+// 		}
+// 	}
+
+// 	return &schema.Resource{Schema: result}
+// }
+
+// func resourceProductTypeCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var ctType *platform.ProductType
+
+// 	attributes, err := resourceProductTypeGetAttributeDefinitions(d)
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	draft := platform.ProductTypeDraft{
+// 		Key:         stringRef(d.Get("key")),
+// 		Name:        d.Get("name").(string),
+// 		Description: d.Get("description").(string),
+// 		Attributes:  attributes,
+// 	}
+
+// 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
+
+// 		ctType, err = client.ProductTypes().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	if ctType == nil {
+// 		log.Fatal("No type created?")
+// 	}
+
+// 	d.SetId(ctType.ID)
+// 	d.Set("version", ctType.Version)
+
+// 	return resourceProductTypeRead(d, m)
+// }
+
+// func resourceProductTypeRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Print("[DEBUG] Reading product type from commercetools")
+// 	client := getClient(m)
+
+// 	ctType, err := client.ProductTypes().WithId(d.Id()).Get().Execute(context.Background())
+
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
+
+// 	if ctType == nil {
+// 		log.Print("[DEBUG] No product type found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Printf("[DEBUG] Found following product type: %#v", ctType)
+// 		log.Print(stringFormatObject(ctType))
+
+// 		attributes := make([]map[string]interface{}, len(ctType.Attributes))
+// 		for i, fieldDef := range ctType.Attributes {
+// 			fieldData := make(map[string]interface{})
+// 			log.Printf("[DEBUG] reading field: %s: %#v", fieldDef.Name, fieldDef)
+// 			fieldType, err := resourceProductTypeReadAttributeType(fieldDef.Type, true)
+// 			if err != nil {
+// 				return err
+// 			}
+
+// 			fieldData["type"] = fieldType
+// 			fieldData["name"] = fieldDef.Name
+// 			fieldData["label"] = fieldDef.Label
+// 			fieldData["required"] = fieldDef.IsRequired
+// 			fieldData["input_hint"] = fieldDef.InputHint
+// 			if fieldDef.InputTip != nil {
+// 				fieldData["input_tip"] = *fieldDef.InputTip
+// 			}
+// 			fieldData["constraint"] = fieldDef.AttributeConstraint
+// 			fieldData["searchable"] = fieldDef.IsSearchable
+
+// 			attributes[i] = fieldData
+// 		}
+
+// 		log.Printf("[DEBUG] Created attributes %#v", attributes)
+// 		d.Set("version", ctType.Version)
+// 		d.Set("key", ctType.Key)
+// 		d.Set("name", ctType.Name)
+// 		d.Set("description", ctType.Description)
+// 		err = d.Set("attribute", attributes)
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+// 	return nil
+// }
+
+// func resourceProductTypeReadAttributeType(attrType platform.AttributeType, setsAllowed bool) ([]interface{}, error) {
+// 	typeData := make(map[string]interface{})
+
+// 	if _, ok := attrType.(platform.AttributeBooleanType); ok {
+// 		typeData["name"] = "boolean"
+// 	} else if _, ok := attrType.(platform.AttributeTextType); ok {
+// 		typeData["name"] = "text"
+// 	} else if _, ok := attrType.(platform.AttributeLocalizableTextType); ok {
+// 		typeData["name"] = "ltext"
+// 	} else if f, ok := attrType.(platform.AttributeEnumType); ok {
+// 		enumValues := make(map[string]interface{}, len(f.Values))
+// 		for _, value := range f.Values {
+// 			enumValues[value.Key] = value.Label
+// 		}
+// 		typeData["name"] = "enum"
+// 		typeData["values"] = enumValues
+// 	} else if f, ok := attrType.(platform.AttributeLocalizedEnumType); ok {
+// 		typeData["name"] = "lenum"
+// 		typeData["localized_value"] = readAttributeLocalizedEnum(f.Values)
+// 	} else if _, ok := attrType.(platform.AttributeNumberType); ok {
+// 		typeData["name"] = "number"
+// 	} else if _, ok := attrType.(platform.AttributeMoneyType); ok {
+// 		typeData["name"] = "money"
+// 	} else if _, ok := attrType.(platform.AttributeDateType); ok {
+// 		typeData["name"] = "date"
+// 	} else if _, ok := attrType.(platform.AttributeTimeType); ok {
+// 		typeData["name"] = "time"
+// 	} else if _, ok := attrType.(platform.AttributeDateTimeType); ok {
+// 		typeData["name"] = "datetime"
+// 	} else if f, ok := attrType.(platform.AttributeReferenceType); ok {
+// 		typeData["name"] = "reference"
+// 		typeData["reference_type_id"] = f.ReferenceTypeId
+// 	} else if f, ok := attrType.(platform.AttributeNestedType); ok {
+// 		typeData["name"] = "nested"
+// 		typeData["type_reference"] = f.TypeReference.ID
+// 	} else if f, ok := attrType.(platform.AttributeSetType); ok {
+// 		typeData["name"] = "set"
+// 		if setsAllowed {
+// 			elemType, err := resourceProductTypeReadAttributeType(f.ElementType, false)
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			typeData["element_type"] = elemType
+// 		}
+// 	} else {
+// 		return nil, fmt.Errorf("Unknown resource Type %T", attrType)
+// 	}
+
+// 	return []interface{}{typeData}, nil
+// }
+
+// func resourceProductTypeUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+
+// 	input := platform.ProductTypeUpdate{
+// 		Version: d.Get("version").(int),
+// 		Actions: []platform.ProductTypeUpdateAction{},
+// 	}
+
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ProductTypeSetKeyAction{Key: &newKey})
+// 	}
+
+// 	if d.HasChange("name") {
+// 		newName := d.Get("name").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ProductTypeChangeNameAction{Name: newName})
+// 	}
+
+// 	if d.HasChange("description") {
+// 		newDescr := d.Get("description").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ProductTypeChangeDescriptionAction{Description: newDescr})
+// 	}
+
+// 	if d.HasChange("attribute") {
+// 		old, new := d.GetChange("attribute")
+// 		attributeChangeActions, err := resourceProductTypeAttributeChangeActions(
+// 			old.([]interface{}), new.([]interface{}))
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		input.Actions = append(input.Actions, attributeChangeActions...)
+// 	}
+
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
+
+// 	_, err := client.ProductTypes().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
+
+// 	return resourceProductTypeRead(d, m)
+// }
+
+// func resourceProductTypeDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.ProductTypes().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyProductTypesByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	return nil
+// }
+
+// func resourceProductTypeAttributeChangeActions(oldValues []interface{}, newValues []interface{}) ([]platform.ProductTypeUpdateAction, error) {
+// 	oldLookup := createLookup(oldValues, "name")
+// 	newLookup := createLookup(newValues, "name")
+// 	newAttrDefinitions := []platform.AttributeDefinition{}
+// 	actions := []platform.ProductTypeUpdateAction{}
+// 	checkAttributeOrder := true
+
+// 	for name := range oldLookup {
+// 		if _, ok := newLookup[name]; !ok {
+// 			log.Printf("[DEBUG] Attribute deleted: %s", name)
+// 			actions = append(actions, platform.ProductTypeRemoveAttributeDefinitionAction{Name: name})
+// 			checkAttributeOrder = false
+// 		}
+// 	}
+
+// 	for _, value := range newValues {
+// 		newV := value.(map[string]interface{})
+// 		name := newV["name"].(string)
+// 		oldValue, existingField := oldLookup[name]
+
+// 		var attrDef platform.AttributeDefinition
+// 		if output, err := resourceProductTypeGetAttributeDefinition(newV, false); err == nil {
+// 			attrDef = output.(platform.AttributeDefinition)
+// 		} else {
+// 			return nil, err
+// 		}
+
+// 		var attrDefDraft platform.AttributeDefinitionDraft
+// 		if output, err := resourceProductTypeGetAttributeDefinition(newV, true); err == nil {
+// 			attrDefDraft = output.(platform.AttributeDefinitionDraft)
+// 		} else {
+// 			return nil, err
+// 		}
+
+// 		newAttrDefinitions = append(newAttrDefinitions, attrDef)
+
+// 		if !existingField {
+// 			log.Printf("[DEBUG] Attribute added: %s", name)
+// 			actions = append(
+// 				actions,
+// 				platform.ProductTypeAddAttributeDefinitionAction{Attribute: attrDefDraft})
+// 			checkAttributeOrder = false
+// 			continue
+// 		}
+
+// 		oldV := oldValue.(map[string]interface{})
+// 		if !reflect.DeepEqual(oldV["label"], newV["label"]) {
+// 			actions = append(
+// 				actions,
+// 				platform.ProductTypeChangeLabelAction{
+// 					AttributeName: name, Label: attrDef.Label})
+// 		}
+// 		if oldV["name"] != newV["name"] {
+// 			actions = append(
+// 				actions,
+// 				platform.ProductTypeChangeAttributeNameAction{
+// 					AttributeName: name, NewAttributeName: attrDef.Name})
+// 		}
+// 		if oldV["searchable"] != newV["searchable"] {
+// 			actions = append(
+// 				actions,
+// 				platform.ProductTypeChangeIsSearchableAction{
+// 					AttributeName: name, IsSearchable: attrDef.IsSearchable})
+// 		}
+// 		if oldV["input_hint"] != newV["input_hint"] {
+// 			actions = append(
+// 				actions,
+// 				platform.ProductTypeChangeInputHintAction{
+// 					AttributeName: name, NewValue: attrDef.InputHint})
+// 		}
+// 		if !reflect.DeepEqual(oldV["input_tip"], newV["input_tip"]) {
+// 			actions = append(
+// 				actions,
+// 				platform.ProductTypeSetInputTipAction{
+// 					AttributeName: name,
+// 					InputTip:      attrDef.InputTip,
+// 				})
+// 		}
+// 		if oldV["constraint"] != newV["constraint"] {
+// 			actions = append(
+// 				actions,
+// 				platform.ProductTypeChangeAttributeConstraintAction{
+// 					AttributeName: name,
+// 					NewValue:      platform.AttributeConstraintEnumDraft(attrDef.AttributeConstraint),
+// 				})
+// 		}
+
+// 		newFieldType := attrDef.Type
+// 		oldFieldType := oldV["type"].([]interface{})[0].(map[string]interface{})
+// 		oldEnumKeys := make(map[string]interface{})
+// 		newEnumKeys := make(map[string]interface{})
+
+// 		actions = handleEnumTypeChanges(newFieldType, oldFieldType, newEnumKeys, actions, name, oldEnumKeys)
+
+// 		if enumType, ok := newFieldType.(platform.AttributeSetType); ok {
+
+// 			myOldFieldType := oldFieldType["element_type"].([]interface{})[0].(map[string]interface{})
+// 			actions = handleEnumTypeChanges(enumType.ElementType, myOldFieldType, newEnumKeys, actions, name, oldEnumKeys)
+
+// 			log.Printf("[DEBUG] Set detected: %s", name)
+// 			log.Print(len(myOldFieldType))
+// 		}
+
+// 		removeEnumKeys := []string{}
+// 		for key := range oldEnumKeys {
+// 			if _, ok := newEnumKeys[key]; !ok {
+// 				removeEnumKeys = append(removeEnumKeys, key)
+// 			}
+// 		}
+
+// 		if len(removeEnumKeys) > 0 {
+// 			actions = append(
+// 				actions,
+// 				platform.ProductTypeRemoveEnumValuesAction{
+// 					AttributeName: name,
+// 					Keys:          removeEnumKeys,
+// 				})
+// 		}
+
+// 	}
+
+// 	oldNames := make([]string, len(oldValues))
+// 	newNames := make([]string, len(newValues))
+
+// 	for i, value := range oldValues {
+// 		v := value.(map[string]interface{})
+// 		oldNames[i] = v["name"].(string)
+// 	}
+// 	for i, value := range newValues {
+// 		v := value.(map[string]interface{})
+// 		newNames[i] = v["name"].(string)
+// 	}
+
+// 	if checkAttributeOrder && !reflect.DeepEqual(oldNames, newNames) {
+// 		actions = append(
+// 			actions,
+// 			platform.ProductTypeChangeAttributeOrderAction{
+// 				Attributes: newAttrDefinitions,
+// 			})
+// 	}
+
+// 	log.Printf("[DEBUG] Construction Attribute change actions")
+
+// 	return actions, nil
+// }
+
+// func handleEnumTypeChanges(newFieldType platform.AttributeType, oldFieldType map[string]interface{}, newEnumKeys map[string]interface{}, actions []platform.ProductTypeUpdateAction, name string, oldEnumKeys map[string]interface{}) []platform.ProductTypeUpdateAction {
+// 	if enumType, ok := newFieldType.(platform.AttributeEnumType); ok {
+// 		oldEnumV := oldFieldType["values"].(map[string]interface{})
+
+// 		for i, enumValue := range enumType.Values {
+// 			newEnumKeys[enumValue.Key] = enumValue
+// 			if _, ok := oldEnumV[enumValue.Key]; !ok {
+// 				// Key does not appear in old enum values, so we'll add it
+// 				actions = append(
+// 					actions,
+// 					platform.ProductTypeAddPlainEnumValueAction{
+// 						AttributeName: name,
+// 						Value:         enumType.Values[i],
+// 					})
+// 			}
+// 		}
+
+// 		return actions
+// 		// Action: changePlainEnumValueOrder
+// 		// TODO: Change the order of EnumValues: https://docs.commercetools.com/http-api-projects-productTypes.html#change-the-order-of-enumvalues
+
+// 	}
+
+// 	if enumType, ok := newFieldType.(platform.AttributeLocalizedEnumType); ok {
+// 		oldEnumV := oldFieldType["localized_value"].([]interface{})
+
+// 		for _, value := range oldEnumV {
+// 			v := value.(map[string]interface{})
+// 			oldEnumKeys[v["key"].(string)] = v
+// 		}
+
+// 		for i, enumValue := range enumType.Values {
+// 			newEnumKeys[enumValue.Key] = enumValue
+// 			if _, ok := oldEnumKeys[enumValue.Key]; !ok {
+// 				// Key does not appear in old enum values, so we'll add it
+// 				actions = append(
+// 					actions,
+// 					platform.ProductTypeAddLocalizedEnumValueAction{
+// 						AttributeName: name,
+// 						Value:         enumType.Values[i],
+// 					})
+// 			} else {
+// 				oldEnumValue := oldEnumKeys[enumValue.Key].(map[string]interface{})
+// 				oldLocalizedLabel := oldEnumValue["label"].(map[string]interface{})
+// 				labelChanged := !localizedStringCompare(enumValue.Label, oldLocalizedLabel)
+// 				if labelChanged {
+// 					actions = append(
+// 						actions,
+// 						platform.ProductTypeChangeLocalizedEnumValueLabelAction{
+// 							AttributeName: name,
+// 							NewValue:      enumType.Values[i],
+// 						})
+// 				}
+// 			}
+// 		}
+
+// 		return actions
+// 		// Action: changeLocalizedEnumValueOrder
+// 		// TODO: Change the order of LocalizedEnumValues: https://docs.commercetools.com/http-api-projects-productTypes.html#change-the-order-of-localizedenumvalues
+// 	}
+// 	return actions
+// }
+
+// func resourceProductTypeGetAttributeDefinitions(d *schema.ResourceData) ([]platform.AttributeDefinitionDraft, error) {
+// 	input := d.Get("attribute").([]interface{})
+// 	var result []platform.AttributeDefinitionDraft
+
+// 	for _, raw := range input {
+// 		fieldDef, err := resourceProductTypeGetAttributeDefinition(raw.(map[string]interface{}), true)
+
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		result = append(result, fieldDef.(platform.AttributeDefinitionDraft))
+// 	}
+
+// 	return result, nil
+// }
+
+// func resourceProductTypeGetAttributeDefinition(input map[string]interface{}, draft bool) (interface{}, error) {
+// 	attrTypes := input["type"].([]interface{})
+// 	attrType, err := getAttributeType(attrTypes[0])
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	label := platform.LocalizedString(
+// 		expandStringMap(input["label"].(map[string]interface{})))
+
+// 	var inputTip platform.LocalizedString
+// 	if inputTipRaw, ok := input["input_tip"]; ok {
+// 		inputTip = platform.LocalizedString(
+// 			expandStringMap(inputTipRaw.(map[string]interface{})))
+// 	}
+
+// 	constraint := platform.AttributeConstraintEnumNone
+// 	constraint, ok := constraintMap[input["constraint"].(string)]
+// 	if !ok {
+// 		constraint = platform.AttributeConstraintEnumNone
+// 	}
+
+// 	inputHint := platform.TextInputHint(input["input_hint"].(string))
+// 	if draft {
+// 		return platform.AttributeDefinitionDraft{
+// 			Type:                attrType,
+// 			Name:                input["name"].(string),
+// 			Label:               label,
+// 			AttributeConstraint: &constraint,
+// 			IsRequired:          input["required"].(bool),
+// 			IsSearchable:        boolRef(input["searchable"]),
+// 			InputHint:           &inputHint,
+// 			InputTip:            &inputTip,
+// 		}, nil
+// 	}
+// 	return platform.AttributeDefinition{
+// 		Type:                attrType,
+// 		Name:                input["name"].(string),
+// 		Label:               label,
+// 		AttributeConstraint: constraint,
+// 		IsRequired:          input["required"].(bool),
+// 		IsSearchable:        input["searchable"].(bool),
+// 		InputHint:           inputHint,
+// 		InputTip:            &inputTip,
+// 	}, nil
+// }
+
+// func getAttributeType(input interface{}) (platform.AttributeType, error) {
+// 	config := input.(map[string]interface{})
+// 	typeName, ok := config["name"].(string)
+
+// 	if !ok {
+// 		return nil, fmt.Errorf("No 'name' for type object given")
+// 	}
+
+// 	switch typeName {
+// 	case "boolean":
+// 		return platform.AttributeBooleanType{}, nil
+// 	case "text":
+// 		return platform.AttributeTextType{}, nil
+// 	case "ltext":
+// 		return platform.AttributeLocalizableTextType{}, nil
+// 	case "enum":
+// 		valuesInput, valuesOk := config["values"].(map[string]interface{})
+// 		if !valuesOk {
+// 			return nil, fmt.Errorf("No values specified for Enum type: %+v", valuesInput)
+// 		}
+// 		var values []platform.AttributePlainEnumValue
+// 		for k, v := range valuesInput {
+// 			values = append(values, platform.AttributePlainEnumValue{
+// 				Key:   k,
+// 				Label: v.(string),
+// 			})
+// 		}
+// 		return platform.AttributeEnumType{Values: values}, nil
+// 	case "lenum":
+// 		valuesInput, valuesOk := config["localized_value"]
+// 		if !valuesOk {
+// 			return nil, fmt.Errorf("No localized_value elements specified for LocalizedEnum type")
+// 		}
+// 		var values []platform.AttributeLocalizedEnumValue
+// 		for _, value := range valuesInput.([]interface{}) {
+// 			v := value.(map[string]interface{})
+// 			labels := platform.LocalizedString(
+// 				expandStringMap(v["label"].(map[string]interface{})))
+
+// 			values = append(values, platform.AttributeLocalizedEnumValue{
+// 				Key:   v["key"].(string),
+// 				Label: labels,
+// 			})
+// 		}
+// 		log.Printf("[DEBUG] GetAttributeType localized enum values: %#v", values)
+// 		return platform.AttributeLocalizedEnumType{Values: values}, nil
+// 	case "number":
+// 		return platform.AttributeNumberType{}, nil
+// 	case "money":
+// 		return platform.AttributeMoneyType{}, nil
+// 	case "date":
+// 		return platform.AttributeDateType{}, nil
+// 	case "time":
+// 		return platform.AttributeTimeType{}, nil
+// 	case "datetime":
+// 		return platform.AttributeDateTimeType{}, nil
+// 	case "reference":
+// 		refTypeID, refTypeIDOk := config["reference_type_id"].(string)
+// 		if !refTypeIDOk {
+// 			return nil, fmt.Errorf("No reference_type_id specified for Reference type")
+// 		}
+// 		return platform.AttributeReferenceType{
+// 			ReferenceTypeId: platform.ReferenceTypeId(refTypeID),
+// 		}, nil
+// 	case "nested":
+// 		typeReference, typeReferenceOk := config["type_reference"].(string)
+// 		if !typeReferenceOk {
+// 			return nil, fmt.Errorf("No type_reference specified for Nested type")
+// 		}
+// 		return platform.AttributeNestedType{
+// 			TypeReference: platform.ProductTypeReference{ID: typeReference},
+// 		}, nil
+// 	case "set":
+// 		elementTypes, elementTypesOk := config["element_type"]
+// 		if !elementTypesOk {
+// 			return nil, fmt.Errorf("No element_type specified for Set type")
+// 		}
+// 		elementTypeList := elementTypes.([]interface{})
+// 		if len(elementTypeList) == 0 {
+// 			return nil, fmt.Errorf("No element_type specified for Set type")
+// 		}
+
+// 		setAttrType, err := getAttributeType(elementTypeList[0])
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		return platform.AttributeSetType{
+// 			ElementType: setAttrType,
+// 		}, nil
+// 	}
+
+// 	return nil, fmt.Errorf("Unknown AttributeType %s", typeName)
+// }
+
+// func readAttributeLocalizedEnum(values []platform.AttributeLocalizedEnumValue) []interface{} {
+// 	enumValues := make([]interface{}, len(values))
+// 	for i, value := range values {
+// 		enumValues[i] = map[string]interface{}{
+// 			"key":   value.Key,
+// 			"label": value.Label,
+// 		}
+// 	}
+// 	log.Printf("[DEBUG] readLocalizedEnum values: %#v", enumValues)
+// 	return enumValues
+// }

--- a/commercetools/resource_product_type_test.go
+++ b/commercetools/resource_product_type_test.go
@@ -1,370 +1,370 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/labd/commercetools-go-sdk/platform"
-	"github.com/stretchr/testify/assert"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// 	"github.com/stretchr/testify/assert"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAttributeTypeElement(t *testing.T) {
-	elem := attributeTypeElement(true)
-	elemType, ok := elem.Schema["element_type"]
+// func TestAttributeTypeElement(t *testing.T) {
+// 	elem := attributeTypeElement(true)
+// 	elemType, ok := elem.Schema["element_type"]
 
-	if !ok {
-		t.Error("element_type does not appear in the Schema")
-	}
+// 	if !ok {
+// 		t.Error("element_type does not appear in the Schema")
+// 	}
 
-	elemTypeResource := elemType.Elem.(*schema.Resource)
+// 	elemTypeResource := elemType.Elem.(*schema.Resource)
 
-	// The element_type itself may not contain an 'element_type'.
-	// This is because we don't allow infinite nested 'Set' elements
-	if _, ok := elemTypeResource.Schema["name"]; !ok {
-		t.Error("element_type Schema does not contain 'name' field")
-	}
-	if _, ok := elemTypeResource.Schema["element_type"]; ok {
-		t.Error("element_type Schema should not include another 'element_type' field")
-	}
-}
+// 	// The element_type itself may not contain an 'element_type'.
+// 	// This is because we don't allow infinite nested 'Set' elements
+// 	if _, ok := elemTypeResource.Schema["name"]; !ok {
+// 		t.Error("element_type Schema does not contain 'name' field")
+// 	}
+// 	if _, ok := elemTypeResource.Schema["element_type"]; ok {
+// 		t.Error("element_type Schema should not include another 'element_type' field")
+// 	}
+// }
 
-func TestGetAttributeType(t *testing.T) {
-	// Test Boolean
-	input := map[string]interface{}{
-		"name": "boolean",
-	}
-	result, err := getAttributeType(input)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if _, ok := result.(platform.AttributeBooleanType); !ok {
-		t.Error("Expected Boolean type")
-	}
+// func TestGetAttributeType(t *testing.T) {
+// 	// Test Boolean
+// 	input := map[string]interface{}{
+// 		"name": "boolean",
+// 	}
+// 	result, err := getAttributeType(input)
+// 	if err != nil {
+// 		t.Errorf("Unexpected error: %s", err)
+// 	}
+// 	if _, ok := result.(platform.AttributeBooleanType); !ok {
+// 		t.Error("Expected Boolean type")
+// 	}
 
-	// Test Enum
-	input = map[string]interface{}{
-		"name": "enum",
-	}
-	_, err = getAttributeType(input)
-	if err == nil {
-		t.Error("No error returned while enum requires values")
-	}
-	input = map[string]interface{}{
-		"name": "enum",
-		"values": map[string]interface{}{
-			"value1": "Value 1",
-			"value2": "Value 2",
-		},
-	}
-	result, err = getAttributeType(input)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if field, ok := result.(platform.AttributeEnumType); ok {
-		assert.ElementsMatch(t, field.Values, []platform.AttributePlainEnumValue{
-			{Key: "value1", Label: "Value 1"},
-			{Key: "value2", Label: "Value 2"},
-		})
-	} else {
-		t.Error("Expected Enum type")
-	}
+// 	// Test Enum
+// 	input = map[string]interface{}{
+// 		"name": "enum",
+// 	}
+// 	_, err = getAttributeType(input)
+// 	if err == nil {
+// 		t.Error("No error returned while enum requires values")
+// 	}
+// 	input = map[string]interface{}{
+// 		"name": "enum",
+// 		"values": map[string]interface{}{
+// 			"value1": "Value 1",
+// 			"value2": "Value 2",
+// 		},
+// 	}
+// 	result, err = getAttributeType(input)
+// 	if err != nil {
+// 		t.Errorf("Unexpected error: %s", err)
+// 	}
+// 	if field, ok := result.(platform.AttributeEnumType); ok {
+// 		assert.ElementsMatch(t, field.Values, []platform.AttributePlainEnumValue{
+// 			{Key: "value1", Label: "Value 1"},
+// 			{Key: "value2", Label: "Value 2"},
+// 		})
+// 	} else {
+// 		t.Error("Expected Enum type")
+// 	}
 
-	// Test Reference
-	input = map[string]interface{}{
-		"name": "reference",
-	}
-	_, err = getAttributeType(input)
-	if err == nil {
-		t.Error("No error returned while Reference requires reference_type_id")
-	}
-	input = map[string]interface{}{
-		"name":              "reference",
-		"reference_type_id": "product",
-	}
-	result, err = getAttributeType(input)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if field, ok := result.(platform.AttributeReferenceType); ok {
-		assert.EqualValues(t, field.ReferenceTypeId, "product")
-	} else {
-		t.Error("Expected Reference type")
-	}
+// 	// Test Reference
+// 	input = map[string]interface{}{
+// 		"name": "reference",
+// 	}
+// 	_, err = getAttributeType(input)
+// 	if err == nil {
+// 		t.Error("No error returned while Reference requires reference_type_id")
+// 	}
+// 	input = map[string]interface{}{
+// 		"name":              "reference",
+// 		"reference_type_id": "product",
+// 	}
+// 	result, err = getAttributeType(input)
+// 	if err != nil {
+// 		t.Errorf("Unexpected error: %s", err)
+// 	}
+// 	if field, ok := result.(platform.AttributeReferenceType); ok {
+// 		assert.EqualValues(t, field.ReferenceTypeId, "product")
+// 	} else {
+// 		t.Error("Expected Reference type")
+// 	}
 
-	// Test Set
-	input = map[string]interface{}{
-		"name": "set",
-	}
-	_, err = getAttributeType(input)
-	if err == nil {
-		t.Error("No error returned while set requires element_type")
-	}
-}
+// 	// Test Set
+// 	input = map[string]interface{}{
+// 		"name": "set",
+// 	}
+// 	_, err = getAttributeType(input)
+// 	if err == nil {
+// 		t.Error("No error returned while set requires element_type")
+// 	}
+// }
 
-func TestAccProductTypes_basic(t *testing.T) {
-	name := "acctest_producttype"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckProductTypesDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccProductTypeConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "key", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "name", "Shipping info",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.0.label.en", "Location",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.0.label.nl", "Locatie",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.0.type.0.name", "text",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.en", "Snack",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.nl", "maaltijd",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.0.label.en", "Breakfast",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.en", "Lunch",
-					),
-				),
-			},
-			{
-				Config: testAccProductTypeConfigLabelChange(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "key", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "name", "Shipping info",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.0.label.en", "Location change",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.en", "snack",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.nl", "nomnom",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.de", "happen",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.0.label.en", "Breakfast",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.en", "Lunch",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.0.label.de", "Frühstück",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.de", "Mittagessen",
-					),
-				),
-			},
-		},
-	})
-}
+// func TestAccProductTypes_basic(t *testing.T) {
+// 	name := "acctest_producttype"
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckProductTypesDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccProductTypeConfig(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "key", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "name", "Shipping info",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.#", "3",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.0.label.en", "Location",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.0.label.nl", "Locatie",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.0.type.0.name", "text",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.en", "Snack",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.nl", "maaltijd",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.0.label.en", "Breakfast",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.en", "Lunch",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccProductTypeConfigLabelChange(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "key", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "name", "Shipping info",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "description", "All things related shipping",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.#", "3",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.0.name", "location",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.0.label.en", "Location change",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.en", "snack",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.nl", "nomnom",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.1.type.0.localized_value.0.label.de", "happen",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.0.label.en", "Breakfast",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.en", "Lunch",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.0.label.de", "Frühstück",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_product_type.acctest_product_type", "attribute.2.type.0.element_type.0.localized_value.1.label.de", "Mittagessen",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccProductTypeConfigLabelChange(name string) string {
-	return fmt.Sprintf(`
-resource "commercetools_product_type" "acctest_product_type" {
-	key = "%s"
-	name = "Shipping info"
-	description = "All things related shipping"
+// func testAccProductTypeConfigLabelChange(name string) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_product_type" "acctest_product_type" {
+// 	key = "%s"
+// 	name = "Shipping info"
+// 	description = "All things related shipping"
 
-	attribute {
-		name = "location"
-		label = {
-			en = "Location change"
-			nl = "Locatie"
-		}
-		type {
-			name = "text"
-		}
-	}
+// 	attribute {
+// 		name = "location"
+// 		label = {
+// 			en = "Location change"
+// 			nl = "Locatie"
+// 		}
+// 		type {
+// 			name = "text"
+// 		}
+// 	}
 
-	attribute {
-		name = "meal"
-		label = {
-			en = "meal"
-			nl = "maaltijd"
-		}
+// 	attribute {
+// 		name = "meal"
+// 		label = {
+// 			en = "meal"
+// 			nl = "maaltijd"
+// 		}
 
-		type {
-			name = "lenum"
+// 		type {
+// 			name = "lenum"
 
-            localized_value {
-			  key = "snack"
+//             localized_value {
+// 			  key = "snack"
 
-			  label = {
-				en = "snack"
-				nl = "nomnom"
-				de = "happen"
-			  }
-			}
-		}
-	}
+// 			  label = {
+// 				en = "snack"
+// 				nl = "nomnom"
+// 				de = "happen"
+// 			  }
+// 			}
+// 		}
+// 	}
 
-	attribute {
-		name = "types"
-		label = {
-			en = "meal types"
-		}
+// 	attribute {
+// 		name = "types"
+// 		label = {
+// 			en = "meal types"
+// 		}
 
-		type {
-			name = "set"
-			element_type {
-				name = "lenum"
+// 		type {
+// 			name = "set"
+// 			element_type {
+// 				name = "lenum"
 
-				localized_value {
-				  key = "breakfast"
+// 				localized_value {
+// 				  key = "breakfast"
 
-				  label = {
-					en = "Breakfast"
-					de = "Frühstück"
-				  }
-				}
+// 				  label = {
+// 					en = "Breakfast"
+// 					de = "Frühstück"
+// 				  }
+// 				}
 
-				localized_value {
-				  key = "lunch"
+// 				localized_value {
+// 				  key = "lunch"
 
-				  label = {
-					en = "Lunch"
-					de = "Mittagessen"
-				  }
-				}
-			}
-		}
-	}
+// 				  label = {
+// 					en = "Lunch"
+// 					de = "Mittagessen"
+// 				  }
+// 				}
+// 			}
+// 		}
+// 	}
 
-}`, name)
-}
+// }`, name)
+// }
 
-func testAccProductTypeConfig(name string) string {
-	return fmt.Sprintf(`
-resource "commercetools_product_type" "acctest_product_type" {
-	key = "%s"
-	name = "Shipping info"
-	description = "All things related shipping"
+// func testAccProductTypeConfig(name string) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_product_type" "acctest_product_type" {
+// 	key = "%s"
+// 	name = "Shipping info"
+// 	description = "All things related shipping"
 
-	attribute {
-		name = "location"
-		label = {
-			en = "Location"
-			nl = "Locatie"
-		}
-		type {
-			name = "text"
-		}
-	}
+// 	attribute {
+// 		name = "location"
+// 		label = {
+// 			en = "Location"
+// 			nl = "Locatie"
+// 		}
+// 		type {
+// 			name = "text"
+// 		}
+// 	}
 
-	attribute {
-		name = "meal"
-		label = {
-			en = "meal"
-			nl = "maaltijd"
-		}
+// 	attribute {
+// 		name = "meal"
+// 		label = {
+// 			en = "meal"
+// 			nl = "maaltijd"
+// 		}
 
-		type {
-			name = "lenum"
+// 		type {
+// 			name = "lenum"
 
-			localized_value {
-			  key = "snack"
+// 			localized_value {
+// 			  key = "snack"
 
-			  label = {
-				en = "Snack"
-				nl = "maaltijd"
-			  }
-			}
-		}
-	}
+// 			  label = {
+// 				en = "Snack"
+// 				nl = "maaltijd"
+// 			  }
+// 			}
+// 		}
+// 	}
 
-	attribute {
-		name = "types"
-		label = {
-			en = "meal types"
-		}
+// 	attribute {
+// 		name = "types"
+// 		label = {
+// 			en = "meal types"
+// 		}
 
-		type {
-			name = "set"
-			element_type {
-				name = "lenum"
+// 		type {
+// 			name = "set"
+// 			element_type {
+// 				name = "lenum"
 
-				localized_value {
-				  key = "breakfast"
+// 				localized_value {
+// 				  key = "breakfast"
 
-				  label = {
-					en = "Breakfast"
-				  }
-				}
+// 				  label = {
+// 					en = "Breakfast"
+// 				  }
+// 				}
 
-				localized_value {
-				  key = "lunch"
+// 				localized_value {
+// 				  key = "lunch"
 
-				  label = {
-					en = "Lunch"
-				  }
-				}
-			}
-		}
-	}
-}`, name)
-}
+// 				  label = {
+// 					en = "Lunch"
+// 				  }
+// 				}
+// 			}
+// 		}
+// 	}
+// }`, name)
+// }
 
-func testAccCheckProductTypesDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckProductTypesDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_product_type" {
-			continue
-		}
-		response, err := client.ProductTypes().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("product type (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_product_type" {
+// 			continue
+// 		}
+// 		response, err := client.ProductTypes().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("product type (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -2,130 +2,122 @@ package commercetools
 
 import (
 	"context"
-	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/labd/commercetools-go-sdk/platform"
 )
 
-// TODO: A lot of fields are optional in this schema that are not optional in platform. When not set via terraform
-// commercetools simply sets the default values for these fields. This works but can be a little confusing. It is worth
-// considering whether to align the optional/required status of the fields in the provider with that of the API itself
-func resourceProjectSettings() *schema.Resource {
-	return &schema.Resource{
-		Description: "The project endpoint provides a limited set of information about settings and configuration of " +
-			"the project. Updating the settings is eventually consistent, it may take up to a minute before " +
-			"a change becomes fully active.\n\n" +
-			"See also the [Project Settings API Documentation](https://docs.commercetools.com/api/projects/project)",
-		Create: resourceProjectCreate,
-		Read:   resourceProjectRead,
-		Update: resourceProjectUpdate,
-		Delete: resourceProjectDelete,
-		Exists: resourceProjectExists,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    resourceProjectSettingsResourceV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: migrateResourceProjectSettingsStateV0toV1,
-				Version: 0,
-			},
-		},
-		Schema: map[string]*schema.Schema{
+type resourceProjectSettingsType struct{}
+
+// // TODO: A lot of fields are optional in this schema that are not optional in platform. When not set via terraform
+// // commercetools simply sets the default values for these fields. This works but can be a little confusing. It is worth
+// // considering whether to align the optional/required status of the fields in the provider with that of the API itself
+func (r resourceProjectSettingsType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+
+		// Description: "The project endpoint provides a limited set of information about settings and configuration of " +
+		// 	"the project. Updating the settings is eventually consistent, it may take up to a minute before " +
+		// 	"a change becomes fully active.\n\n" +
+		// 	"See also the [Project Settings API Documentation](https://docs.commercetools.com/api/projects/project)",
+		// Create: resourceProjectCreate,
+		// Read:   resourceProjectRead,
+		// Update: resourceProjectUpdate,
+		// Delete: resourceProjectDelete,
+		// Exists: resourceProjectExists,
+		// Importer: &schema.ResourceImporter{
+		// 	State: schema.ImportStatePassthrough,
+		// },
+		// SchemaVersion: 1,
+		// StateUpgraders: []schema.StateUpgrader{
+		// 	{
+		// 		Type:    resourceProjectSettingsResourceV0().CoreConfigSchema().ImpliedType(),
+		// 		Upgrade: migrateResourceProjectSettingsStateV0toV1,
+		// 		Version: 0,
+		// 	},
+		// },
+		Attributes: map[string]tfsdk.Attribute{
 			"key": {
 				Description: "The unique key of the project",
-				Type:        schema.TypeString,
+				Type:        types.StringType,
 				Computed:    true,
 			},
 			"name": {
 				Description: "The name of the project",
-				Type:        schema.TypeString,
+				Type:        types.StringType,
 				Optional:    true,
 			},
 			"currencies": {
 				Description: "A three-digit currency code as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
-				Type:        schema.TypeList,
+				Type:        types.ListType{ElemType: types.StringType},
 				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"countries": {
 				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
-				Type:        schema.TypeList,
+				Type:        types.ListType{ElemType: types.StringType},
 				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"languages": {
 				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
-				Type:        schema.TypeList,
+				Type:        types.ListType{ElemType: types.StringType},
 				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"messages": {
 				Description: "[Messages Configuration](https://docs.commercetools.com/api/projects/project#messages-configuration)",
-				Type:        schema.TypeList,
-				MaxItems:    1,
 				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Description: "When true the creation of messages on the Messages Query HTTP API is enabled",
-							Type:        schema.TypeBool,
-							Required:    true,
-						},
+				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+					"enabled": {
+						Description: "When true the creation of messages on the Messages Query HTTP API is enabled",
+						Type:        types.BoolType,
+						Required:    true,
 					},
-				},
+				}),
 			},
 			"external_oauth": {
 				Description: "[External OAUTH](https://docs.commercetools.com/api/projects/project#externaloauth)",
-				Type:        schema.TypeList,
-				MaxItems:    1,
+				Type:        types.ListType{ElemType: types.StringType},
 				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"url": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"authorization_header": {
-							Description: "Partially hidden on retrieval",
-							Type:        schema.TypeString,
-							Required:    true,
-						},
+				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+					"url": {
+						Type:     types.StringType,
+						Required: true,
 					},
-				},
+					"authorization_header": {
+						Description: "Partially hidden on retrieval",
+						Type:        types.StringType,
+						Required:    true,
+					},
+				}),
 			},
 			"carts": {
 				Description: "[Carts Configuration](https://docs.commercetools.com/api/projects/project#carts-configuration)",
-				Type:        schema.TypeList,
-				MaxItems:    1,
+				Type:        types.ListType{ElemType: types.StringType},
 				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"country_tax_rate_fallback_enabled": {
-							Description: "Indicates if country - no state tax rate fallback should be used when a " +
-								"shipping address state is not explicitly covered in the rates lists of all tax " +
-								"categories of a cart line items",
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						"delete_days_after_last_modification": {
-							Description: "Number - Optional The default value for the " +
-								"deleteDaysAfterLastModification parameter of the CartDraft. Initially set to 90 for " +
-								"projects created after December 2019.",
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
+				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+					"country_tax_rate_fallback_enabled": {
+						Description: "Indicates if country - no state tax rate fallback should be used when a " +
+							"shipping address state is not explicitly covered in the rates lists of all tax " +
+							"categories of a cart line items",
+						Type:     types.BoolType,
+						Required: true,
 					},
-				},
+					"delete_days_after_last_modification": {
+						Description: "Number - Optional The default value for the " +
+							"deleteDaysAfterLastModification parameter of the CartDraft. Initially set to 90 for " +
+							"projects created after December 2019.",
+						Type:     types.Int64Type,
+						Optional: true,
+					},
+				}),
 			},
 			"shipping_rate_input_type": {
 				Description: "Three ways to dynamically select a ShippingRatePriceTier exist. The CartValue type uses " +
 					"the sum of all line item prices, whereas CartClassification and CartScore use the " +
 					"shippingRateInput field on the cart to select a tier",
-				Type:     schema.TypeString,
+				Type:     types.StringType,
 				Optional: true,
 			},
 			"shipping_rate_cart_classification_value": {
@@ -133,268 +125,503 @@ func resourceProjectSettings() *schema.Resource {
 					"tiers\n. Only a key defined inside the values array can be used to create a tier, or to set a value " +
 					"for the shippingRateInput on the cart. The keys are checked for uniqueness and the request is " +
 					"rejected if keys are not unique",
-				Type:     schema.TypeList,
+				Type:     types.ListType{ElemType: types.StringType},
 				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"label": {
-							Type:     TypeLocalizedString,
-							Optional: true,
-						},
+				Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+					"key": {
+						Type:     types.StringType,
+						Required: true,
 					},
-				},
+					"label": {
+						Type:     TypeLocalizedString(),
+						Optional: true,
+					},
+				}, tfsdk.ListNestedAttributesOptions{}),
 			},
 			"version": {
-				Type:     schema.TypeInt,
+				Type:     types.Int64Type,
 				Computed: true,
 			},
 		},
-	}
+	}, nil
 }
 
-func resourceProjectExists(d *schema.ResourceData, m interface{}) (bool, error) {
-	client := getClient(m)
+type ProjectSettings struct {
+	Key           types.String                 `tfsdk:"key"`
+	Name          types.String                 `tfsdk:"name"`
+	Version       types.Int64                  `tfsdk:"version"`
+	Currencies    []types.String               `tfsdk:"currencies"`
+	Countries     []types.String               `tfsdk:"countries"`
+	Languages     []types.String               `tfsdk:"languages"`
+	Message       ProjectSettingsMessage       `tfsdk:"messages"`
+	ExternalOAuth ProjectSettingsExternalOAuth `tfsdk:"external_oauth"`
+}
 
-	_, err := client.Get().Execute(context.Background())
+type ProjectSettingsMessage struct {
+	Enabled types.Bool `tfsdk:"enabled"`
+}
+
+type ProjectSettingsExternalOAuth struct {
+	URL                 types.String `tfsdk:"url"`
+	AuthorizationHeader types.String `tfsdk:"authorization_header"`
+}
+
+// New resource instance
+func (r resourceProjectSettingsType) NewResource(_ context.Context, p tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+	return resourceProjectSettings{
+		p: *(p.(*provider)),
+	}, nil
+}
+
+type resourceProjectSettings struct {
+	p provider
+}
+
+// func resourceProjectExists(d *schema.ResourceData, m interface{}) (bool, error) {
+// 	client := getClient(m)
+
+// 	_, err := client.Get().Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				return false, nil
+// 			}
+// 		}
+// 		return false, err
+// 	}
+// 	return true, nil
+// }
+
+func (r resourceProjectSettings) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+	if !r.p.configured {
+		resp.Diagnostics.AddError(
+			"Provider not configured",
+			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
+		)
+		return
+	}
+
+	// Retrieve values from plan
+	var plan ProjectSettings
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	project, err := r.p.client.Get().Execute(context.Background())
+
 	if err != nil {
 		if ctErr, ok := err.(platform.ErrorResponse); ok {
 			if ctErr.StatusCode == 404 {
-				return false, nil
+				return
 			}
 		}
-		return false, err
+
+		resp.Diagnostics.AddError("Unable to retrieve project settings", err.Error())
+		return
 	}
-	return true, nil
+
+	err = r.projectUpdate(&plan, project)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	return resourceProjectRead(d, m)
 }
 
-func resourceProjectCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	project, err := client.Get().Execute(context.Background())
-
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				return nil
-			}
-		}
-		return err
-	}
-
-	err = projectUpdate(d, client, project.Version)
-	if err != nil {
-		return err
-	}
-	return resourceProjectRead(d, m)
-}
-
-func resourceProjectRead(d *schema.ResourceData, m interface{}) error {
+func (r resourceProjectSettings) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
 	log.Print("[DEBUG] Reading projects from commercetools")
-	client := getClient(m)
+	var state ProjectSettings
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	project, err := client.Get().Execute(context.Background())
+	project, err := r.p.client.Get().Execute(context.Background())
 
 	if err != nil {
 		if ctErr, ok := err.(platform.ErrorResponse); ok {
 			if ctErr.StatusCode == 404 {
-				return nil
+				return
 			}
 		}
-		return err
+		resp.Diagnostics.AddError("Unable to retrieve project settings", err.Error())
 	}
 
 	log.Print("[DEBUG] Found the following project:")
 	log.Print(stringFormatObject(project))
 
-	d.SetId(project.Key)
-	d.Set("version", project.Version)
-	d.Set("name", project.Name)
-	d.Set("currencies", project.Currencies)
-	d.Set("countries", project.Countries)
-	d.Set("languages", project.Languages)
-	d.Set("shipping_rate_input_type", marshallProjectShippingRateInputType(project.ShippingRateInputType))
-	d.Set("external_oauth", marshallProjectExternalOAuth(project.ExternalOAuth))
-	d.Set("carts", marshallProjectCarts(project.Carts))
-	d.Set("messages", marshallProjectMessages(project.Messages))
-	return nil
+	state = ProjectSettings{
+		Key:        types.String{Value: project.Key},
+		Version:    types.Int64{Value: int64(project.Version)},
+		Name:       types.String{Value: project.Name},
+		Countries:  transformStringSlice(project.Countries),
+		Currencies: transformStringSlice(project.Currencies),
+		Languages:  transformStringSlice(project.Languages),
+		ExternalOAuth: ProjectSettingsExternalOAuth{
+			URL:                 types.String{Value: project.ExternalOAuth.Url},
+			AuthorizationHeader: types.String{Value: project.ExternalOAuth.AuthorizationHeader},
+		},
+		Message: ProjectSettingsMessage{
+			Enabled: types.Bool{Value: project.Messages.Enabled},
+		},
+	}
+
+	// d.Set("shipping_rate_input_type", marshallProjectShippingRateInputType(project.ShippingRateInputType))
+	// d.Set("carts", marshallProjectCarts(project.Carts))
+
+	// Set state
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
-func resourceProjectUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	err := projectUpdate(d, client, version)
+func (r resourceProjectSettings) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+
+	var plan ProjectSettings
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state ProjectSettings
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	project, err := r.p.client.Get().Execute(context.Background())
 	if err != nil {
-		return err
+		resp.Diagnostics.AddError("Unable to retrieve project settings", err.Error())
 	}
-	return resourceProjectRead(d, m)
+
+	r.projectUpdate(&plan, project)
+
+	// Set state
+	// diags = resp.State.Set(ctx, result)
+	// resp.Diagnostics.Append(diags...)
+	// if resp.Diagnostics.HasError() {
+	// 	return
+	// }
+
+	// func resourceProjectDelete(d *schema.ResourceData, m interface{}) error {
+	// 	d.SetId("")
+	// 	return nil
 }
 
-func resourceProjectDelete(d *schema.ResourceData, m interface{}) error {
-	d.SetId("")
+func (r resourceProjectSettings) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+	// Simply remove resource from state since we cannot delete a project
+	resp.State.RemoveResource(ctx)
+}
+
+// Import resource
+func (r resourceProjectSettings) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+	// Save the import identifier in the key attribute
+	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("key"), req, resp)
+}
+
+func (r resourceProjectSettings) projectUpdate(plan *ProjectSettings, obj *platform.Project) error {
+	// input := platform.ProjectUpdate{
+	// 	Version: obj.Version,
+	// 	Actions: []platform.ProjectUpdateAction{},
+	// }
+
+	// if d.HasChange("name") {
+	// 	input.Actions = append(input.Actions, &platform.ProjectChangeNameAction{Name: d.Get("name").(string)})
+	// }
+
+	// if d.HasChange("currencies") {
+	// 	newCurrencies := []string{}
+	// 	for _, item := range getStringSlice(d, "currencies") {
+	// 		newCurrencies = append(newCurrencies, item)
+	// 	}
+
+	// 	input.Actions = append(
+	// 		input.Actions,
+	// 		&platform.ProjectChangeCurrenciesAction{Currencies: newCurrencies})
+	// }
+
+	// if d.HasChange("countries") {
+	// 	newCountries := []string{}
+	// 	for _, item := range getStringSlice(d, "countries") {
+	// 		newCountries = append(newCountries, item)
+	// 	}
+
+	// 	input.Actions = append(
+	// 		input.Actions,
+	// 		&platform.ProjectChangeCountriesAction{Countries: newCountries})
+	// }
+
+	// if d.HasChange("languages") {
+	// 	newLanguages := []string{}
+	// 	for _, item := range getStringSlice(d, "languages") {
+	// 		newLanguages = append(newLanguages, item)
+	// 	}
+	// 	input.Actions = append(
+	// 		input.Actions,
+	// 		&platform.ProjectChangeLanguagesAction{Languages: newLanguages})
+	// }
+
+	// if d.HasChange("messages") {
+	// 	messages, err := elementFromList(d, "messages")
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	if messages["enabled"] != nil {
+	// 		input.Actions = append(
+	// 			input.Actions,
+	// 			&platform.ProjectChangeMessagesEnabledAction{MessagesEnabled: messages["enabled"].(bool)})
+	// 	} else {
+	// 		// To commercetools this field is not optional, so when deleting we revert to the default: false:
+	// 		input.Actions = append(
+	// 			input.Actions,
+	// 			&platform.ProjectChangeMessagesEnabledAction{MessagesEnabled: false})
+	// 	}
+
+	// }
+
+	// if d.HasChange("shipping_rate_input_type") || d.HasChange("shipping_rate_cart_classification_value") {
+	// 	newShippingRateInputType, err := getShippingRateInputType(d)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	input.Actions = append(
+	// 		input.Actions,
+	// 		&platform.ProjectSetShippingRateInputTypeAction{ShippingRateInputType: &newShippingRateInputType})
+	// }
+
+	// if d.HasChange("external_oauth") {
+	// 	externalOAuth, err := elementFromList(d, "external_oauth")
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	if externalOAuth["url"] != nil && externalOAuth["authorization_header"] != nil {
+	// 		newExternalOAuth := platform.ExternalOAuth{
+	// 			Url:                 externalOAuth["url"].(string),
+	// 			AuthorizationHeader: externalOAuth["authorization_header"].(string),
+	// 		}
+	// 		input.Actions = append(
+	// 			input.Actions,
+	// 			&platform.ProjectSetExternalOAuthAction{ExternalOAuth: &newExternalOAuth})
+	// 	} else {
+	// 		input.Actions = append(input.Actions, &platform.ProjectSetExternalOAuthAction{ExternalOAuth: nil})
+	// 	}
+	// }
+
+	// if d.HasChange("carts") {
+	// 	carts, err := elementFromList(d, "carts")
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	fallbackEnabled := false
+	// 	if carts["country_tax_rate_fallback_enabled"] != nil {
+	// 		fallbackEnabled = carts["country_tax_rate_fallback_enabled"].(bool)
+	// 	}
+
+	// 	var deleteDaysAfterLastModification *int
+	// 	if carts["delete_days_after_last_modification"] != nil {
+	// 		val := carts["delete_days_after_last_modification"].(int)
+	// 		deleteDaysAfterLastModification = &val
+	// 	}
+
+	// 	input.Actions = append(
+	// 		input.Actions,
+	// 		&platform.ProjectChangeCartsConfiguration{
+	// 			CartsConfiguration: &platform.CartsConfiguration{
+	// 				CountryTaxRateFallbackEnabled:   boolRef(fallbackEnabled),
+	// 				DeleteDaysAfterLastModification: deleteDaysAfterLastModification,
+	// 			},
+	// 		})
+	// }
+
+	// _, err := client.Post(input).Execute(context.Background())
+	// return err
 	return nil
 }
 
-func projectUpdate(d *schema.ResourceData, client *platform.ByProjectKeyRequestBuilder, version int) error {
-	input := platform.ProjectUpdate{
-		Version: version,
-		Actions: []platform.ProjectUpdateAction{},
-	}
+// func getStringSlice(d *schema.ResourceData, field string) []string {
+// 	input := d.Get(field).([]interface{})
+// 	var currencyObjects []string
+// 	for _, raw := range input {
+// 		currencyObjects = append(currencyObjects, raw.(string))
+// 	}
 
-	if d.HasChange("name") {
-		input.Actions = append(input.Actions, &platform.ProjectChangeNameAction{Name: d.Get("name").(string)})
-	}
+// 	return currencyObjects
+// }
 
-	if d.HasChange("currencies") {
-		newCurrencies := []string{}
-		for _, item := range getStringSlice(d, "currencies") {
-			newCurrencies = append(newCurrencies, item)
-		}
+// func getShippingRateInputType(d *schema.ResourceData) (platform.ShippingRateInputType, error) {
+// 	switch d.Get("shipping_rate_input_type").(string) {
+// 	case "CartValue":
+// 		return platform.CartValueType{}, nil
+// 	case "CartScore":
+// 		return platform.CartScoreType{}, nil
+// 	case "CartClassification":
+// 		values, err := getCartClassificationValues(d)
+// 		if err != nil {
+// 			return "", fmt.Errorf("invalid cart classification value: %v, %w", values, err)
+// 		}
+// 		return platform.CartClassificationType{Values: values}, nil
+// 	default:
+// 		return "", fmt.Errorf("shipping rate input type %s not implemented", d.Get("shipping_rate_input_type").(string))
+// 	}
+// }
 
-		input.Actions = append(
-			input.Actions,
-			&platform.ProjectChangeCurrenciesAction{Currencies: newCurrencies})
-	}
+// func getCartClassificationValues(d *schema.ResourceData) ([]platform.CustomFieldLocalizedEnumValue, error) {
+// 	var values []platform.CustomFieldLocalizedEnumValue
+// 	data := d.Get("shipping_rate_cart_classification_value").([]interface{})
+// 	for _, item := range data {
+// 		itemMap := item.(map[string]interface{})
+// 		label := platform.LocalizedString(expandStringMap(itemMap["label"].(map[string]interface{})))
+// 		values = append(values, platform.CustomFieldLocalizedEnumValue{
+// 			Label: label,
+// 			Key:   itemMap["key"].(string),
+// 		})
+// 	}
+// 	return values, nil
+// }
 
-	if d.HasChange("countries") {
-		newCountries := []string{}
-		for _, item := range getStringSlice(d, "countries") {
-			newCountries = append(newCountries, item)
-		}
+// func marshallProjectCarts(val platform.CartsConfiguration) []map[string]interface{} {
+// 	return []map[string]interface{}{
+// 		{
+// 			"country_tax_rate_fallback_enabled":   val.CountryTaxRateFallbackEnabled,
+// 			"delete_days_after_last_modification": val.DeleteDaysAfterLastModification,
+// 		},
+// 	}
+// }
 
-		input.Actions = append(
-			input.Actions,
-			&platform.ProjectChangeCountriesAction{Countries: newCountries})
-	}
+// func marshallProjectExternalOAuth(val *platform.ExternalOAuth) []map[string]interface{} {
+// 	if val == nil {
+// 		return []map[string]interface{}{}
+// 	}
+// 	return []map[string]interface{}{
+// 		{
+// 			"url":                  val.Url,
+// 			"authorization_header": val.AuthorizationHeader,
+// 		},
+// 	}
+// }
 
-	if d.HasChange("languages") {
-		newLanguages := []string{}
-		for _, item := range getStringSlice(d, "languages") {
-			newLanguages = append(newLanguages, item)
-		}
-		input.Actions = append(
-			input.Actions,
-			&platform.ProjectChangeLanguagesAction{Languages: newLanguages})
-	}
+// func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) string {
+// 	switch val.(type) {
+// 	case platform.CartScoreType:
+// 		return "CartScore"
+// 	case platform.CartValueType:
+// 		return "CartValue"
+// 	case platform.CartClassificationType:
+// 		return "CartClassification"
+// 	}
+// 	return ""
+// }
 
-	if d.HasChange("messages") {
-		messages, err := elementFromList(d, "messages")
-		if err != nil {
-			return err
-		}
-		if messages["enabled"] != nil {
-			input.Actions = append(
-				input.Actions,
-				&platform.ProjectChangeMessagesEnabledAction{MessagesEnabled: messages["enabled"].(bool)})
-		} else {
-			// To commercetools this field is not optional, so when deleting we revert to the default: false:
-			input.Actions = append(
-				input.Actions,
-				&platform.ProjectChangeMessagesEnabledAction{MessagesEnabled: false})
-		}
+// func marshallProjectMessages(val platform.MessageConfiguration) []map[string]interface{} {
+// 	return []map[string]interface{}{
+// 		{
+// 			"enabled": val.Enabled,
+// 		},
+// 	}
+// }
 
-	}
+// func resourceProjectSettingsResourceV0() *schema.Resource {
+// 	return &schema.Resource{
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "The unique key of the project",
+// 				Type:        types.StringType,
+// 				Computed:    true,
+// 			},
+// 			"name": {
+// 				Description: "The name of the project",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"currencies": {
+// 				Description: "A three-digit currency code as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 			},
+// 			"countries": {
+// 				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 			},
+// 			"languages": {
+// 				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 			},
+// 			"messages": {
+// 				Description: "[Messages Configuration](https://docs.commercetools.com/api/projects/project#messages-configuration)",
+// 				Type:        schema.TypeMap,
+// 				Optional:    true,
+// 				Elem: &schema.Schema{
+// 					Type: types.BoolType,
+// 				},
+// 			},
+// 			"external_oauth": {
+// 				Description: "[External OAUTH](https://docs.commercetools.com/api/projects/project#externaloauth)",
+// 				Type:        schema.TypeMap,
+// 				Optional:    true,
+// 				Elem: &schema.Schema{
+// 					Type: types.StringType,
+// 				},
+// 			},
+// 			"carts": {
+// 				Description: "[Carts Configuration](https://docs.commercetools.com/api/projects/project#carts-configuration)",
+// 				Type:        schema.TypeMap,
+// 				Optional:    true,
+// 				Elem: &schema.Schema{
+// 					Type: types.StringType,
+// 				},
+// 			},
+// 			"shipping_rate_input_type": {
+// 				Description: "Three ways to dynamically select a ShippingRatePriceTier exist. The CartValue type uses " +
+// 					"the sum of all line item prices, whereas CartClassification and CartScore use the " +
+// 					"shippingRateInput field on the cart to select a tier",
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"shipping_rate_cart_classification_value": {
+// 				Description: "If shipping_rate_input_type is set to CartClassification these values are used to create " +
+// 					"tiers\n. Only a key defined inside the values array can be used to create a tier, or to set a value " +
+// 					"for the shippingRateInput on the cart. The keys are checked for uniqueness and the request is " +
+// 					"rejected if keys are not unique",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				Optional: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"key": {
+// 							Type:     types.StringType,
+// 							Required: true,
+// 						},
+// 						"label": {
+// 							Type:     TypeLocalizedString,
+// 							Optional: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-	if d.HasChange("shipping_rate_input_type") || d.HasChange("shipping_rate_cart_classification_value") {
-		newShippingRateInputType, err := getShippingRateInputType(d)
-		if err != nil {
-			return err
-		}
-		input.Actions = append(
-			input.Actions,
-			&platform.ProjectSetShippingRateInputTypeAction{ShippingRateInputType: &newShippingRateInputType})
-	}
-
-	if d.HasChange("external_oauth") {
-		externalOAuth, err := elementFromList(d, "external_oauth")
-		if err != nil {
-			return err
-		}
-		if externalOAuth["url"] != nil && externalOAuth["authorization_header"] != nil {
-			newExternalOAuth := platform.ExternalOAuth{
-				Url:                 externalOAuth["url"].(string),
-				AuthorizationHeader: externalOAuth["authorization_header"].(string),
-			}
-			input.Actions = append(
-				input.Actions,
-				&platform.ProjectSetExternalOAuthAction{ExternalOAuth: &newExternalOAuth})
-		} else {
-			input.Actions = append(input.Actions, &platform.ProjectSetExternalOAuthAction{ExternalOAuth: nil})
-		}
-	}
-
-	if d.HasChange("carts") {
-		carts, err := elementFromList(d, "carts")
-		if err != nil {
-			return err
-		}
-		fallbackEnabled := false
-		if carts["country_tax_rate_fallback_enabled"] != nil {
-			fallbackEnabled = carts["country_tax_rate_fallback_enabled"].(bool)
-		}
-
-		var deleteDaysAfterLastModification *int
-		if carts["delete_days_after_last_modification"] != nil {
-			val := carts["delete_days_after_last_modification"].(int)
-			deleteDaysAfterLastModification = &val
-		}
-
-		input.Actions = append(
-			input.Actions,
-			&platform.ProjectChangeCartsConfiguration{
-				CartsConfiguration: &platform.CartsConfiguration{
-					CountryTaxRateFallbackEnabled:   boolRef(fallbackEnabled),
-					DeleteDaysAfterLastModification: deleteDaysAfterLastModification,
-				},
-			})
-	}
-
-	_, err := client.Post(input).Execute(context.Background())
-	return err
-}
-
-func getStringSlice(d *schema.ResourceData, field string) []string {
-	input := d.Get(field).([]interface{})
-	var currencyObjects []string
-	for _, raw := range input {
-		currencyObjects = append(currencyObjects, raw.(string))
-	}
-
-	return currencyObjects
-}
-
-func getShippingRateInputType(d *schema.ResourceData) (platform.ShippingRateInputType, error) {
-	switch d.Get("shipping_rate_input_type").(string) {
-	case "CartValue":
-		return platform.CartValueType{}, nil
-	case "CartScore":
-		return platform.CartScoreType{}, nil
-	case "CartClassification":
-		values, err := getCartClassificationValues(d)
-		if err != nil {
-			return "", fmt.Errorf("invalid cart classification value: %v, %w", values, err)
-		}
-		return platform.CartClassificationType{Values: values}, nil
-	default:
-		return "", fmt.Errorf("shipping rate input type %s not implemented", d.Get("shipping_rate_input_type").(string))
-	}
-}
-
-func getCartClassificationValues(d *schema.ResourceData) ([]platform.CustomFieldLocalizedEnumValue, error) {
-	var values []platform.CustomFieldLocalizedEnumValue
-	data := d.Get("shipping_rate_cart_classification_value").([]interface{})
-	for _, item := range data {
-		itemMap := item.(map[string]interface{})
-		label := platform.LocalizedString(expandStringMap(itemMap["label"].(map[string]interface{})))
-		values = append(values, platform.CustomFieldLocalizedEnumValue{
-			Label: label,
-			Key:   itemMap["key"].(string),
-		})
-	}
-	return values, nil
-}
+// func migrateResourceProjectSettingsStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+// 	transformToList(rawState, "messages")
+// 	transformToList(rawState, "external_oauth")
+// 	transformToList(rawState, "carts")
+// 	return rawState, nil
+// }
 
 func marshallProjectCarts(val platform.CartsConfiguration) []map[string]interface{} {
 	if *val.CountryTaxRateFallbackEnabled == false && val.DeleteDaysAfterLastModification == nil {
@@ -408,133 +635,4 @@ func marshallProjectCarts(val platform.CartsConfiguration) []map[string]interfac
 		},
 	}
 	return result
-}
-
-func marshallProjectExternalOAuth(val *platform.ExternalOAuth) []map[string]interface{} {
-	if val == nil {
-		return []map[string]interface{}{}
-	}
-	return []map[string]interface{}{
-		{
-			"url":                  val.Url,
-			"authorization_header": val.AuthorizationHeader,
-		},
-	}
-}
-
-func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) string {
-	switch val.(type) {
-	case platform.CartScoreType:
-		return "CartScore"
-	case platform.CartValueType:
-		return "CartValue"
-	case platform.CartClassificationType:
-		return "CartClassification"
-	}
-	return ""
-}
-
-func marshallProjectMessages(val platform.MessageConfiguration) []map[string]interface{} {
-	return []map[string]interface{}{
-		{
-			"enabled": val.Enabled,
-		},
-	}
-}
-
-func resourceProjectSettingsResourceV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "The unique key of the project",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
-			"name": {
-				Description: "The name of the project",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"currencies": {
-				Description: "A three-digit currency code as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			"countries": {
-				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			"languages": {
-				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			"messages": {
-				Description: "[Messages Configuration](https://docs.commercetools.com/api/projects/project#messages-configuration)",
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeBool,
-				},
-			},
-			"external_oauth": {
-				Description: "[External OAUTH](https://docs.commercetools.com/api/projects/project#externaloauth)",
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"carts": {
-				Description: "[Carts Configuration](https://docs.commercetools.com/api/projects/project#carts-configuration)",
-				Type:        schema.TypeMap,
-				Optional:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"shipping_rate_input_type": {
-				Description: "Three ways to dynamically select a ShippingRatePriceTier exist. The CartValue type uses " +
-					"the sum of all line item prices, whereas CartClassification and CartScore use the " +
-					"shippingRateInput field on the cart to select a tier",
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"shipping_rate_cart_classification_value": {
-				Description: "If shipping_rate_input_type is set to CartClassification these values are used to create " +
-					"tiers\n. Only a key defined inside the values array can be used to create a tier, or to set a value " +
-					"for the shippingRateInput on the cart. The keys are checked for uniqueness and the request is " +
-					"rejected if keys are not unique",
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"label": {
-							Type:     TypeLocalizedString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
-
-func migrateResourceProjectSettingsStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	transformToList(rawState, "messages")
-	transformToList(rawState, "external_oauth")
-	transformToList(rawState, "carts")
-	return rawState, nil
 }

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -1,279 +1,279 @@
 package commercetools
 
-import (
-	"testing"
+// import (
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccProjectCreate_basic(t *testing.T) {
+// func TestAccProjectCreate_basic(t *testing.T) {
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckProjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccProjectConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "countries.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "currencies.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "languages.#", "4",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url", "https://example.com/oauth/token",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header", "Bearer secret",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartValue",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.delete_days_after_last_modification", "7"),
-				),
-			},
-			{
-				Config: testAccProjectConfigUpdate(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "countries.#", "4",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "currencies.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "languages.#", "5",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url", "https://new-example.com/oauth/token",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header", "Bearer new-secret",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartClassification",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.key", "Small",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.en", "Small",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.nl", "Klein",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.1.key", "Medium",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.1.label.en", "Medium",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.1.label.nl", "Middel",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.delete_days_after_last_modification", "21",
-					),
-				),
-			},
-			{
-				Config: testAccProjectConfigDeleteOAuthAndCarts(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing new",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "countries.#", "4",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "currencies.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "languages.#", "5",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "false",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartClassification",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.key", "Small",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.en", "Small",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.nl", "Klein",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled",
-					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.delete_days_after_last_modification",
-					),
-				),
-			},
-			// Running this step again so project settings match what later shipping_zone_rate_test will need
-			{
-				Config: testAccProjectConfig(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "countries.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "currencies.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "languages.#", "4",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url", "https://example.com/oauth/token",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header", "Bearer secret",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartValue",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled", "true",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckProjectDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccProjectConfig(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "countries.#", "3",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "currencies.#", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "languages.#", "4",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url", "https://example.com/oauth/token",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header", "Bearer secret",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartValue",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "carts.0.delete_days_after_last_modification", "7"),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccProjectConfigUpdate(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "countries.#", "4",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "currencies.#", "3",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "languages.#", "5",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "false",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url", "https://new-example.com/oauth/token",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header", "Bearer new-secret",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartClassification",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.#", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.key", "Small",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.en", "Small",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.nl", "Klein",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.1.key", "Medium",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.1.label.en", "Medium",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.1.label.nl", "Middel",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled", "false",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "carts.0.delete_days_after_last_modification", "21",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccProjectConfigDeleteOAuthAndCarts(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing new",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "countries.#", "4",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "currencies.#", "3",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "languages.#", "5",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "false",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartClassification",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.#", "1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.key", "Small",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.en", "Small",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.nl", "Klein",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled",
+// 					),
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "carts.0.delete_days_after_last_modification",
+// 					),
+// 				),
+// 			},
+// 			// Running this step again so project settings match what later shipping_zone_rate_test will need
+// 			{
+// 				Config: testAccProjectConfig(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "countries.#", "3",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "currencies.#", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "languages.#", "4",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url", "https://example.com/oauth/token",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header", "Bearer secret",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartValue",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled", "true",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccCheckProjectDestroy(s *terraform.State) error {
-	return nil
-}
+// func testAccCheckProjectDestroy(s *terraform.State) error {
+// 	return nil
+// }
 
-func testAccProjectConfig() string {
-	return `
-		resource "commercetools_project_settings" "acctest_project_settings" {
-			name       = "Test this thing"
-			countries  = ["NL", "DE", "US"]
-			currencies = ["EUR", "USD"]
-			languages  = ["nl", "de", "en", "en-US"]
+// func testAccProjectConfig() string {
+// 	return `
+// 		resource "commercetools_project_settings" "acctest_project_settings" {
+// 			name       = "Test this thing"
+// 			countries  = ["NL", "DE", "US"]
+// 			currencies = ["EUR", "USD"]
+// 			languages  = ["nl", "de", "en", "en-US"]
 
-			external_oauth {
-				url = "https://example.com/oauth/token"
-				authorization_header = "Bearer secret"
-			}
-			messages {
-			  enabled = true
-			}
+// 			external_oauth {
+// 				url = "https://example.com/oauth/token"
+// 				authorization_header = "Bearer secret"
+// 			}
+// 			messages {
+// 			  enabled = true
+// 			}
 
-			carts {
-              country_tax_rate_fallback_enabled = true
-              delete_days_after_last_modification = 7
-            }
+// 			carts {
+//               country_tax_rate_fallback_enabled = true
+//               delete_days_after_last_modification = 7
+//             }
 
-			shipping_rate_input_type = "CartValue"
-		}`
-}
+// 			shipping_rate_input_type = "CartValue"
+// 		}`
+// }
 
-func testAccProjectConfigUpdate() string {
-	return `
-		resource "commercetools_project_settings" "acctest_project_settings" {
-			name       = "Test this thing new"
-			countries  = ["NL", "DE", "US", "GB"]
-			currencies = ["EUR", "USD", "GBP"]
-			languages  = ["nl", "de", "en", "en-US", "fr"]
-			external_oauth {
-				url = "https://new-example.com/oauth/token"
-				authorization_header = "Bearer new-secret"
-			}
-			messages {
-			  enabled = false
-			}
+// func testAccProjectConfigUpdate() string {
+// 	return `
+// 		resource "commercetools_project_settings" "acctest_project_settings" {
+// 			name       = "Test this thing new"
+// 			countries  = ["NL", "DE", "US", "GB"]
+// 			currencies = ["EUR", "USD", "GBP"]
+// 			languages  = ["nl", "de", "en", "en-US", "fr"]
+// 			external_oauth {
+// 				url = "https://new-example.com/oauth/token"
+// 				authorization_header = "Bearer new-secret"
+// 			}
+// 			messages {
+// 			  enabled = false
+// 			}
 
-			carts {
-              country_tax_rate_fallback_enabled = false
-              delete_days_after_last_modification = 21
-            }
+// 			carts {
+//               country_tax_rate_fallback_enabled = false
+//               delete_days_after_last_modification = 21
+//             }
 
-            shipping_rate_input_type = "CartClassification"
-			shipping_rate_cart_classification_value {
-				key = "Small"
-				label = {
-					"en" = "Small"
-					"nl" = "Klein"
-				}
-			}
+//             shipping_rate_input_type = "CartClassification"
+// 			shipping_rate_cart_classification_value {
+// 				key = "Small"
+// 				label = {
+// 					"en" = "Small"
+// 					"nl" = "Klein"
+// 				}
+// 			}
 
-			shipping_rate_cart_classification_value {
-				key = "Medium"
-				label = {
-					"en" = "Medium"
-					"nl" = "Middel"
-				}
-			}
-		}`
-}
+// 			shipping_rate_cart_classification_value {
+// 				key = "Medium"
+// 				label = {
+// 					"en" = "Medium"
+// 					"nl" = "Middel"
+// 				}
+// 			}
+// 		}`
+// }
 
-func testAccProjectConfigDeleteOAuthAndCarts() string {
-	return `
-		resource "commercetools_project_settings" "acctest_project_settings" {
-			name       = "Test this thing new"
-			countries  = ["NL", "DE", "US", "GB"]
-			currencies = ["EUR", "USD", "GBP"]
-			languages  = ["nl", "de", "en", "en-US", "fr"]
-			messages {
-			  enabled = false
-			}
+// func testAccProjectConfigDeleteOAuthAndCarts() string {
+// 	return `
+// 		resource "commercetools_project_settings" "acctest_project_settings" {
+// 			name       = "Test this thing new"
+// 			countries  = ["NL", "DE", "US", "GB"]
+// 			currencies = ["EUR", "USD", "GBP"]
+// 			languages  = ["nl", "de", "en", "en-US", "fr"]
+// 			messages {
+// 			  enabled = false
+// 			}
 
-			shipping_rate_input_type = "CartClassification"
-			shipping_rate_cart_classification_value {
-				key = "Small"
-				label = {
-					"en" = "Small"
-					"nl" = "Klein"
-				}
-			}
-		}`
-}
+// 			shipping_rate_input_type = "CartClassification"
+// 			shipping_rate_cart_classification_value {
+// 				key = "Small"
+// 				label = {
+// 					"en" = "Small"
+// 					"nl" = "Klein"
+// 				}
+// 			}
+// 		}`
+// }

--- a/commercetools/resource_shipping_method.go
+++ b/commercetools/resource_shipping_method.go
@@ -1,248 +1,248 @@
 package commercetools
 
-import (
-	"context"
-	"log"
-	"time"
+// import (
+// 	"context"
+// 	"log"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceShippingMethod() *schema.Resource {
-	return &schema.Resource{
-		Description: "With Shipping Methods you can specify which shipping services you want to provide to your " +
-			"customers for deliveries to different areas of the world at rates you can define.\n\n" +
-			"See also the [Shipping Methods API Documentation](https://docs.commercetoolstools.com/api/projects/shippingMethods)",
-		Create: resourceShippingMethodCreate,
-		Read:   resourceShippingMethodRead,
-		Update: resourceShippingMethodUpdate,
-		Delete: resourceShippingMethodDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for the shipping method",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"localized_description": {
-				Description: "[LocalizedString](https://docs.commercetoolstools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"is_default": {
-				Description: "One shipping method in a project can be default",
-				Type:        schema.TypeBool,
-				Optional:    true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"tax_category_id": {
-				Description: "ID of a [Tax Category](https://docs.commercetoolstools.com/api/projects/taxCategories#taxcategory)",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"predicate": {
-				Description: "A Cart predicate which can be used to more precisely select a shipping method for a cart",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-		},
-	}
-}
+// func resourceShippingMethod() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "With Shipping Methods you can specify which shipping services you want to provide to your " +
+// 			"customers for deliveries to different areas of the world at rates you can define.\n\n" +
+// 			"See also the [Shipping Methods API Documentation](https://docs.commercetoolstools.com/api/projects/shippingMethods)",
+// 		Create: resourceShippingMethodCreate,
+// 		Read:   resourceShippingMethodRead,
+// 		Update: resourceShippingMethodUpdate,
+// 		Delete: resourceShippingMethodDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for the shipping method",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"name": {
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"description": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"localized_description": {
+// 				Description: "[LocalizedString](https://docs.commercetoolstools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"is_default": {
+// 				Description: "One shipping method in a project can be default",
+// 				Type:        types.BoolType,
+// 				Optional:    true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 			"tax_category_id": {
+// 				Description: "ID of a [Tax Category](https://docs.commercetoolstools.com/api/projects/taxCategories#taxcategory)",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"predicate": {
+// 				Description: "A Cart predicate which can be used to more precisely select a shipping method for a cart",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceShippingMethodCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var shippingMethod *platform.ShippingMethod
-	taxCategory := platform.TaxCategoryResourceIdentifier{}
-	if taxCategoryID, ok := d.GetOk("tax_category_id"); ok {
-		taxCategory.ID = stringRef(taxCategoryID)
-	}
+// func resourceShippingMethodCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var shippingMethod *platform.ShippingMethod
+// 	taxCategory := platform.TaxCategoryResourceIdentifier{}
+// 	if taxCategoryID, ok := d.GetOk("tax_category_id"); ok {
+// 		taxCategory.ID = stringRef(taxCategoryID)
+// 	}
 
-	localizedDescription := platform.LocalizedString(
-		expandStringMap(d.Get("localized_description").(map[string]interface{})))
+// 	localizedDescription := platform.LocalizedString(
+// 		expandStringMap(d.Get("localized_description").(map[string]interface{})))
 
-	draft := platform.ShippingMethodDraft{
-		Key:                  stringRef(d.Get("key")),
-		Name:                 d.Get("name").(string),
-		Description:          stringRef(d.Get("description")),
-		LocalizedDescription: &localizedDescription,
-		IsDefault:            d.Get("is_default").(bool),
-		TaxCategory:          taxCategory,
-		Predicate:            stringRef(d.Get("predicate")),
-	}
+// 	draft := platform.ShippingMethodDraft{
+// 		Key:                  stringRef(d.Get("key")),
+// 		Name:                 d.Get("name").(string),
+// 		Description:          stringRef(d.Get("description")),
+// 		LocalizedDescription: &localizedDescription,
+// 		IsDefault:            d.Get("is_default").(bool),
+// 		TaxCategory:          taxCategory,
+// 		Predicate:            stringRef(d.Get("predicate")),
+// 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
+// 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
 
-		shippingMethod, err = client.ShippingMethods().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		shippingMethod, err = client.ShippingMethods().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	if shippingMethod == nil {
-		log.Fatal("No shipping method created?")
-	}
+// 	if shippingMethod == nil {
+// 		log.Fatal("No shipping method created?")
+// 	}
 
-	d.SetId(shippingMethod.ID)
-	d.Set("version", shippingMethod.Version)
+// 	d.SetId(shippingMethod.ID)
+// 	d.Set("version", shippingMethod.Version)
 
-	return resourceShippingMethodRead(d, m)
-}
+// 	return resourceShippingMethodRead(d, m)
+// }
 
-func resourceShippingMethodRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Reading shipping method from commercetools, with shippingMethod id: %s", d.Id())
+// func resourceShippingMethodRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Printf("[DEBUG] Reading shipping method from commercetools, with shippingMethod id: %s", d.Id())
 
-	client := getClient(m)
+// 	client := getClient(m)
 
-	shippingMethod, err := client.ShippingMethods().WithId(d.Id()).Get().Execute(context.Background())
+// 	shippingMethod, err := client.ShippingMethods().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if shippingMethod == nil {
-		log.Print("[DEBUG] No shipping method found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following shipping method:")
-		log.Print(stringFormatObject(shippingMethod))
+// 	if shippingMethod == nil {
+// 		log.Print("[DEBUG] No shipping method found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following shipping method:")
+// 		log.Print(stringFormatObject(shippingMethod))
 
-		d.Set("version", shippingMethod.Version)
-		d.Set("key", shippingMethod.Key)
-		d.Set("name", shippingMethod.Name)
-		d.Set("description", shippingMethod.Description)
-		d.Set("localized_description", shippingMethod.LocalizedDescription)
-		d.Set("is_default", shippingMethod.IsDefault)
-		d.Set("tax_category_id", shippingMethod.TaxCategory.ID)
-		d.Set("predicate", shippingMethod.Predicate)
-	}
+// 		d.Set("version", shippingMethod.Version)
+// 		d.Set("key", shippingMethod.Key)
+// 		d.Set("name", shippingMethod.Name)
+// 		d.Set("description", shippingMethod.Description)
+// 		d.Set("localized_description", shippingMethod.LocalizedDescription)
+// 		d.Set("is_default", shippingMethod.IsDefault)
+// 		d.Set("tax_category_id", shippingMethod.TaxCategory.ID)
+// 		d.Set("predicate", shippingMethod.Predicate)
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func resourceShippingMethodUpdate(d *schema.ResourceData, m interface{}) error {
-	ctMutexKV.Lock(d.Id())
-	defer ctMutexKV.Unlock(d.Id())
+// func resourceShippingMethodUpdate(d *schema.ResourceData, m interface{}) error {
+// 	ctMutexKV.Lock(d.Id())
+// 	defer ctMutexKV.Unlock(d.Id())
 
-	client := getClient(m)
-	shippingMethod, err := client.ShippingMethods().WithId(d.Id()).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	client := getClient(m)
+// 	shippingMethod, err := client.ShippingMethods().WithId(d.Id()).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	input := platform.ShippingMethodUpdate{
-		Version: shippingMethod.Version,
-		Actions: []platform.ShippingMethodUpdateAction{},
-	}
+// 	input := platform.ShippingMethodUpdate{
+// 		Version: shippingMethod.Version,
+// 		Actions: []platform.ShippingMethodUpdateAction{},
+// 	}
 
-	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodChangeNameAction{Name: newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := d.Get("name").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodChangeNameAction{Name: newName})
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodSetKeyAction{Key: &newKey})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodSetKeyAction{Key: &newKey})
+// 	}
 
-	if d.HasChange("description") {
-		newDescription := d.Get("description").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodSetDescriptionAction{Description: &newDescription})
-	}
+// 	if d.HasChange("description") {
+// 		newDescription := d.Get("description").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodSetDescriptionAction{Description: &newDescription})
+// 	}
 
-	if d.HasChange("localized_description") {
-		newLocalizedDescription := platform.LocalizedString(
-			expandStringMap(d.Get("localized_description").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodSetLocalizedDescriptionAction{LocalizedDescription: &newLocalizedDescription})
-	}
+// 	if d.HasChange("localized_description") {
+// 		newLocalizedDescription := platform.LocalizedString(
+// 			expandStringMap(d.Get("localized_description").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodSetLocalizedDescriptionAction{LocalizedDescription: &newLocalizedDescription})
+// 	}
 
-	if d.HasChange("is_default") {
-		newIsDefault := d.Get("is_default").(bool)
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodChangeIsDefaultAction{IsDefault: newIsDefault})
-	}
+// 	if d.HasChange("is_default") {
+// 		newIsDefault := d.Get("is_default").(bool)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodChangeIsDefaultAction{IsDefault: newIsDefault})
+// 	}
 
-	if d.HasChange("tax_category_id") {
-		taxCategoryID := d.Get("tax_category_id").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodChangeTaxCategoryAction{TaxCategory: platform.TaxCategoryResourceIdentifier{ID: &taxCategoryID}})
-	}
+// 	if d.HasChange("tax_category_id") {
+// 		taxCategoryID := d.Get("tax_category_id").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodChangeTaxCategoryAction{TaxCategory: platform.TaxCategoryResourceIdentifier{ID: &taxCategoryID}})
+// 	}
 
-	if d.HasChange("predicate") {
-		newPredicate := d.Get("predicate").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodSetPredicateAction{Predicate: &newPredicate})
-	}
+// 	if d.HasChange("predicate") {
+// 		newPredicate := d.Get("predicate").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodSetPredicateAction{Predicate: &newPredicate})
+// 	}
 
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
 
-	_, err = client.ShippingMethods().WithId(shippingMethod.ID).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
+// 	_, err = client.ShippingMethods().WithId(shippingMethod.ID).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
 
-	return resourceShippingMethodRead(d, m)
-}
+// 	return resourceShippingMethodRead(d, m)
+// }
 
-func resourceShippingMethodDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceShippingMethodDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	ctMutexKV.Lock(d.Id())
-	defer ctMutexKV.Unlock(d.Id())
+// 	ctMutexKV.Lock(d.Id())
+// 	defer ctMutexKV.Unlock(d.Id())
 
-	shippingMethod, err := client.ShippingMethods().WithId(d.Id()).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	shippingMethod, err := client.ShippingMethods().WithId(d.Id()).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	_, err = client.ShippingMethods().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyShippingMethodsByIDRequestMethodDeleteInput{
-		Version: shippingMethod.Version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	_, err = client.ShippingMethods().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyShippingMethodsByIDRequestMethodDeleteInput{
+// 		Version: shippingMethod.Version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }

--- a/commercetools/resource_shipping_method_test.go
+++ b/commercetools/resource_shipping_method_test.go
@@ -1,145 +1,145 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccShippingMethod_createAndUpdateWithID(t *testing.T) {
+// func TestAccShippingMethod_createAndUpdateWithID(t *testing.T) {
 
-	name := "test sh method"
-	key := "test-sh-method"
-	description := "test shipping method description"
-	predicate := "1 = 1"
+// 	name := "test sh method"
+// 	key := "test-sh-method"
+// 	description := "test shipping method description"
+// 	predicate := "1 = 1"
 
-	newName := "new test sh method"
-	newKey := "new-test-sh-method"
-	newDescription := "new test shipping method description"
-	newPredicate := "2 = 2"
+// 	newName := "new test sh method"
+// 	newKey := "new-test-sh-method"
+// 	newDescription := "new test shipping method description"
+// 	newPredicate := "2 = 2"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckShippingMethodDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccShippingMethodConfig(name, key, description, description, false, true, predicate),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "key", key,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "description", description,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "localized_description.en", description,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "is_default", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "predicate", predicate,
-					),
-				),
-			},
-			{
-				Config: testAccShippingMethodConfig(newName, newKey, newDescription, newDescription, true, true, newPredicate),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "name", newName,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "key", newKey,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "description", newDescription,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "localized_description.en", newDescription,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "is_default", "true",
-					),
-					resource.TestCheckResourceAttrSet(
-						"commercetools_shipping_method.standard", "tax_category_id",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_method.standard", "predicate", newPredicate,
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckShippingMethodDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccShippingMethodConfig(name, key, description, description, false, true, predicate),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "key", key,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "description", description,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "localized_description.en", description,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "is_default", "false",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "predicate", predicate,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccShippingMethodConfig(newName, newKey, newDescription, newDescription, true, true, newPredicate),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "name", newName,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "key", newKey,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "description", newDescription,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "localized_description.en", newDescription,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "is_default", "true",
+// 					),
+// 					resource.TestCheckResourceAttrSet(
+// 						"commercetools_shipping_method.standard", "tax_category_id",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_method.standard", "predicate", newPredicate,
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccShippingMethodConfig(name string, key string, description string, localizedDescription string, isDefault bool, setTaxCategory bool, predicate string) string {
-	taxCategoryReference := ""
-	if setTaxCategory {
-		taxCategoryReference = "tax_category_id = \"${commercetools_tax_category.test.id}\""
-	}
-	return fmt.Sprintf(`
-resource "commercetools_tax_category" "test" {
-	name = "test"
-	key = "test"
-	description = "test"
-}
+// func testAccShippingMethodConfig(name string, key string, description string, localizedDescription string, isDefault bool, setTaxCategory bool, predicate string) string {
+// 	taxCategoryReference := ""
+// 	if setTaxCategory {
+// 		taxCategoryReference = "tax_category_id = \"${commercetools_tax_category.test.id}\""
+// 	}
+// 	return fmt.Sprintf(`
+// resource "commercetools_tax_category" "test" {
+// 	name = "test"
+// 	key = "test"
+// 	description = "test"
+// }
 
-resource "commercetools_shipping_method" "standard" {
-	name = "%s"
-	key = "%s"
-	description = "%s"
-	localized_description = {
-		en = "%s"
-	}
-	is_default = "%t"
-	predicate = "%s"
+// resource "commercetools_shipping_method" "standard" {
+// 	name = "%s"
+// 	key = "%s"
+// 	description = "%s"
+// 	localized_description = {
+// 		en = "%s"
+// 	}
+// 	is_default = "%t"
+// 	predicate = "%s"
 
-	%s
-	`, name, key, description, localizedDescription, isDefault, predicate, taxCategoryReference) + "\n}\n"
-}
+// 	%s
+// 	`, name, key, description, localizedDescription, isDefault, predicate, taxCategoryReference) + "\n}\n"
+// }
 
-func testAccCheckShippingMethodDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckShippingMethodDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		switch rs.Type {
-		case "commercetools_tax_category":
-			{
-				response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
-						return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
+// 	for _, rs := range s.RootModule().Resources {
+// 		switch rs.Type {
+// 		case "commercetools_tax_category":
+// 			{
+// 				response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
+// 						return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
 
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		case "commercetools_shipping_method":
-			{
-				response, err := client.ShippingMethods().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
-						return fmt.Errorf("shipping method (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		default:
-			continue
-		}
-	}
-	return nil
-}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		case "commercetools_shipping_method":
+// 			{
+// 				response, err := client.ShippingMethods().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
+// 						return fmt.Errorf("shipping method (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		default:
+// 			continue
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_shipping_zone.go
+++ b/commercetools/resource_shipping_zone.go
@@ -1,261 +1,261 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"time"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"log"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceShippingZone() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceShippingZoneCreate,
-		Read:   resourceShippingZoneRead,
-		Update: resourceShippingZoneUpdate,
-		Delete: resourceShippingZoneDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"key": {
-				Description: "User-specific unique identifier for a zone. Must be unique across a project",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"location": {
-				Description: "[Location](https://docs.commercetoolstools.pi/projects/zones#location)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"country": {
-							Description: "A two-digit country code as per " +
-								"[ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"state": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceShippingZone() *schema.Resource {
+// 	return &schema.Resource{
+// 		Create: resourceShippingZoneCreate,
+// 		Read:   resourceShippingZoneRead,
+// 		Update: resourceShippingZoneUpdate,
+// 		Delete: resourceShippingZoneDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"name": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"description": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"key": {
+// 				Description: "User-specific unique identifier for a zone. Must be unique across a project",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"location": {
+// 				Description: "[Location](https://docs.commercetoolstools.pi/projects/zones#location)",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"country": {
+// 							Description: "A two-digit country code as per " +
+// 								"[ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
+// 							Type:     types.StringType,
+// 							Required: true,
+// 						},
+// 						"state": {
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceShippingZoneCreate(d *schema.ResourceData, m interface{}) error {
-	log.Print("[DEBUG] Creating shippingzones in commercetools")
-	client := getClient(m)
+// func resourceShippingZoneCreate(d *schema.ResourceData, m interface{}) error {
+// 	log.Print("[DEBUG] Creating shippingzones in commercetools")
+// 	client := getClient(m)
 
-	var shippingZone *platform.Zone
+// 	var shippingZone *platform.Zone
 
-	input := d.Get("location").([]interface{})
-	locations := unmarshallShippingZoneLocations(input)
+// 	input := d.Get("location").([]interface{})
+// 	locations := unmarshallShippingZoneLocations(input)
 
-	draft := platform.ZoneDraft{
-		Key:         stringRef(d.Get("key")),
-		Name:        d.Get("name").(string),
-		Description: stringRef(d.Get("description")),
-		Locations:   locations,
-	}
+// 	draft := platform.ZoneDraft{
+// 		Key:         stringRef(d.Get("key")),
+// 		Name:        d.Get("name").(string),
+// 		Description: stringRef(d.Get("description")),
+// 		Locations:   locations,
+// 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
+// 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
 
-		shippingZone, err = client.Zones().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		shippingZone, err = client.Zones().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	if shippingZone == nil {
-		return fmt.Errorf("Error creating shipping zone")
-	}
+// 	if shippingZone == nil {
+// 		return fmt.Errorf("Error creating shipping zone")
+// 	}
 
-	d.SetId(shippingZone.ID)
-	d.Set("version", shippingZone.Version)
+// 	d.SetId(shippingZone.ID)
+// 	d.Set("version", shippingZone.Version)
 
-	return resourceShippingZoneRead(d, m)
-}
+// 	return resourceShippingZoneRead(d, m)
+// }
 
-func resourceShippingZoneRead(d *schema.ResourceData, m interface{}) error {
-	log.Print("[DEBUG] Reading shippingzones from commercetools")
-	client := getClient(m)
+// func resourceShippingZoneRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Print("[DEBUG] Reading shippingzones from commercetools")
+// 	client := getClient(m)
 
-	shippingZone, err := client.Zones().WithId(d.Id()).Get().Execute(context.Background())
+// 	shippingZone, err := client.Zones().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if shippingZone == nil {
-		log.Print("[DEBUG] No shippingzones found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following shippingzones:")
-		log.Print(stringFormatObject(shippingZone))
+// 	if shippingZone == nil {
+// 		log.Print("[DEBUG] No shippingzones found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following shippingzones:")
+// 		log.Print(stringFormatObject(shippingZone))
 
-		d.Set("version", shippingZone.Version)
-		d.Set("key", shippingZone.Key)
-		d.Set("name", shippingZone.Name)
-		d.Set("description", shippingZone.Description)
-		d.Set("location", marshallShippingZoneLocations(shippingZone.Locations))
-	}
-	return nil
-}
+// 		d.Set("version", shippingZone.Version)
+// 		d.Set("key", shippingZone.Key)
+// 		d.Set("name", shippingZone.Name)
+// 		d.Set("description", shippingZone.Description)
+// 		d.Set("location", marshallShippingZoneLocations(shippingZone.Locations))
+// 	}
+// 	return nil
+// }
 
-func resourceShippingZoneUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceShippingZoneUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	ctMutexKV.Lock(d.Id())
-	defer ctMutexKV.Unlock(d.Id())
+// 	ctMutexKV.Lock(d.Id())
+// 	defer ctMutexKV.Unlock(d.Id())
 
-	input := platform.ZoneUpdate{
-		Version: d.Get("version").(int),
-		Actions: []platform.ZoneUpdateAction{},
-	}
+// 	input := platform.ZoneUpdate{
+// 		Version: d.Get("version").(int),
+// 		Actions: []platform.ZoneUpdateAction{},
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ZoneSetKeyAction{Key: &newKey})
-	}
-	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ZoneChangeNameAction{Name: newName})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ZoneSetKeyAction{Key: &newKey})
+// 	}
+// 	if d.HasChange("name") {
+// 		newName := d.Get("name").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ZoneChangeNameAction{Name: newName})
+// 	}
 
-	if d.HasChange("description") {
-		newDescription := d.Get("description").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.ZoneSetDescriptionAction{Description: &newDescription})
-	}
+// 	if d.HasChange("description") {
+// 		newDescription := d.Get("description").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ZoneSetDescriptionAction{Description: &newDescription})
+// 	}
 
-	if d.HasChange("location") {
-		old, new := d.GetChange("location")
+// 	if d.HasChange("location") {
+// 		old, new := d.GetChange("location")
 
-		oldLocations := unmarshallShippingZoneLocations(old)
-		newLocations := unmarshallShippingZoneLocations(new)
+// 		oldLocations := unmarshallShippingZoneLocations(old)
+// 		newLocations := unmarshallShippingZoneLocations(new)
 
-		for i, location := range oldLocations {
-			if !_locationInSlice(location, newLocations) {
-				input.Actions = append(
-					input.Actions,
-					&platform.ZoneRemoveLocationAction{Location: oldLocations[i]})
-			}
-		}
-		for i, location := range newLocations {
-			if !_locationInSlice(location, oldLocations) {
-				input.Actions = append(
-					input.Actions,
-					&platform.ZoneAddLocationAction{Location: newLocations[i]})
-			}
-		}
-	}
+// 		for i, location := range oldLocations {
+// 			if !_locationInSlice(location, newLocations) {
+// 				input.Actions = append(
+// 					input.Actions,
+// 					&platform.ZoneRemoveLocationAction{Location: oldLocations[i]})
+// 			}
+// 		}
+// 		for i, location := range newLocations {
+// 			if !_locationInSlice(location, oldLocations) {
+// 				input.Actions = append(
+// 					input.Actions,
+// 					&platform.ZoneAddLocationAction{Location: newLocations[i]})
+// 			}
+// 		}
+// 	}
 
-	_, err := client.Zones().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	_, err := client.Zones().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return resourceShippingZoneRead(d, m)
-}
+// 	return resourceShippingZoneRead(d, m)
+// }
 
-func resourceShippingZoneDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceShippingZoneDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	// Lock to prevent concurrent updates due to Version number conflicts
-	ctMutexKV.Lock(d.Id())
-	defer ctMutexKV.Unlock(d.Id())
+// 	// Lock to prevent concurrent updates due to Version number conflicts
+// 	ctMutexKV.Lock(d.Id())
+// 	defer ctMutexKV.Unlock(d.Id())
 
-	version := d.Get("version").(int)
-	_, err := client.Zones().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyZonesByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	version := d.Get("version").(int)
+// 	_, err := client.Zones().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyZonesByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func unmarshallShippingZoneLocations(input interface{}) []platform.Location {
-	inputSlice := input.([]interface{})
-	var result []platform.Location
+// func unmarshallShippingZoneLocations(input interface{}) []platform.Location {
+// 	inputSlice := input.([]interface{})
+// 	var result []platform.Location
 
-	for _, raw := range inputSlice {
-		i := raw.(map[string]interface{})
+// 	for _, raw := range inputSlice {
+// 		i := raw.(map[string]interface{})
 
-		country, ok := i["country"].(string)
-		if !ok {
-			country = ""
-		}
+// 		country, ok := i["country"].(string)
+// 		if !ok {
+// 			country = ""
+// 		}
 
-		state, ok := i["state"].(string)
-		if !ok {
-			state = ""
-		}
+// 		state, ok := i["state"].(string)
+// 		if !ok {
+// 			state = ""
+// 		}
 
-		result = append(result, platform.Location{
-			Country: country,
-			State:   &state,
-		})
-	}
+// 		result = append(result, platform.Location{
+// 			Country: country,
+// 			State:   &state,
+// 		})
+// 	}
 
-	return result
-}
+// 	return result
+// }
 
-func marshallShippingZoneLocations(locations []platform.Location) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(locations))
+// func marshallShippingZoneLocations(locations []platform.Location) []map[string]interface{} {
+// 	result := make([]map[string]interface{}, 0, len(locations))
 
-	for _, location := range locations {
-		result = append(result, map[string]interface{}{
-			"country": location.Country,
-			"state":   location.State,
-		})
-	}
+// 	for _, location := range locations {
+// 		result = append(result, map[string]interface{}{
+// 			"country": location.Country,
+// 			"state":   location.State,
+// 		})
+// 	}
 
-	return result
-}
+// 	return result
+// }
 
-func _locationInSlice(needle platform.Location, haystack []platform.Location) bool {
-	for _, item := range haystack {
-		if item == needle {
-			return true
-		}
-	}
-	return false
-}
+// func _locationInSlice(needle platform.Location, haystack []platform.Location) bool {
+// 	for _, item := range haystack {
+// 		if item == needle {
+// 			return true
+// 		}
+// 	}
+// 	return false
+// }

--- a/commercetools/resource_shipping_zone_rate.go
+++ b/commercetools/resource_shipping_zone_rate.go
@@ -1,567 +1,567 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"strings"
-	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
-
-func resourceShippingZoneRate() *schema.Resource {
-	return &schema.Resource{
-		Description: "Defines shipping rates (prices) for a specific zone.\n\n" +
-			"See also [ZoneRate API Documentation](https://docs.commercetools.com/api/projects/shippingMethods#zonerate)",
-		Create: resourceShippingZoneRateCreate,
-		Read:   resourceShippingZoneRateRead,
-		Update: resourceShippingZoneRateUpdate,
-		Delete: resourceShippingZoneRateDelete,
-		Importer: &schema.ResourceImporter{
-			State: resourceShippingZoneRateImportState,
-		},
-		Schema: map[string]*schema.Schema{
-			"shipping_method_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"shipping_zone_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"price": {
-				Type:     schema.TypeList,
-				Required: true,
-				MinItems: 1,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"currency_code": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: ValidateCurrencyCode,
-						},
-						"cent_amount": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
-					},
-				},
-			},
-			"free_above": {
-				Description: "The shipping is free if the sum of the (custom) line item prices reaches the freeAbove value",
-				Type:        schema.TypeList,
-				MinItems:    1,
-				MaxItems:    1,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"currency_code": {
-							Description:  "The currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: ValidateCurrencyCode,
-						},
-						"cent_amount": {
-							Description: "The amount in cents (the smallest indivisible unit of the currency)",
-							Type:        schema.TypeInt,
-							Required:    true,
-						},
-					},
-				},
-			},
-			"shipping_rate_price_tier": {
-				Description: "A price tier is selected instead of the default price when a certain threshold or " +
-					"specific cart value is reached. If no tiered price is suitable for the cart, the base price of the " +
-					"shipping rate is used\n. " +
-					"See also [Shipping Rate Price Tier API Docs](https://docs.commercetools.com/api/projects/shippingMethods#shippingratepricetier)",
-				Type:     schema.TypeList,
-				MinItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Description: "CartValue, CartScore or CartClassification",
-							Type:        schema.TypeString,
-							Required:    true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(platform.ShippingRateTierTypeCartValue),
-								string(platform.ShippingRateTierTypeCartScore),
-								string(platform.ShippingRateTierTypeCartClassification),
-							}, false),
-						},
-						"minimum_cent_amount": {
-							Description: "If type is CartValue this represents the cent amount of the tier",
-							Type:        schema.TypeInt,
-							Optional:    true,
-						},
-						"value": {
-							Description: "If type is CartClassification, must be a valid key of the CartClassification",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"score": {
-							Description: "If type is CartScore. Sets a fixed price for this score value",
-							Type:        schema.TypeFloat,
-							Optional:    true,
-						},
-						"price": {
-							Description: "The price of the score, value or minimum_cent_amount tier",
-							Type:        schema.TypeList,
-							Required:    true,
-							MinItems:    1,
-							MaxItems:    1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"currency_code": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: ValidateCurrencyCode,
-									},
-									"cent_amount": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func resourceShippingZoneRateImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := getClient(meta)
-	shippingMethodID, _, _ := getShippingIDs(d.Id())
-
-	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
-
-	if err != nil {
-		return nil, err
-	}
-
-	results := make([]*schema.ResourceData, 0)
-	shippingZoneRateState := resourceShippingZoneRate().Data(nil)
-	shippingZoneRateState.SetId(d.Id())
-	shippingZoneRateState.SetType("commercetools_shipping_zone_rate")
-
-	setShippingZoneRateState(d, shippingMethod)
-
-	results = append(results, shippingZoneRateState)
-
-	log.Printf("[DEBUG] Importing results: %#v", results)
-
-	return results, nil
-}
-
-func resourceShippingZoneRateCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	shippingZoneID := d.Get("shipping_zone_id").(string)
-	shippingMethodID := d.Get("shipping_method_id").(string)
-
-	// Lock to prevent concurrent updates due to Version number conflicts
-	ctMutexKV.Lock(shippingMethodID)
-	defer ctMutexKV.Unlock(shippingMethodID)
-
-	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
-
-	if err != nil {
-		return err
-	}
-
-	input := platform.ShippingMethodUpdate{
-		Version: shippingMethod.Version,
-		Actions: []platform.ShippingMethodUpdateAction{},
-	}
-	price := d.Get("price").([]interface{})[0].(map[string]interface{})
-
-	var freeAbove *platform.Money
-	if freeAboveState, ok := d.GetOk("free_above"); ok {
-		log.Printf("[DEBUG] Free above state: %s", stringFormatObject(freeAboveState))
-		freeAboveMap := freeAboveState.([]interface{})[0].(map[string]interface{})
-		freeAbove = &platform.Money{
-			CurrencyCode: freeAboveMap["currency_code"].(string),
-			CentAmount:   freeAboveMap["cent_amount"].(int),
-		}
-	}
-	log.Printf("[DEBUG] Setting freeAbove: %s", stringFormatObject(freeAbove))
-
-	shippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
-	if err != nil {
-		return err
-	}
-	log.Printf("[DEBUG] Setting shippingRatePriceTiers: %s", stringFormatObject(shippingRatePriceTiers))
-
-	priceCurrencyCode := price["currency_code"].(string)
-
-	zoneNotFound := true
-	for _, v := range shippingMethod.ZoneRates {
-		if v.Zone.ID == shippingZoneID {
-			zoneNotFound = false
-			break
-		}
-	}
-
-	if zoneNotFound {
-		input.Actions = append(input.Actions, platform.ShippingMethodAddZoneAction{
-			Zone: platform.ZoneResourceIdentifier{ID: &shippingZoneID},
-		})
-	}
-
-	input.Actions = append(input.Actions, platform.ShippingMethodAddShippingRateAction{
-		Zone: platform.ZoneResourceIdentifier{ID: &shippingZoneID},
-		ShippingRate: platform.ShippingRateDraft{
-			Price: platform.Money{
-				CurrencyCode: priceCurrencyCode,
-				CentAmount:   price["cent_amount"].(int),
-			},
-			FreeAbove: freeAbove,
-			Tiers:     shippingRatePriceTiers,
-		},
-	})
-
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
-
-		shippingMethod, err = client.ShippingMethods().WithId(shippingMethod.ID).Post(input).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
-
-	if err != nil {
-		return err
-	}
-
-	if shippingMethod == nil {
-		log.Fatal("No shipping method created?")
-	}
-
-	d.SetId(buildShippingZoneRateID(shippingMethod.ID, shippingZoneID, string(priceCurrencyCode)))
-
-	return resourceShippingZoneRateRead(d, m)
-}
-
-func unmarshallShippingRatePriceTiers(d *schema.ResourceData) ([]platform.ShippingRatePriceTier, error) {
-	values, ok := d.GetOk("shipping_rate_price_tier")
-	if !ok {
-		return []platform.ShippingRatePriceTier{}, nil
-	}
-
-	var tiers []platform.ShippingRatePriceTier
-	for _, priceTier := range values.([]interface{}) {
-		tierMap := priceTier.(map[string]interface{})
-
-		priceMap := tierMap["price"].([]interface{})[0].(map[string]interface{})
-		price := platform.Money{
-			CurrencyCode: priceMap["currency_code"].(string),
-			CentAmount:   priceMap["cent_amount"].(int),
-		}
-
-		tierType := tierMap["type"].(string)
-		switch tierType {
-		case string(platform.ShippingRateTierTypeCartValue):
-			tiers = append(tiers, platform.CartValueTier{
-				MinimumCentAmount: tierMap["minimum_cent_amount"].(int),
-				Price:             price,
-			})
-		case string(platform.ShippingRateTierTypeCartClassification):
-			tiers = append(tiers, platform.CartClassificationTier{
-				Value: tierMap["value"].(string),
-				Price: price,
-			})
-		case string(platform.ShippingRateTierTypeCartScore):
-			tiers = append(tiers, platform.CartScoreTier{
-				Score: tierMap["score"].(float64),
-				Price: &price,
-			})
-			// Do we want to fail on 1 wrong tier?
-		default:
-			return nil, fmt.Errorf("invalid shippingRatePriceTier type: %s", tierType)
-		}
-	}
-	return tiers, nil
-}
-
-func buildShippingZoneRateID(shippingMethodID string, shippingZoneID string, currencyCode string) string {
-	return shippingMethodID + "@" + shippingZoneID + "@" + currencyCode
-}
-
-func resourceShippingZoneRateRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Reading shipping zone rate from commercetools, with id: %s", d.Id())
-
-	shippingMethodID, _, _ := getShippingIDs(d.Id())
-
-	client := getClient(m)
-
-	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
-
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
-
-	if shippingMethod == nil {
-		log.Print("[DEBUG] No shipping method found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following shipping method:")
-		log.Print(stringFormatObject(shippingMethod))
-
-		err = setShippingZoneRateState(d, shippingMethod)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func resourceShippingZoneRateUpdate(d *schema.ResourceData, m interface{}) error {
-	shippingMethodID, shippingZoneID, currencyCode := getShippingIDs(d.Id())
-	ctMutexKV.Lock(shippingMethodID)
-	defer ctMutexKV.Unlock(shippingMethodID)
-
-	client := getClient(m)
-	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
-
-	shippingRate, err := findShippingZoneRate(shippingZoneID, currencyCode, shippingMethod)
-
-	if err != nil {
-		return err
-	}
-
-	input := platform.ShippingMethodUpdate{
-		Version: shippingMethod.Version,
-		Actions: []platform.ShippingMethodUpdateAction{},
-	}
-
-	if d.HasChange("price") || d.HasChange("free_above") || d.HasChange("shipping_rate_price_tier") {
-		zoneResourceIdentifier := platform.ZoneResourceIdentifier{
-			ID: &shippingZoneID,
-		}
-
-		oldTypedPrice := shippingRate.Price.(platform.CentPrecisionMoney)
-		var oldFreeAboveMoney *platform.Money
-		if shippingRate.FreeAbove != nil {
-			oldFreeAbove := (shippingRate.FreeAbove).(platform.CentPrecisionMoney)
-			oldFreeAboveMoney = &platform.Money{
-				CurrencyCode: currencyCode,
-				CentAmount:   oldFreeAbove.CentAmount,
-			}
-		}
-		var oldShippingRatePriceTiers []platform.ShippingRatePriceTier
-		if shippingRate.Tiers != nil {
-			oldShippingRatePriceTiers = shippingRate.Tiers
-		}
-
-		oldShippingRateDraft := platform.ShippingRateDraft{
-			Price: platform.Money{
-				CurrencyCode: currencyCode,
-				CentAmount:   oldTypedPrice.CentAmount,
-			},
-			FreeAbove: oldFreeAboveMoney,
-			Tiers:     oldShippingRatePriceTiers,
-		}
-
-		price := d.Get("price").([]interface{})[0].(map[string]interface{})
-		var newFreeAboveMoney *platform.Money
-		if freeAbove, ok := d.GetOk("free_above"); ok {
-			freeAboveMap := freeAbove.([]interface{})[0].(map[string]interface{})
-			newFreeAboveMoney = &platform.Money{
-				CurrencyCode: currencyCode,
-				CentAmount:   freeAboveMap["cent_amount"].(int),
-			}
-		}
-
-		newShippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
-		if err != nil {
-			return err
-		}
-
-		newShippingRateDraft := platform.ShippingRateDraft{
-			Price: platform.Money{
-				CurrencyCode: currencyCode,
-				CentAmount:   price["cent_amount"].(int),
-			},
-			FreeAbove: newFreeAboveMoney,
-			Tiers:     newShippingRatePriceTiers,
-		}
-
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodRemoveShippingRateAction{
-				Zone: platform.ZoneResourceIdentifier{
-					ID: &shippingZoneID,
-				},
-				ShippingRate: oldShippingRateDraft,
-			})
-		input.Actions = append(
-			input.Actions,
-			&platform.ShippingMethodAddShippingRateAction{
-				Zone:         zoneResourceIdentifier,
-				ShippingRate: newShippingRateDraft,
-			})
-	}
-
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
-
-	_, err = client.ShippingMethods().WithId(shippingMethodID).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
-
-	return resourceShippingZoneRateRead(d, m)
-}
-
-func resourceShippingZoneRateDelete(d *schema.ResourceData, m interface{}) error {
-	shippingMethodID := d.Get("shipping_method_id").(string)
-	ctMutexKV.Lock(shippingMethodID)
-	defer ctMutexKV.Unlock(shippingMethodID)
-
-	client := getClient(m)
-	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
-
-	input := platform.ShippingMethodUpdate{
-		Version: shippingMethod.Version,
-		Actions: []platform.ShippingMethodUpdateAction{},
-	}
-
-	price := d.Get("price").([]interface{})[0].(map[string]interface{})
-	var newFreeAboveMoney *platform.Money
-	if freeAbove, ok := d.GetOk("free_above"); ok {
-		freeAboveMap := freeAbove.([]interface{})[0].(map[string]interface{})
-		newFreeAboveMoney = &platform.Money{
-			CurrencyCode: freeAboveMap["currency_code"].(string),
-			CentAmount:   freeAboveMap["cent_amount"].(int),
-		}
-	}
-
-	newShippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
-	if err != nil {
-		return err
-	}
-
-	shippingZoneID := d.Get("shipping_zone_id").(string)
-	removeAction := platform.ShippingMethodRemoveShippingRateAction{
-		Zone: platform.ZoneResourceIdentifier{ID: &shippingZoneID},
-		ShippingRate: platform.ShippingRateDraft{
-			Price: platform.Money{
-				CurrencyCode: price["currency_code"].(string),
-				CentAmount:   price["cent_amount"].(int),
-			},
-			FreeAbove: newFreeAboveMoney,
-			Tiers:     newShippingRatePriceTiers,
-		},
-	}
-
-	input.Actions = append(input.Actions, removeAction)
-
-	for _, v := range shippingMethod.ZoneRates {
-		if v.Zone.ID == shippingZoneID && len(v.ShippingRates) == 1 {
-			input.Actions = append(input.Actions, platform.ShippingMethodRemoveZoneAction{
-				Zone: platform.ZoneResourceIdentifier{ID: &shippingZoneID},
-			})
-			break
-		}
-	}
-
-	_, err = client.ShippingMethods().WithId(shippingMethodID).Post(input).Execute(context.Background())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func getShippingIDs(shippingZoneRateID string) (string, string, string) {
-	idSplit := strings.Split(shippingZoneRateID, "@")
-
-	shippingMethodID := idSplit[0]
-	shippingZoneID := idSplit[1]
-	currencyCode := idSplit[2]
-
-	return shippingMethodID, shippingZoneID, currencyCode
-}
-
-func findShippingZoneRate(shippingZoneID string, currencyCode string, shippingMethod *platform.ShippingMethod) (*platform.ShippingRate, error) {
-	for _, zoneRate := range shippingMethod.ZoneRates {
-		if zoneRate.Zone.ID == shippingZoneID {
-			for _, shippingRate := range zoneRate.ShippingRates {
-				if shippingRate.Price.(platform.CentPrecisionMoney).CurrencyCode == currencyCode {
-					return &shippingRate, nil
-				}
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("Couldn't find shipping zone rate")
-}
-
-func setShippingZoneRateState(d *schema.ResourceData, shippingMethod *platform.ShippingMethod) error {
-	shippingMethodID, shippingZoneID, currencyCode := getShippingIDs(d.Id())
-
-	d.Set("shipping_method_id", shippingMethodID)
-	d.Set("shipping_zone_id", shippingZoneID)
-
-	shippingRate, err := findShippingZoneRate(shippingZoneID, currencyCode, shippingMethod)
-
-	if err != nil {
-		return err
-	}
-
-	log.Printf("[DEBUG] Found shipping rate: %s", stringFormatObject(shippingRate))
-
-	if typedPrice, ok := shippingRate.Price.(platform.CentPrecisionMoney); ok {
-		price := map[string]interface{}{
-			"currency_code": string(typedPrice.CurrencyCode),
-			"cent_amount":   typedPrice.CentAmount,
-		}
-		err = d.Set("price", []interface{}{price})
-		if err != nil {
-			return err
-		}
-	}
-
-	if typedFreeAbove, ok := (shippingRate.FreeAbove).(platform.CentPrecisionMoney); ok {
-		freeAbove := map[string]interface{}{
-			"currency_code": string(typedFreeAbove.CurrencyCode),
-			"cent_amount":   typedFreeAbove.CentAmount,
-		}
-		err = d.Set("free_above", []interface{}{freeAbove})
-		if err != nil {
-			return err
-		}
-	}
-	log.Printf("[DEBUG] New state: %#v", d)
-
-	return nil
-}
+// import (
+// 	"context"
+// 	"fmt"
+// 	"log"
+// 	"strings"
+// 	"time"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
+
+// func resourceShippingZoneRate() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Defines shipping rates (prices) for a specific zone.\n\n" +
+// 			"See also [ZoneRate API Documentation](https://docs.commercetools.com/api/projects/shippingMethods#zonerate)",
+// 		Create: resourceShippingZoneRateCreate,
+// 		Read:   resourceShippingZoneRateRead,
+// 		Update: resourceShippingZoneRateUpdate,
+// 		Delete: resourceShippingZoneRateDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: resourceShippingZoneRateImportState,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"shipping_method_id": {
+// 				Type:     types.StringType,
+// 				Required: true,
+// 				ForceNew: true,
+// 			},
+// 			"shipping_zone_id": {
+// 				Type:     types.StringType,
+// 				Required: true,
+// 				ForceNew: true,
+// 			},
+// 			"price": {
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				Required: true,
+// 				MinItems: 1,
+// 				MaxItems: 1,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"currency_code": {
+// 							Type:         types.StringType,
+// 							Required:     true,
+// 							ForceNew:     true,
+// 							ValidateFunc: ValidateCurrencyCode,
+// 						},
+// 						"cent_amount": {
+// 							Type:     types.Int64Type,
+// 							Required: true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"free_above": {
+// 				Description: "The shipping is free if the sum of the (custom) line item prices reaches the freeAbove value",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				MinItems:    1,
+// 				MaxItems:    1,
+// 				Optional:    true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"currency_code": {
+// 							Description:  "The currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
+// 							Type:         types.StringType,
+// 							Required:     true,
+// 							ForceNew:     true,
+// 							ValidateFunc: ValidateCurrencyCode,
+// 						},
+// 						"cent_amount": {
+// 							Description: "The amount in cents (the smallest indivisible unit of the currency)",
+// 							Type:        types.Int64Type,
+// 							Required:    true,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"shipping_rate_price_tier": {
+// 				Description: "A price tier is selected instead of the default price when a certain threshold or " +
+// 					"specific cart value is reached. If no tiered price is suitable for the cart, the base price of the " +
+// 					"shipping rate is used\n. " +
+// 					"See also [Shipping Rate Price Tier API Docs](https://docs.commercetools.com/api/projects/shippingMethods#shippingratepricetier)",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				MinItems: 1,
+// 				Optional: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Description: "CartValue, CartScore or CartClassification",
+// 							Type:        types.StringType,
+// 							Required:    true,
+// 							ValidateFunc: validation.StringInSlice([]string{
+// 								string(platform.ShippingRateTierTypeCartValue),
+// 								string(platform.ShippingRateTierTypeCartScore),
+// 								string(platform.ShippingRateTierTypeCartClassification),
+// 							}, false),
+// 						},
+// 						"minimum_cent_amount": {
+// 							Description: "If type is CartValue this represents the cent amount of the tier",
+// 							Type:        types.Int64Type,
+// 							Optional:    true,
+// 						},
+// 						"value": {
+// 							Description: "If type is CartClassification, must be a valid key of the CartClassification",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 						"score": {
+// 							Description: "If type is CartScore. Sets a fixed price for this score value",
+// 							Type:        schema.TypeFloat,
+// 							Optional:    true,
+// 						},
+// 						"price": {
+// 							Description: "The price of the score, value or minimum_cent_amount tier",
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Required:    true,
+// 							MinItems:    1,
+// 							MaxItems:    1,
+// 							Elem: &schema.Resource{
+// 								Schema: map[string]*schema.Schema{
+// 									"currency_code": {
+// 										Type:         types.StringType,
+// 										Required:     true,
+// 										ForceNew:     true,
+// 										ValidateFunc: ValidateCurrencyCode,
+// 									},
+// 									"cent_amount": {
+// 										Type:     types.Int64Type,
+// 										Required: true,
+// 									},
+// 								},
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
+// }
+
+// func resourceShippingZoneRateImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+// 	client := getClient(meta)
+// 	shippingMethodID, _, _ := getShippingIDs(d.Id())
+
+// 	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
+
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	results := make([]*schema.ResourceData, 0)
+// 	shippingZoneRateState := resourceShippingZoneRate().Data(nil)
+// 	shippingZoneRateState.SetId(d.Id())
+// 	shippingZoneRateState.SetType("commercetools_shipping_zone_rate")
+
+// 	setShippingZoneRateState(d, shippingMethod)
+
+// 	results = append(results, shippingZoneRateState)
+
+// 	log.Printf("[DEBUG] Importing results: %#v", results)
+
+// 	return results, nil
+// }
+
+// func resourceShippingZoneRateCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	shippingZoneID := d.Get("shipping_zone_id").(string)
+// 	shippingMethodID := d.Get("shipping_method_id").(string)
+
+// 	// Lock to prevent concurrent updates due to Version number conflicts
+// 	ctMutexKV.Lock(shippingMethodID)
+// 	defer ctMutexKV.Unlock(shippingMethodID)
+
+// 	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	input := platform.ShippingMethodUpdate{
+// 		Version: shippingMethod.Version,
+// 		Actions: []platform.ShippingMethodUpdateAction{},
+// 	}
+// 	price := d.Get("price").([]interface{})[0].(map[string]interface{})
+
+// 	var freeAbove *platform.Money
+// 	if freeAboveState, ok := d.GetOk("free_above"); ok {
+// 		log.Printf("[DEBUG] Free above state: %s", stringFormatObject(freeAboveState))
+// 		freeAboveMap := freeAboveState.([]interface{})[0].(map[string]interface{})
+// 		freeAbove = &platform.Money{
+// 			CurrencyCode: freeAboveMap["currency_code"].(string),
+// 			CentAmount:   freeAboveMap["cent_amount"].(int),
+// 		}
+// 	}
+// 	log.Printf("[DEBUG] Setting freeAbove: %s", stringFormatObject(freeAbove))
+
+// 	shippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	log.Printf("[DEBUG] Setting shippingRatePriceTiers: %s", stringFormatObject(shippingRatePriceTiers))
+
+// 	priceCurrencyCode := price["currency_code"].(string)
+
+// 	zoneNotFound := true
+// 	for _, v := range shippingMethod.ZoneRates {
+// 		if v.Zone.ID == shippingZoneID {
+// 			zoneNotFound = false
+// 			break
+// 		}
+// 	}
+
+// 	if zoneNotFound {
+// 		input.Actions = append(input.Actions, platform.ShippingMethodAddZoneAction{
+// 			Zone: platform.ZoneResourceIdentifier{ID: &shippingZoneID},
+// 		})
+// 	}
+
+// 	input.Actions = append(input.Actions, platform.ShippingMethodAddShippingRateAction{
+// 		Zone: platform.ZoneResourceIdentifier{ID: &shippingZoneID},
+// 		ShippingRate: platform.ShippingRateDraft{
+// 			Price: platform.Money{
+// 				CurrencyCode: priceCurrencyCode,
+// 				CentAmount:   price["cent_amount"].(int),
+// 			},
+// 			FreeAbove: freeAbove,
+// 			Tiers:     shippingRatePriceTiers,
+// 		},
+// 	})
+
+// 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
+
+// 		shippingMethod, err = client.ShippingMethods().WithId(shippingMethod.ID).Post(input).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	if shippingMethod == nil {
+// 		log.Fatal("No shipping method created?")
+// 	}
+
+// 	d.SetId(buildShippingZoneRateID(shippingMethod.ID, shippingZoneID, string(priceCurrencyCode)))
+
+// 	return resourceShippingZoneRateRead(d, m)
+// }
+
+// func unmarshallShippingRatePriceTiers(d *schema.ResourceData) ([]platform.ShippingRatePriceTier, error) {
+// 	values, ok := d.GetOk("shipping_rate_price_tier")
+// 	if !ok {
+// 		return []platform.ShippingRatePriceTier{}, nil
+// 	}
+
+// 	var tiers []platform.ShippingRatePriceTier
+// 	for _, priceTier := range values.([]interface{}) {
+// 		tierMap := priceTier.(map[string]interface{})
+
+// 		priceMap := tierMap["price"].([]interface{})[0].(map[string]interface{})
+// 		price := platform.Money{
+// 			CurrencyCode: priceMap["currency_code"].(string),
+// 			CentAmount:   priceMap["cent_amount"].(int),
+// 		}
+
+// 		tierType := tierMap["type"].(string)
+// 		switch tierType {
+// 		case string(platform.ShippingRateTierTypeCartValue):
+// 			tiers = append(tiers, platform.CartValueTier{
+// 				MinimumCentAmount: tierMap["minimum_cent_amount"].(int),
+// 				Price:             price,
+// 			})
+// 		case string(platform.ShippingRateTierTypeCartClassification):
+// 			tiers = append(tiers, platform.CartClassificationTier{
+// 				Value: tierMap["value"].(string),
+// 				Price: price,
+// 			})
+// 		case string(platform.ShippingRateTierTypeCartScore):
+// 			tiers = append(tiers, platform.CartScoreTier{
+// 				Score: tierMap["score"].(float64),
+// 				Price: &price,
+// 			})
+// 			// Do we want to fail on 1 wrong tier?
+// 		default:
+// 			return nil, fmt.Errorf("invalid shippingRatePriceTier type: %s", tierType)
+// 		}
+// 	}
+// 	return tiers, nil
+// }
+
+// func buildShippingZoneRateID(shippingMethodID string, shippingZoneID string, currencyCode string) string {
+// 	return shippingMethodID + "@" + shippingZoneID + "@" + currencyCode
+// }
+
+// func resourceShippingZoneRateRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Printf("[DEBUG] Reading shipping zone rate from commercetools, with id: %s", d.Id())
+
+// 	shippingMethodID, _, _ := getShippingIDs(d.Id())
+
+// 	client := getClient(m)
+
+// 	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
+
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
+
+// 	if shippingMethod == nil {
+// 		log.Print("[DEBUG] No shipping method found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following shipping method:")
+// 		log.Print(stringFormatObject(shippingMethod))
+
+// 		err = setShippingZoneRateState(d, shippingMethod)
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+
+// 	return nil
+// }
+
+// func resourceShippingZoneRateUpdate(d *schema.ResourceData, m interface{}) error {
+// 	shippingMethodID, shippingZoneID, currencyCode := getShippingIDs(d.Id())
+// 	ctMutexKV.Lock(shippingMethodID)
+// 	defer ctMutexKV.Unlock(shippingMethodID)
+
+// 	client := getClient(m)
+// 	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	shippingRate, err := findShippingZoneRate(shippingZoneID, currencyCode, shippingMethod)
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	input := platform.ShippingMethodUpdate{
+// 		Version: shippingMethod.Version,
+// 		Actions: []platform.ShippingMethodUpdateAction{},
+// 	}
+
+// 	if d.HasChange("price") || d.HasChange("free_above") || d.HasChange("shipping_rate_price_tier") {
+// 		zoneResourceIdentifier := platform.ZoneResourceIdentifier{
+// 			ID: &shippingZoneID,
+// 		}
+
+// 		oldTypedPrice := shippingRate.Price.(platform.CentPrecisionMoney)
+// 		var oldFreeAboveMoney *platform.Money
+// 		if shippingRate.FreeAbove != nil {
+// 			oldFreeAbove := (shippingRate.FreeAbove).(platform.CentPrecisionMoney)
+// 			oldFreeAboveMoney = &platform.Money{
+// 				CurrencyCode: currencyCode,
+// 				CentAmount:   oldFreeAbove.CentAmount,
+// 			}
+// 		}
+// 		var oldShippingRatePriceTiers []platform.ShippingRatePriceTier
+// 		if shippingRate.Tiers != nil {
+// 			oldShippingRatePriceTiers = shippingRate.Tiers
+// 		}
+
+// 		oldShippingRateDraft := platform.ShippingRateDraft{
+// 			Price: platform.Money{
+// 				CurrencyCode: currencyCode,
+// 				CentAmount:   oldTypedPrice.CentAmount,
+// 			},
+// 			FreeAbove: oldFreeAboveMoney,
+// 			Tiers:     oldShippingRatePriceTiers,
+// 		}
+
+// 		price := d.Get("price").([]interface{})[0].(map[string]interface{})
+// 		var newFreeAboveMoney *platform.Money
+// 		if freeAbove, ok := d.GetOk("free_above"); ok {
+// 			freeAboveMap := freeAbove.([]interface{})[0].(map[string]interface{})
+// 			newFreeAboveMoney = &platform.Money{
+// 				CurrencyCode: currencyCode,
+// 				CentAmount:   freeAboveMap["cent_amount"].(int),
+// 			}
+// 		}
+
+// 		newShippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		newShippingRateDraft := platform.ShippingRateDraft{
+// 			Price: platform.Money{
+// 				CurrencyCode: currencyCode,
+// 				CentAmount:   price["cent_amount"].(int),
+// 			},
+// 			FreeAbove: newFreeAboveMoney,
+// 			Tiers:     newShippingRatePriceTiers,
+// 		}
+
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodRemoveShippingRateAction{
+// 				Zone: platform.ZoneResourceIdentifier{
+// 					ID: &shippingZoneID,
+// 				},
+// 				ShippingRate: oldShippingRateDraft,
+// 			})
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.ShippingMethodAddShippingRateAction{
+// 				Zone:         zoneResourceIdentifier,
+// 				ShippingRate: newShippingRateDraft,
+// 			})
+// 	}
+
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
+
+// 	_, err = client.ShippingMethods().WithId(shippingMethodID).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
+
+// 	return resourceShippingZoneRateRead(d, m)
+// }
+
+// func resourceShippingZoneRateDelete(d *schema.ResourceData, m interface{}) error {
+// 	shippingMethodID := d.Get("shipping_method_id").(string)
+// 	ctMutexKV.Lock(shippingMethodID)
+// 	defer ctMutexKV.Unlock(shippingMethodID)
+
+// 	client := getClient(m)
+// 	shippingMethod, err := client.ShippingMethods().WithId(shippingMethodID).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	input := platform.ShippingMethodUpdate{
+// 		Version: shippingMethod.Version,
+// 		Actions: []platform.ShippingMethodUpdateAction{},
+// 	}
+
+// 	price := d.Get("price").([]interface{})[0].(map[string]interface{})
+// 	var newFreeAboveMoney *platform.Money
+// 	if freeAbove, ok := d.GetOk("free_above"); ok {
+// 		freeAboveMap := freeAbove.([]interface{})[0].(map[string]interface{})
+// 		newFreeAboveMoney = &platform.Money{
+// 			CurrencyCode: freeAboveMap["currency_code"].(string),
+// 			CentAmount:   freeAboveMap["cent_amount"].(int),
+// 		}
+// 	}
+
+// 	newShippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	shippingZoneID := d.Get("shipping_zone_id").(string)
+// 	removeAction := platform.ShippingMethodRemoveShippingRateAction{
+// 		Zone: platform.ZoneResourceIdentifier{ID: &shippingZoneID},
+// 		ShippingRate: platform.ShippingRateDraft{
+// 			Price: platform.Money{
+// 				CurrencyCode: price["currency_code"].(string),
+// 				CentAmount:   price["cent_amount"].(int),
+// 			},
+// 			FreeAbove: newFreeAboveMoney,
+// 			Tiers:     newShippingRatePriceTiers,
+// 		},
+// 	}
+
+// 	input.Actions = append(input.Actions, removeAction)
+
+// 	for _, v := range shippingMethod.ZoneRates {
+// 		if v.Zone.ID == shippingZoneID && len(v.ShippingRates) == 1 {
+// 			input.Actions = append(input.Actions, platform.ShippingMethodRemoveZoneAction{
+// 				Zone: platform.ZoneResourceIdentifier{ID: &shippingZoneID},
+// 			})
+// 			break
+// 		}
+// 	}
+
+// 	_, err = client.ShippingMethods().WithId(shippingMethodID).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	return nil
+// }
+
+// func getShippingIDs(shippingZoneRateID string) (string, string, string) {
+// 	idSplit := strings.Split(shippingZoneRateID, "@")
+
+// 	shippingMethodID := idSplit[0]
+// 	shippingZoneID := idSplit[1]
+// 	currencyCode := idSplit[2]
+
+// 	return shippingMethodID, shippingZoneID, currencyCode
+// }
+
+// func findShippingZoneRate(shippingZoneID string, currencyCode string, shippingMethod *platform.ShippingMethod) (*platform.ShippingRate, error) {
+// 	for _, zoneRate := range shippingMethod.ZoneRates {
+// 		if zoneRate.Zone.ID == shippingZoneID {
+// 			for _, shippingRate := range zoneRate.ShippingRates {
+// 				if shippingRate.Price.(platform.CentPrecisionMoney).CurrencyCode == currencyCode {
+// 					return &shippingRate, nil
+// 				}
+// 			}
+// 		}
+// 	}
+
+// 	return nil, fmt.Errorf("Couldn't find shipping zone rate")
+// }
+
+// func setShippingZoneRateState(d *schema.ResourceData, shippingMethod *platform.ShippingMethod) error {
+// 	shippingMethodID, shippingZoneID, currencyCode := getShippingIDs(d.Id())
+
+// 	d.Set("shipping_method_id", shippingMethodID)
+// 	d.Set("shipping_zone_id", shippingZoneID)
+
+// 	shippingRate, err := findShippingZoneRate(shippingZoneID, currencyCode, shippingMethod)
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	log.Printf("[DEBUG] Found shipping rate: %s", stringFormatObject(shippingRate))
+
+// 	if typedPrice, ok := shippingRate.Price.(platform.CentPrecisionMoney); ok {
+// 		price := map[string]interface{}{
+// 			"currency_code": string(typedPrice.CurrencyCode),
+// 			"cent_amount":   typedPrice.CentAmount,
+// 		}
+// 		err = d.Set("price", []interface{}{price})
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+
+// 	if typedFreeAbove, ok := (shippingRate.FreeAbove).(platform.CentPrecisionMoney); ok {
+// 		freeAbove := map[string]interface{}{
+// 			"currency_code": string(typedFreeAbove.CurrencyCode),
+// 			"cent_amount":   typedFreeAbove.CentAmount,
+// 		}
+// 		err = d.Set("free_above", []interface{}{freeAbove})
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+// 	log.Printf("[DEBUG] New state: %#v", d)
+
+// 	return nil
+// }

--- a/commercetools/resource_shipping_zone_rate_test.go
+++ b/commercetools/resource_shipping_zone_rate_test.go
@@ -1,278 +1,278 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccShippingZoneRate_createAndUpdate(t *testing.T) {
+// func TestAccShippingZoneRate_createAndUpdate(t *testing.T) {
 
-	taxCategoryName := acctest.RandomWithPrefix("tf-acc-test")
-	shippingMethodName := acctest.RandomWithPrefix("tf-acc-test")
+// 	taxCategoryName := acctest.RandomWithPrefix("tf-acc-test")
+// 	shippingMethodName := acctest.RandomWithPrefix("tf-acc-test")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckShippingZoneRateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccShippingZoneRateConfig(taxCategoryName, shippingMethodName, "EUR"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "price.0.cent_amount", "5000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "price.0.currency_code", "EUR",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "free_above.0.cent_amount", "50000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "free_above.0.currency_code", "EUR",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.type", "CartValue",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.minimum_cent_amount", "5000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.price.0.cent_amount", "5000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.type", "CartValue",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.minimum_cent_amount", "20000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.price.0.cent_amount", "2000",
-					),
-				),
-			},
-			{
-				Config: testAccShippingZoneRateUpdate(taxCategoryName, shippingMethodName, "USD"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "price.0.cent_amount", "4321",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "price.0.currency_code", "USD",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "free_above.0.cent_amount", "12345",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "free_above.0.currency_code", "USD",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.type", "CartScore",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.score", "10",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.price.0.cent_amount", "5000",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.type", "CartScore",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.score", "20",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.price.0.cent_amount", "2000",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckShippingZoneRateDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccShippingZoneRateConfig(taxCategoryName, shippingMethodName, "EUR"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "price.0.cent_amount", "5000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "price.0.currency_code", "EUR",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "free_above.0.cent_amount", "50000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "free_above.0.currency_code", "EUR",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.#", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.type", "CartValue",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.minimum_cent_amount", "5000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.price.0.cent_amount", "5000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.type", "CartValue",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.minimum_cent_amount", "20000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.price.0.cent_amount", "2000",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccShippingZoneRateUpdate(taxCategoryName, shippingMethodName, "USD"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "price.0.cent_amount", "4321",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "price.0.currency_code", "USD",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "free_above.0.cent_amount", "12345",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "free_above.0.currency_code", "USD",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.#", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.type", "CartScore",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.score", "10",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.0.price.0.cent_amount", "5000",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.type", "CartScore",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.score", "20",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone_rate.standard-de", "shipping_rate_price_tier.1.price.0.cent_amount", "2000",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccShippingZoneRateConfig(taxCategoryName string, shippingMethodName string, currencyCode string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_tax_category" "standard" {
-		name        = "%[1]s"
-		key         = "%[1]s"
-		description = "Terraform test rate tax"
-	}
+// func testAccShippingZoneRateConfig(taxCategoryName string, shippingMethodName string, currencyCode string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_tax_category" "standard" {
+// 		name        = "%[1]s"
+// 		key         = "%[1]s"
+// 		description = "Terraform test rate tax"
+// 	}
 
-	resource "commercetools_shipping_method" "standard" {
-		name            = "%[2]s"
-		key             = "%[2]s"
-		description     = "Terraform test tax category"
-		tax_category_id = "${commercetools_tax_category.standard.id}"
-		predicate		= "1 = 1"
-	}
+// 	resource "commercetools_shipping_method" "standard" {
+// 		name            = "%[2]s"
+// 		key             = "%[2]s"
+// 		description     = "Terraform test tax category"
+// 		tax_category_id = "${commercetools_tax_category.standard.id}"
+// 		predicate		= "1 = 1"
+// 	}
 
-	resource "commercetools_shipping_zone" "de" {
-	    name        = "DE"
-	    description = "Germany"
-        location {
-		    country = "DE"
-	    }
-	}
+// 	resource "commercetools_shipping_zone" "de" {
+// 	    name        = "DE"
+// 	    description = "Germany"
+//         location {
+// 		    country = "DE"
+// 	    }
+// 	}
 
-	resource "commercetools_shipping_zone_rate" "standard-de" {
-		shipping_method_id = "${commercetools_shipping_method.standard.id}"
-		shipping_zone_id   = "${commercetools_shipping_zone.de.id}"
+// 	resource "commercetools_shipping_zone_rate" "standard-de" {
+// 		shipping_method_id = "${commercetools_shipping_method.standard.id}"
+// 		shipping_zone_id   = "${commercetools_shipping_zone.de.id}"
 
-		price {
-		    cent_amount   = 5000
-		    currency_code = "%[3]s"
-		}
+// 		price {
+// 		    cent_amount   = 5000
+// 		    currency_code = "%[3]s"
+// 		}
 
-		free_above {
-		    cent_amount   = 50000
-		    currency_code = "%[3]s"
-		}
+// 		free_above {
+// 		    cent_amount   = 50000
+// 		    currency_code = "%[3]s"
+// 		}
 
-		shipping_rate_price_tier {
-            type                = "CartValue"
-            minimum_cent_amount = 5000
+// 		shipping_rate_price_tier {
+//             type                = "CartValue"
+//             minimum_cent_amount = 5000
 
-            price {
-              cent_amount      = 5000
-              currency_code    = "%[3]s"
-            }
-		}
+//             price {
+//               cent_amount      = 5000
+//               currency_code    = "%[3]s"
+//             }
+// 		}
 
-		shipping_rate_price_tier {
-			type                = "CartValue"
-            minimum_cent_amount = 20000
+// 		shipping_rate_price_tier {
+// 			type                = "CartValue"
+//             minimum_cent_amount = 20000
 
-            price {
-              cent_amount      = 2000
-              currency_code    = "%[3]s"
-            }
-		}
+//             price {
+//               cent_amount      = 2000
+//               currency_code    = "%[3]s"
+//             }
+// 		}
 
-	}
-`, taxCategoryName, shippingMethodName, currencyCode)
-}
+// 	}
+// `, taxCategoryName, shippingMethodName, currencyCode)
+// }
 
-func testAccShippingZoneRateUpdate(taxCategoryName string, shippingMethodName string, currencyCode string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_tax_category" "standard" {
-		name        = "%[1]s"
-		key         = "%[1]s"
-		description = "Terraform test rate tax"
-	}
+// func testAccShippingZoneRateUpdate(taxCategoryName string, shippingMethodName string, currencyCode string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_tax_category" "standard" {
+// 		name        = "%[1]s"
+// 		key         = "%[1]s"
+// 		description = "Terraform test rate tax"
+// 	}
 
-	resource "commercetools_shipping_method" "standard" {
-		name            = "%[2]s"
-		key             = "%[2]s"
-		description     = "Terraform test tax category"
-		tax_category_id = "${commercetools_tax_category.standard.id}"
-		predicate		= "1 = 1"
-	}
+// 	resource "commercetools_shipping_method" "standard" {
+// 		name            = "%[2]s"
+// 		key             = "%[2]s"
+// 		description     = "Terraform test tax category"
+// 		tax_category_id = "${commercetools_tax_category.standard.id}"
+// 		predicate		= "1 = 1"
+// 	}
 
-	resource "commercetools_shipping_zone" "de" {
-	    name        = "DE"
-	    description = "Germany"
-        location {
-		    country = "DE"
-	    }
-	}
+// 	resource "commercetools_shipping_zone" "de" {
+// 	    name        = "DE"
+// 	    description = "Germany"
+//         location {
+// 		    country = "DE"
+// 	    }
+// 	}
 
-	resource "commercetools_shipping_zone_rate" "standard-de" {
-		shipping_method_id = "${commercetools_shipping_method.standard.id}"
-		shipping_zone_id   = "${commercetools_shipping_zone.de.id}"
+// 	resource "commercetools_shipping_zone_rate" "standard-de" {
+// 		shipping_method_id = "${commercetools_shipping_method.standard.id}"
+// 		shipping_zone_id   = "${commercetools_shipping_zone.de.id}"
 
-		price {
-		    cent_amount   = 4321
-		    currency_code = "%[3]s"
-		}
+// 		price {
+// 		    cent_amount   = 4321
+// 		    currency_code = "%[3]s"
+// 		}
 
-		free_above {
-		    cent_amount   = 12345
-		    currency_code = "%[3]s"
-		}
+// 		free_above {
+// 		    cent_amount   = 12345
+// 		    currency_code = "%[3]s"
+// 		}
 
-        shipping_rate_price_tier {
-            type                = "CartScore"
-            score               = 10
+//         shipping_rate_price_tier {
+//             type                = "CartScore"
+//             score               = 10
 
-            price {
-              cent_amount      = 5000
-              currency_code    = "%[3]s"
-            }
-		}
+//             price {
+//               cent_amount      = 5000
+//               currency_code    = "%[3]s"
+//             }
+// 		}
 
-		shipping_rate_price_tier {
-			type                = "CartScore"
-            score               = 20
+// 		shipping_rate_price_tier {
+// 			type                = "CartScore"
+//             score               = 20
 
-            price {
-              cent_amount      = 2000
-              currency_code    = "%[3]s"
-            }
-		}
+//             price {
+//               cent_amount      = 2000
+//               currency_code    = "%[3]s"
+//             }
+// 		}
 
-	}
-`, taxCategoryName, shippingMethodName, currencyCode)
-}
+// 	}
+// `, taxCategoryName, shippingMethodName, currencyCode)
+// }
 
-func testAccCheckShippingZoneRateDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
-	// TODO: Do we want to check trailing rates separately? Similar to resource_tax_category_test_rate.go
+// func testAccCheckShippingZoneRateDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
+// 	// TODO: Do we want to check trailing rates separately? Similar to resource_tax_category_test_rate.go
 
-	for _, rs := range s.RootModule().Resources {
-		switch rs.Type {
-		case "commercetools_tax_category":
-			{
-				response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
-						return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		case "commercetools_shipping_method":
-			{
-				response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
+// 	for _, rs := range s.RootModule().Resources {
+// 		switch rs.Type {
+// 		case "commercetools_tax_category":
+// 			{
+// 				response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
+// 						return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		case "commercetools_shipping_method":
+// 			{
+// 				response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
 
-						return fmt.Errorf("shipping method (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		case "commercetools_shipping_zone":
-			{
-				response, err := client.Zones().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
-						return fmt.Errorf("shipping zone (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		default:
-			continue
-		}
-	}
-	return nil
-}
+// 						return fmt.Errorf("shipping method (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		case "commercetools_shipping_zone":
+// 			{
+// 				response, err := client.Zones().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
+// 						return fmt.Errorf("shipping zone (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		default:
+// 			continue
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_shipping_zone_test.go
+++ b/commercetools/resource_shipping_zone_test.go
@@ -1,238 +1,238 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccShippingZone_createAndUpdateWithID(t *testing.T) {
+// func TestAccShippingZone_createAndUpdateWithID(t *testing.T) {
 
-	key := "key"
-	name := "name"
-	description := "description"
+// 	key := "key"
+// 	name := "name"
+// 	description := "description"
 
-	newKey := "new-key"
-	newName := "new name"
-	newDescription := "new description"
+// 	newKey := "new-key"
+// 	newName := "new name"
+// 	newDescription := "new description"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckShippingZoneDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccShippingZoneConfig(name, description, key),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "description", description,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "key", key,
-					),
-				),
-			},
-			{
-				Config: testAccShippingZoneConfig(newName, newDescription, newKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "name", newName,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "description", newDescription,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.#", "2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "key", newKey,
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckShippingZoneDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccShippingZoneConfig(name, description, key),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "description", description,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.#", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "key", key,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccShippingZoneConfig(newName, newDescription, newKey),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "name", newName,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "description", newDescription,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.#", "2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "key", newKey,
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccShippingZoneConfig(name string, description string, key string) string {
-	return fmt.Sprintf(`
-resource "commercetools_shipping_zone" "standard" {
-	name = "%s"
-	description = "%s"
-	key = "%s"
-	location {
-		country = "DE"
-	}
-	location {
-		country = "US"
-		state = "Nevada"
-	}
-}`, name, description, key)
-}
+// func testAccShippingZoneConfig(name string, description string, key string) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_shipping_zone" "standard" {
+// 	name = "%s"
+// 	description = "%s"
+// 	key = "%s"
+// 	location {
+// 		country = "DE"
+// 	}
+// 	location {
+// 		country = "US"
+// 		state = "Nevada"
+// 	}
+// }`, name, description, key)
+// }
 
-func TestAccShippingZone_createAndAddLocation(t *testing.T) {
+// func TestAccShippingZone_createAndAddLocation(t *testing.T) {
 
-	name := "name"
-	description := "description"
+// 	name := "name"
+// 	description := "description"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckShippingZoneDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccShippingZoneConfig(name, description, name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.0.country", "DE",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.1.country", "US",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.1.state", "Nevada",
-					),
-				),
-			},
-			{
-				Config: testAccShippingZoneConfigLocationAdded(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "name", "the zone",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "description", "the description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.#", "3",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.0.country", "DE",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.1.country", "ES",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.2.country", "US",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.2.state", "Nevada",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckShippingZoneDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccShippingZoneConfig(name, description, name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.0.country", "DE",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.1.country", "US",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.1.state", "Nevada",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccShippingZoneConfigLocationAdded(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "name", "the zone",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "description", "the description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.#", "3",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.0.country", "DE",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.1.country", "ES",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.2.country", "US",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.2.state", "Nevada",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccShippingZoneConfigLocationAdded() string {
-	return `
-resource "commercetools_shipping_zone" "standard" {
-	name = "the zone"
-	description = "the description"
-	location {
-		country = "DE"
-	}
-	location {
-		country = "ES"
-	}
-	location {
-		country = "US"
-		state = "Nevada"
-	}
-}`
-}
+// func testAccShippingZoneConfigLocationAdded() string {
+// 	return `
+// resource "commercetools_shipping_zone" "standard" {
+// 	name = "the zone"
+// 	description = "the description"
+// 	location {
+// 		country = "DE"
+// 	}
+// 	location {
+// 		country = "ES"
+// 	}
+// 	location {
+// 		country = "US"
+// 		state = "Nevada"
+// 	}
+// }`
+// }
 
-func TestAccShippingZone_createAndRemoveLocation(t *testing.T) {
+// func TestAccShippingZone_createAndRemoveLocation(t *testing.T) {
 
-	name := "name"
-	description := "description"
+// 	name := "name"
+// 	description := "description"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckShippingZoneDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccShippingZoneConfig(name, description, name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.0.country", "DE",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.1.country", "US",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.1.state", "Nevada",
-					),
-				),
-			},
-			{
-				Config: testAccShippingZoneConfigLocationRemoved(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "name", "the zone",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "description", "the description",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.0.country", "US",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_shipping_zone.standard", "location.0.state", "Nevada",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckShippingZoneDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccShippingZoneConfig(name, description, name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.0.country", "DE",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.1.country", "US",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.1.state", "Nevada",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccShippingZoneConfigLocationRemoved(),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "name", "the zone",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "description", "the description",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.#", "1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.0.country", "US",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_shipping_zone.standard", "location.0.state", "Nevada",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccShippingZoneConfigLocationRemoved() string {
-	return `
-resource "commercetools_shipping_zone" "standard" {
-	name = "the zone"
-	description = "the description"
-	location {
-		country = "US"
-		state = "Nevada"
-	}
-}`
-}
+// func testAccShippingZoneConfigLocationRemoved() string {
+// 	return `
+// resource "commercetools_shipping_zone" "standard" {
+// 	name = "the zone"
+// 	description = "the description"
+// 	location {
+// 		country = "US"
+// 		state = "Nevada"
+// 	}
+// }`
+// }
 
-func testAccCheckShippingZoneDestroy(s *terraform.State) error {
-	conn := getClient(testAccProvider.Meta())
+// func testAccCheckShippingZoneDestroy(s *terraform.State) error {
+// 	conn := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_shipping_zone" {
-			continue
-		}
-		response, err := conn.Zones().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("shipping zone (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_shipping_zone" {
+// 			continue
+// 		}
+// 		response, err := conn.Zones().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("shipping zone (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_state.go
+++ b/commercetools/resource_state.go
@@ -1,277 +1,277 @@
 package commercetools
 
-import (
-	"context"
-	"time"
+// import (
+// 	"context"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceState() *schema.Resource {
-	return &schema.Resource{
-		Description: "The commercetools platform allows you to model states of certain objects, such as orders, line " +
-			"items, products, reviews, and payments to define finite state machines reflecting the business " +
-			"logic you'd like to implement.\n\n" +
-			"See also the [State API Documentation](https://docs.commercetools.com/api/projects/states)",
-		Create: resourceStateCreate,
-		Read:   resourceStateRead,
-		Update: resourceStateUpdate,
-		Delete: resourceStateDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "A unique identifier for the state",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"type": {
-				Description: "[StateType](https://docs.commercetools.com/api/projects/states#statetype)",
-				Type:        schema.TypeString,
-				Required:    true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(platform.StateTypeEnumOrderState),
-					string(platform.StateTypeEnumLineItemState),
-					string(platform.StateTypeEnumProductState),
-					string(platform.StateTypeEnumReviewState),
-					string(platform.StateTypeEnumPaymentState),
-				}, false),
-			},
-			"name": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"description": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"initial": {
-				Description: "A state can be declared as an initial state for any state machine. When a workflow " +
-					"starts, this first state must be an initial state",
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"roles": {
-				Description: "Array of [State Role](https://docs.commercetools.com/api/projects/states#staterole)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(platform.StateRoleEnumReviewIncludedInStatistics),
-						string(platform.StateRoleEnumReturn),
-					}, false),
-				},
-			},
-			"transitions": {
-				Description: "Transitions are a way to describe possible transformations of the current state to other " +
-					"states of the same type (for example: Initial -> Shipped). When performing a transitionState update " +
-					"action and transitions is set, the currently referenced state must have a transition to the new state.\n" +
-					"If transitions is an empty list, it means the current state is a final state and no further " +
-					"transitions are allowed.\nIf transitions is not set, the validation is turned off. When " +
-					"performing a transitionState update action, any other state of the same type can be transitioned to",
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-		},
-	}
-}
+// func resourceState() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "The commercetools platform allows you to model states of certain objects, such as orders, line " +
+// 			"items, products, reviews, and payments to define finite state machines reflecting the business " +
+// 			"logic you'd like to implement.\n\n" +
+// 			"See also the [State API Documentation](https://docs.commercetools.com/api/projects/states)",
+// 		Create: resourceStateCreate,
+// 		Read:   resourceStateRead,
+// 		Update: resourceStateUpdate,
+// 		Delete: resourceStateDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "A unique identifier for the state",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 			"type": {
+// 				Description: "[StateType](https://docs.commercetools.com/api/projects/states#statetype)",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 				ValidateFunc: validation.StringInSlice([]string{
+// 					string(platform.StateTypeEnumOrderState),
+// 					string(platform.StateTypeEnumLineItemState),
+// 					string(platform.StateTypeEnumProductState),
+// 					string(platform.StateTypeEnumReviewState),
+// 					string(platform.StateTypeEnumPaymentState),
+// 				}, false),
+// 			},
+// 			"name": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"description": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"initial": {
+// 				Description: "A state can be declared as an initial state for any state machine. When a workflow " +
+// 					"starts, this first state must be an initial state",
+// 				Type:     types.BoolType,
+// 				Optional: true,
+// 			},
+// 			"roles": {
+// 				Description: "Array of [State Role](https://docs.commercetools.com/api/projects/states#staterole)",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem: &schema.Schema{
+// 					Type: types.StringType,
+// 					ValidateFunc: validation.StringInSlice([]string{
+// 						string(platform.StateRoleEnumReviewIncludedInStatistics),
+// 						string(platform.StateRoleEnumReturn),
+// 					}, false),
+// 				},
+// 			},
+// 			"transitions": {
+// 				Description: "Transitions are a way to describe possible transformations of the current state to other " +
+// 					"states of the same type (for example: Initial -> Shipped). When performing a transitionState update " +
+// 					"action and transitions is set, the currently referenced state must have a transition to the new state.\n" +
+// 					"If transitions is an empty list, it means the current state is a final state and no further " +
+// 					"transitions are allowed.\nIf transitions is not set, the validation is turned off. When " +
+// 					"performing a transitionState update action, any other state of the same type can be transitioned to",
+// 				Type:     schema.TypeSet,
+// 				Optional: true,
+// 				Elem: &schema.Schema{
+// 					Type: types.StringType,
+// 				},
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceStateCreate(d *schema.ResourceData, m interface{}) error {
-	name := platform.LocalizedString(
-		expandStringMap(d.Get("name").(map[string]interface{})))
-	description := platform.LocalizedString(
-		expandStringMap(d.Get("description").(map[string]interface{})))
+// func resourceStateCreate(d *schema.ResourceData, m interface{}) error {
+// 	name := platform.LocalizedString(
+// 		expandStringMap(d.Get("name").(map[string]interface{})))
+// 	description := platform.LocalizedString(
+// 		expandStringMap(d.Get("description").(map[string]interface{})))
 
-	roles := []platform.StateRoleEnum{}
-	for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
-		roles = append(roles, platform.StateRoleEnum(value))
-	}
+// 	roles := []platform.StateRoleEnum{}
+// 	for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
+// 		roles = append(roles, platform.StateRoleEnum(value))
+// 	}
 
-	var transitions []platform.StateResourceIdentifier
-	for _, value := range d.Get("transitions").(*schema.Set).List() {
-		transitions = append(transitions, platform.StateResourceIdentifier{
-			ID: stringRef(value),
-		})
-	}
+// 	var transitions []platform.StateResourceIdentifier
+// 	for _, value := range d.Get("transitions").(*schema.Set).List() {
+// 		transitions = append(transitions, platform.StateResourceIdentifier{
+// 			ID: stringRef(value),
+// 		})
+// 	}
 
-	draft := platform.StateDraft{
-		Key:         d.Get("key").(string),
-		Type:        platform.StateTypeEnum(d.Get("type").(string)),
-		Name:        &name,
-		Description: &description,
-		Roles:       roles,
-		Transitions: transitions,
-	}
+// 	draft := platform.StateDraft{
+// 		Key:         d.Get("key").(string),
+// 		Type:        platform.StateTypeEnum(d.Get("type").(string)),
+// 		Name:        &name,
+// 		Description: &description,
+// 		Roles:       roles,
+// 		Transitions: transitions,
+// 	}
 
-	// Note the use of GetOkExists since it's an optional bool type
-	if _, exists := d.GetOkExists("initial"); exists {
-		draft.Initial = boolRef(d.Get("initial"))
-	}
+// 	// Note the use of GetOkExists since it's an optional bool type
+// 	if _, exists := d.GetOkExists("initial"); exists {
+// 		draft.Initial = boolRef(d.Get("initial"))
+// 	}
 
-	client := getClient(m)
-	var state *platform.State
+// 	client := getClient(m)
+// 	var state *platform.State
 
-	err := resource.Retry(20*time.Second, func() *resource.RetryError {
-		var err error
+// 	err := resource.Retry(20*time.Second, func() *resource.RetryError {
+// 		var err error
 
-		state, err = client.States().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		state, err = client.States().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	d.SetId(state.ID)
-	d.Set("version", state.Version)
-	return resourceStateRead(d, m)
-}
+// 	d.SetId(state.ID)
+// 	d.Set("version", state.Version)
+// 	return resourceStateRead(d, m)
+// }
 
-func resourceStateRead(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	state, err := client.States().WithId(d.Id()).Get().Execute(context.Background())
+// func resourceStateRead(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	state, err := client.States().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	d.SetId(state.ID)
-	d.Set("version", state.Version)
-	d.Set("key", state.Key)
-	d.Set("type", state.Type)
-	if state.Name != nil {
-		d.Set("name", *state.Name)
-	}
-	if state.Description != nil {
-		d.Set("description", *state.Description)
-	}
-	d.Set("initial", state.Initial)
-	if state.Roles != nil {
-		d.Set("roles", state.Roles)
-	}
-	if state.Transitions != nil {
-		d.Set("transitions", marshallStateTransitions(state.Transitions))
-	}
-	return nil
-}
+// 	d.SetId(state.ID)
+// 	d.Set("version", state.Version)
+// 	d.Set("key", state.Key)
+// 	d.Set("type", state.Type)
+// 	if state.Name != nil {
+// 		d.Set("name", *state.Name)
+// 	}
+// 	if state.Description != nil {
+// 		d.Set("description", *state.Description)
+// 	}
+// 	d.Set("initial", state.Initial)
+// 	if state.Roles != nil {
+// 		d.Set("roles", state.Roles)
+// 	}
+// 	if state.Transitions != nil {
+// 		d.Set("transitions", marshallStateTransitions(state.Transitions))
+// 	}
+// 	return nil
+// }
 
-func resourceStateUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceStateUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	input := platform.StateUpdate{
-		Version: d.Get("version").(int),
-		Actions: []platform.StateUpdateAction{},
-	}
+// 	input := platform.StateUpdate{
+// 		Version: d.Get("version").(int),
+// 		Actions: []platform.StateUpdateAction{},
+// 	}
 
-	if d.HasChange("name") {
-		newName := platform.LocalizedString(
-			expandStringMap(d.Get("name").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.StateSetNameAction{Name: newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := platform.LocalizedString(
+// 			expandStringMap(d.Get("name").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StateSetNameAction{Name: newName})
+// 	}
 
-	if d.HasChange("description") {
-		newDescription := platform.LocalizedString(
-			expandStringMap(d.Get("description").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.StateSetDescriptionAction{Description: newDescription})
-	}
+// 	if d.HasChange("description") {
+// 		newDescription := platform.LocalizedString(
+// 			expandStringMap(d.Get("description").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StateSetDescriptionAction{Description: newDescription})
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.StateChangeKeyAction{Key: newKey})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StateChangeKeyAction{Key: newKey})
+// 	}
 
-	if d.HasChange("type") {
-		newType := d.Get("type").(platform.StateTypeEnum)
-		input.Actions = append(
-			input.Actions,
-			&platform.StateChangeTypeAction{Type: newType})
-	}
+// 	if d.HasChange("type") {
+// 		newType := d.Get("type").(platform.StateTypeEnum)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StateChangeTypeAction{Type: newType})
+// 	}
 
-	if d.HasChange("initial") {
-		newInitial := d.Get("initial").(bool)
-		input.Actions = append(
-			input.Actions,
-			&platform.StateChangeInitialAction{Initial: newInitial})
-	}
+// 	if d.HasChange("initial") {
+// 		newInitial := d.Get("initial").(bool)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StateChangeInitialAction{Initial: newInitial})
+// 	}
 
-	if d.HasChange("roles") {
-		roles := []platform.StateRoleEnum{}
-		for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
-			roles = append(roles, platform.StateRoleEnum(value))
-		}
-		input.Actions = append(
-			input.Actions,
-			&platform.StateSetRolesAction{Roles: roles})
-	}
+// 	if d.HasChange("roles") {
+// 		roles := []platform.StateRoleEnum{}
+// 		for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
+// 			roles = append(roles, platform.StateRoleEnum(value))
+// 		}
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StateSetRolesAction{Roles: roles})
+// 	}
 
-	if d.HasChange("transitions") {
-		var transitions []platform.StateResourceIdentifier
-		for _, value := range d.Get("transitions").(*schema.Set).List() {
-			transitions = append(transitions, platform.StateResourceIdentifier{
-				ID: stringRef(value),
-			})
-		}
-		input.Actions = append(
-			input.Actions,
-			&platform.StateSetTransitionsAction{
-				Transitions: transitions,
-			})
-	}
+// 	if d.HasChange("transitions") {
+// 		var transitions []platform.StateResourceIdentifier
+// 		for _, value := range d.Get("transitions").(*schema.Set).List() {
+// 			transitions = append(transitions, platform.StateResourceIdentifier{
+// 				ID: stringRef(value),
+// 			})
+// 		}
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StateSetTransitionsAction{
+// 				Transitions: transitions,
+// 			})
+// 	}
 
-	_, err := client.States().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	_, err := client.States().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return resourceStateRead(d, m)
-}
+// 	return resourceStateRead(d, m)
+// }
 
-func resourceStateDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.States().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyStatesByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// func resourceStateDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.States().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyStatesByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func marshallStateTransitions(values []platform.StateReference) []string {
-	result := make([]string, len(values))
-	for idx, _ := range values {
-		result[idx] = values[idx].ID
-	}
-	return result
-}
+// func marshallStateTransitions(values []platform.StateReference) []string {
+// 	result := make([]string, len(values))
+// 	for idx, _ := range values {
+// 		result[idx] = values[idx].ID
+// 	}
+// 	return result
+// }

--- a/commercetools/resource_state_test.go
+++ b/commercetools/resource_state_test.go
@@ -1,153 +1,153 @@
 package commercetools
 
-import (
-	"bytes"
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"bytes"
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccState_createAndUpdateWithID(t *testing.T) {
-	name := "test state"
-	key := "test-state"
+// func TestAccState_createAndUpdateWithID(t *testing.T) {
+// 	name := "test state"
+// 	key := "test-state"
 
-	newName := "new test state name"
+// 	newName := "new test state name"
 
-	transition := "state-b"
+// 	transition := "state-b"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckStateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccStateConfig(t, name, key, false),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-state", "name.en", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-state", "key", key,
-					),
-				),
-			},
-			{
-				Config: testAccStateConfig(t, newName, key, true),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-state", "name.en", newName,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-state", "key", key,
-					),
-				),
-			},
-			{
-				Config: testAccTransitionConfig(t, transition),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-t1", "transitions.#", "1",
-					),
-				),
-			},
-			{
-				Config: testAccTransitionsConfig(t, "null"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr(
-						"commercetools_state.acctest-transitions", "transitions",
-					),
-				),
-			},
-			{
-				Config: testAccTransitionsConfig(t, "[]"),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_state.acctest-transitions", "transitions.#", "0",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckStateDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccStateConfig(t, name, key, false),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_state.acctest-state", "name.en", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_state.acctest-state", "key", key,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccStateConfig(t, newName, key, true),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_state.acctest-state", "name.en", newName,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_state.acctest-state", "key", key,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTransitionConfig(t, transition),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_state.acctest-t1", "transitions.#", "1",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTransitionsConfig(t, "null"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckNoResourceAttr(
+// 						"commercetools_state.acctest-transitions", "transitions",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTransitionsConfig(t, "[]"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_state.acctest-transitions", "transitions.#", "0",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccStateConfig(t *testing.T, name string, key string, addRole bool) string {
-	buf := bytes.Buffer{}
-	stateConfig := fmt.Sprintf(`
-	resource "commercetools_state" "acctest-state" {
-		key = "%[2]s"
-		type = "ReviewState"
-		name = {
-			en = "%[1]s"
-			nl = "%[1]s"
-		}
-	`, name, key)
-	buf.WriteString(stateConfig)
+// func testAccStateConfig(t *testing.T, name string, key string, addRole bool) string {
+// 	buf := bytes.Buffer{}
+// 	stateConfig := fmt.Sprintf(`
+// 	resource "commercetools_state" "acctest-state" {
+// 		key = "%[2]s"
+// 		type = "ReviewState"
+// 		name = {
+// 			en = "%[1]s"
+// 			nl = "%[1]s"
+// 		}
+// 	`, name, key)
+// 	buf.WriteString(stateConfig)
 
-	if addRole {
-		buf.WriteString("roles = [\"ReviewIncludedInStatistics\"]\n")
-	}
-	buf.WriteString("}")
-	newState := buf.String()
+// 	if addRole {
+// 		buf.WriteString("roles = [\"ReviewIncludedInStatistics\"]\n")
+// 	}
+// 	buf.WriteString("}")
+// 	newState := buf.String()
 
-	return newState
-}
+// 	return newState
+// }
 
-func testAccTransitionConfig(t *testing.T, transition string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_state" "acctest-t1" {
-		depends_on = [commercetools_state.acctest_t2]
-		key = "state-a"
-		type = "ReviewState"
-		name = {
-			en = "State #1"
-		}
-		transitions = [commercetools_state.acctest_t2.id]
-	}
+// func testAccTransitionConfig(t *testing.T, transition string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_state" "acctest-t1" {
+// 		depends_on = [commercetools_state.acctest_t2]
+// 		key = "state-a"
+// 		type = "ReviewState"
+// 		name = {
+// 			en = "State #1"
+// 		}
+// 		transitions = [commercetools_state.acctest_t2.id]
+// 	}
 
-	resource "commercetools_state" "acctest_t2" {
-		key = "%[1]s"
-		type = "ReviewState"
-		name = {
-			en = "State #2"
-		}
-		transitions = []
-	}
-	`, transition)
-}
+// 	resource "commercetools_state" "acctest_t2" {
+// 		key = "%[1]s"
+// 		type = "ReviewState"
+// 		name = {
+// 			en = "State #2"
+// 		}
+// 		transitions = []
+// 	}
+// 	`, transition)
+// }
 
-func testAccTransitionsConfig(t *testing.T, transitions string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_state" "acctest-transitions" {
-		key = "state-c"
-		type = "ReviewState"
-		name = {
-			en = "State C"
-		}
-		transitions = %s
-	}
-	`, transitions)
-}
+// func testAccTransitionsConfig(t *testing.T, transitions string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_state" "acctest-transitions" {
+// 		key = "state-c"
+// 		type = "ReviewState"
+// 		name = {
+// 			en = "State C"
+// 		}
+// 		transitions = %s
+// 	}
+// 	`, transitions)
+// }
 
-func testAccCheckStateDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckStateDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_state" {
-			continue
-		}
-		response, err := client.States().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("state (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_state" {
+// 			continue
+// 		}
+// 		response, err := client.States().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("state (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_store.go
+++ b/commercetools/resource_store.go
@@ -1,258 +1,258 @@
 package commercetools
 
-import (
-	"context"
-	"errors"
-	"log"
-	"time"
+// import (
+// 	"context"
+// 	"errors"
+// 	"log"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceStore() *schema.Resource {
-	return &schema.Resource{
-		Description: "Stores can be used to model, for example, physical retail locations, brand stores, " +
-			"or country-specific stores.\n\n" +
-			"See also the [Stores API Documentation](https://docs.commercetools.com/api/projects/stores)",
-		Create: resourceStoreCreate,
-		Read:   resourceStoreRead,
-		Update: resourceStoreUpdate,
-		Delete: resourceStoreDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for the store. The key is mandatory and immutable. " +
-					"It is used to reference the store",
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"name": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"languages": {
-				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			"distribution_channels": {
-				Description: "Set of ResourceIdentifier to a Channel with ProductDistribution",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			"supply_channels": {
-				Description: "Set of ResourceIdentifier of Channels with InventorySupply",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-		},
-	}
-}
+// func resourceStore() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Stores can be used to model, for example, physical retail locations, brand stores, " +
+// 			"or country-specific stores.\n\n" +
+// 			"See also the [Stores API Documentation](https://docs.commercetools.com/api/projects/stores)",
+// 		Create: resourceStoreCreate,
+// 		Read:   resourceStoreRead,
+// 		Update: resourceStoreUpdate,
+// 		Delete: resourceStoreDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for the store. The key is mandatory and immutable. " +
+// 					"It is used to reference the store",
+// 				Type:     types.StringType,
+// 				Required: true,
+// 				ForceNew: true,
+// 			},
+// 			"name": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 			"languages": {
+// 				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 			},
+// 			"distribution_channels": {
+// 				Description: "Set of ResourceIdentifier to a Channel with ProductDistribution",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 			},
+// 			"supply_channels": {
+// 				Description: "Set of ResourceIdentifier of Channels with InventorySupply",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem:        &schema.Schema{Type: types.StringType},
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceStoreCreate(d *schema.ResourceData, m interface{}) error {
-	name := platform.LocalizedString(
-		expandStringMap(d.Get("name").(map[string]interface{})))
-	dcIdentifiers := expandStoreChannels(d.Get("distribution_channels"))
+// func resourceStoreCreate(d *schema.ResourceData, m interface{}) error {
+// 	name := platform.LocalizedString(
+// 		expandStringMap(d.Get("name").(map[string]interface{})))
+// 	dcIdentifiers := expandStoreChannels(d.Get("distribution_channels"))
 
-	draft := platform.StoreDraft{
-		Key:                  d.Get("key").(string),
-		Name:                 &name,
-		Languages:            expandStringArray(d.Get("languages").([]interface{})),
-		DistributionChannels: dcIdentifiers,
-	}
+// 	draft := platform.StoreDraft{
+// 		Key:                  d.Get("key").(string),
+// 		Name:                 &name,
+// 		Languages:            expandStringArray(d.Get("languages").([]interface{})),
+// 		DistributionChannels: dcIdentifiers,
+// 	}
 
-	client := getClient(m)
+// 	client := getClient(m)
 
-	var store *platform.Store
+// 	var store *platform.Store
 
-	err := resource.Retry(20*time.Second, func() *resource.RetryError {
-		var err error
-		store, err = client.Stores().Post(draft).Execute(context.Background())
+// 	err := resource.Retry(20*time.Second, func() *resource.RetryError {
+// 		var err error
+// 		store, err = client.Stores().Post(draft).Execute(context.Background())
 
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	d.SetId(store.ID)
-	d.Set("version", store.Version)
-	return resourceStoreRead(d, m)
-}
+// 	d.SetId(store.ID)
+// 	d.Set("version", store.Version)
+// 	return resourceStoreRead(d, m)
+// }
 
-func resourceStoreRead(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceStoreRead(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	store, err := client.Stores().WithId(d.Id()).Get().WithQueryParams(platform.ByProjectKeyStoresByIDRequestMethodGetInput{
-		Expand: []string{"distributionChannels[*]", "supplyChannels[*]"},
-	}).Execute(context.Background())
+// 	store, err := client.Stores().WithId(d.Id()).Get().WithQueryParams(platform.ByProjectKeyStoresByIDRequestMethodGetInput{
+// 		Expand: []string{"distributionChannels[*]", "supplyChannels[*]"},
+// 	}).Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	d.SetId(store.ID)
-	d.Set("key", store.Key)
-	if store.Name != nil {
-		d.Set("name", *store.Name)
-	} else {
-		d.Set("name", nil)
-	}
-	d.Set("version", store.Version)
-	if store.Languages != nil {
-		d.Set("languages", store.Languages)
-	}
+// 	d.SetId(store.ID)
+// 	d.Set("key", store.Key)
+// 	if store.Name != nil {
+// 		d.Set("name", *store.Name)
+// 	} else {
+// 		d.Set("name", nil)
+// 	}
+// 	d.Set("version", store.Version)
+// 	if store.Languages != nil {
+// 		d.Set("languages", store.Languages)
+// 	}
 
-	log.Printf("[DEBUG] Store read, distributionChannels: %+v", store.DistributionChannels)
-	if store.DistributionChannels != nil {
-		channelKeys, err := flattenStoreChannels(store.DistributionChannels)
-		if err != nil {
-			return err
-		}
-		log.Printf("[DEBUG] Setting channel keys to: %+v", channelKeys)
-		d.Set("distribution_channels", channelKeys)
-	}
-	log.Printf("[DEBUG] Store read, supplyChannels: %+v", store.SupplyChannels)
+// 	log.Printf("[DEBUG] Store read, distributionChannels: %+v", store.DistributionChannels)
+// 	if store.DistributionChannels != nil {
+// 		channelKeys, err := flattenStoreChannels(store.DistributionChannels)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		log.Printf("[DEBUG] Setting channel keys to: %+v", channelKeys)
+// 		d.Set("distribution_channels", channelKeys)
+// 	}
+// 	log.Printf("[DEBUG] Store read, supplyChannels: %+v", store.SupplyChannels)
 
-	if store.SupplyChannels != nil {
-		channelKeys, err := flattenStoreChannels(store.SupplyChannels)
-		if err != nil {
-			return err
-		}
-		log.Printf("[DEBUG] Setting channel keys to: %+v", channelKeys)
-		d.Set("supply_channels", channelKeys)
-	}
-	return nil
-}
+// 	if store.SupplyChannels != nil {
+// 		channelKeys, err := flattenStoreChannels(store.SupplyChannels)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		log.Printf("[DEBUG] Setting channel keys to: %+v", channelKeys)
+// 		d.Set("supply_channels", channelKeys)
+// 	}
+// 	return nil
+// }
 
-func resourceStoreUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceStoreUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	input := platform.StoreUpdate{
-		Version: d.Get("version").(int),
-		Actions: []platform.StoreUpdateAction{},
-	}
+// 	input := platform.StoreUpdate{
+// 		Version: d.Get("version").(int),
+// 		Actions: []platform.StoreUpdateAction{},
+// 	}
 
-	if d.HasChange("name") {
-		newName := platform.LocalizedString(
-			expandStringMap(d.Get("name").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.StoreSetNameAction{Name: &newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := platform.LocalizedString(
+// 			expandStringMap(d.Get("name").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StoreSetNameAction{Name: &newName})
+// 	}
 
-	if d.HasChange("languages") {
-		languages := expandStringArray(d.Get("languages").([]interface{}))
+// 	if d.HasChange("languages") {
+// 		languages := expandStringArray(d.Get("languages").([]interface{}))
 
-		input.Actions = append(
-			input.Actions,
-			&platform.StoreSetLanguagesAction{Languages: languages})
-	}
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StoreSetLanguagesAction{Languages: languages})
+// 	}
 
-	if d.HasChange("distribution_channels") {
-		dcIdentifiers := expandStoreChannels(d.Get("distribution_channels"))
+// 	if d.HasChange("distribution_channels") {
+// 		dcIdentifiers := expandStoreChannels(d.Get("distribution_channels"))
 
-		log.Printf("[DEBUG] distributionChannels change, new identifiers: %v", dcIdentifiers)
+// 		log.Printf("[DEBUG] distributionChannels change, new identifiers: %v", dcIdentifiers)
 
-		// set action replaces current values
-		input.Actions = append(
-			input.Actions,
-			&platform.StoreSetDistributionChannelsAction{
-				DistributionChannels: dcIdentifiers,
-			},
-		)
-	}
+// 		// set action replaces current values
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StoreSetDistributionChannelsAction{
+// 				DistributionChannels: dcIdentifiers,
+// 			},
+// 		)
+// 	}
 
-	if d.HasChange("supply_channels") {
-		scIdentifiers := expandStoreChannels(d.Get("supply_channels"))
+// 	if d.HasChange("supply_channels") {
+// 		scIdentifiers := expandStoreChannels(d.Get("supply_channels"))
 
-		log.Printf("[DEBUG] supplyChannels change, new identifiers: %v", scIdentifiers)
+// 		log.Printf("[DEBUG] supplyChannels change, new identifiers: %v", scIdentifiers)
 
-		// set action replaces current values
-		input.Actions = append(
-			input.Actions,
-			&platform.StoreSetSupplyChannelsAction{
-				SupplyChannels: scIdentifiers,
-			},
-		)
-	}
+// 		// set action replaces current values
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.StoreSetSupplyChannelsAction{
+// 				SupplyChannels: scIdentifiers,
+// 			},
+// 		)
+// 	}
 
-	_, err := client.Stores().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	_, err := client.Stores().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return resourceStoreRead(d, m)
-}
+// 	return resourceStoreRead(d, m)
+// }
 
-func resourceStoreDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.Stores().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyStoresByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// func resourceStoreDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.Stores().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyStoresByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
-func convertChannelKeysToIdentifiers(channelKeys []string) []platform.ChannelResourceIdentifier {
-	identifiers := make([]platform.ChannelResourceIdentifier, 0)
-	for i := 0; i < len(channelKeys); i++ {
-		channelIdentifier := platform.ChannelResourceIdentifier{
-			Key: &channelKeys[i],
-		}
-		identifiers = append(identifiers, channelIdentifier)
-	}
+// func convertChannelKeysToIdentifiers(channelKeys []string) []platform.ChannelResourceIdentifier {
+// 	identifiers := make([]platform.ChannelResourceIdentifier, 0)
+// 	for i := 0; i < len(channelKeys); i++ {
+// 		channelIdentifier := platform.ChannelResourceIdentifier{
+// 			Key: &channelKeys[i],
+// 		}
+// 		identifiers = append(identifiers, channelIdentifier)
+// 	}
 
-	log.Printf("[DEBUG] Converted keys: %v", identifiers)
-	return identifiers
-}
+// 	log.Printf("[DEBUG] Converted keys: %v", identifiers)
+// 	return identifiers
+// }
 
-func expandStoreChannels(channelData interface{}) []platform.ChannelResourceIdentifier {
-	log.Printf("[DEBUG] Expanding store channels: %v", channelData)
-	channelKeys := expandStringArray(channelData.([]interface{}))
-	log.Printf("[DEBUG] Expanding store channels, got keys: %v", channelKeys)
-	return convertChannelKeysToIdentifiers(channelKeys)
-}
+// func expandStoreChannels(channelData interface{}) []platform.ChannelResourceIdentifier {
+// 	log.Printf("[DEBUG] Expanding store channels: %v", channelData)
+// 	channelKeys := expandStringArray(channelData.([]interface{}))
+// 	log.Printf("[DEBUG] Expanding store channels, got keys: %v", channelKeys)
+// 	return convertChannelKeysToIdentifiers(channelKeys)
+// }
 
-func flattenStoreChannels(channels []platform.ChannelReference) ([]string, error) {
-	log.Printf("[DEBUG] flattening: %+v", channels)
-	channelKeys := make([]string, 0)
-	for i := 0; i < len(channels); i++ {
+// func flattenStoreChannels(channels []platform.ChannelReference) ([]string, error) {
+// 	log.Printf("[DEBUG] flattening: %+v", channels)
+// 	channelKeys := make([]string, 0)
+// 	for i := 0; i < len(channels); i++ {
 
-		log.Printf("[DEBUG] flattening checking channel: %s", stringFormatObject(channels[i]))
-		log.Printf("[DEBUG] flattening checking channel obj: %s", stringFormatObject(channels[i].Obj))
-		if channels[i].Obj == nil {
-			return nil, errors.New("failed to expand channel objects")
-		}
-		channelKeys = append(channelKeys, channels[i].Obj.Key)
-	}
-	log.Printf("[DEBUG] flattening final keys: %v", channelKeys)
-	return channelKeys, nil
-}
+// 		log.Printf("[DEBUG] flattening checking channel: %s", stringFormatObject(channels[i]))
+// 		log.Printf("[DEBUG] flattening checking channel obj: %s", stringFormatObject(channels[i].Obj))
+// 		if channels[i].Obj == nil {
+// 			return nil, errors.New("failed to expand channel objects")
+// 		}
+// 		channelKeys = append(channelKeys, channels[i].Obj.Key)
+// 	}
+// 	log.Printf("[DEBUG] flattening final keys: %v", channelKeys)
+// 	return channelKeys, nil
+// }

--- a/commercetools/resource_store_test.go
+++ b/commercetools/resource_store_test.go
@@ -1,226 +1,226 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccStore_createAndUpdateWithID(t *testing.T) {
+// func TestAccStore_createAndUpdateWithID(t *testing.T) {
 
-	name := "test method"
-	key := "test-method"
-	languages := []string{"en-US"}
+// 	name := "test method"
+// 	key := "test-method"
+// 	languages := []string{"en-US"}
 
-	newName := "new test method"
+// 	newName := "new test method"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckStoreDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccStoreConfig(name, key),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_store.standard", "name.en", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_store.standard", "key", key,
-					),
-				),
-			},
-			{
-				Config: testAccStoreConfig(newName, key),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_store.standard", "name.en", newName,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_store.standard", "key", key,
-					),
-				),
-			},
-			{
-				Config: testAccStoreConfigWithLanguages(name, key, languages),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_store.standard", "languages.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_store.standard", "languages.0", "en-US",
-					),
-				),
-			},
-			{
-				Config: testAccNewStoreConfigWithLanguages(name, key, languages),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_store.standard", "languages.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_store.standard", "languages.0", "en-US",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckStoreDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccStoreConfig(name, key),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.standard", "name.en", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.standard", "key", key,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccStoreConfig(newName, key),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.standard", "name.en", newName,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.standard", "key", key,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccStoreConfigWithLanguages(name, key, languages),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.standard", "languages.#", "1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.standard", "languages.0", "en-US",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccNewStoreConfigWithLanguages(name, key, languages),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.standard", "languages.#", "1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.standard", "languages.0", "en-US",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func TestAccStore_createAndUpdateDistributionLanguages(t *testing.T) {
-	name := "test dl"
-	key := "test-dl"
-	languages := []string{"en-US"}
+// func TestAccStore_createAndUpdateDistributionLanguages(t *testing.T) {
+// 	name := "test dl"
+// 	key := "test-dl"
+// 	languages := []string{"en-US"}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckStoreDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccNewStoreConfigWithChannels(name, key, languages),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_store.test", "distribution_channels.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_store.test", "distribution_channels.0", "TEST",
-					),
-				),
-			},
-			{
-				Config: testAccNewStoreConfigWithoutChannels(name, key, languages),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_store.test", "distribution_channels.#", "0",
-					),
-				),
-			},
-			{
-				Config: testAccNewStoreConfigWithChannels(name, key, languages),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_store.test", "distribution_channels.#", "1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_store.test", "distribution_channels.0", "TEST",
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckStoreDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccNewStoreConfigWithChannels(name, key, languages),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.test", "distribution_channels.#", "1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.test", "distribution_channels.0", "TEST",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccNewStoreConfigWithoutChannels(name, key, languages),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.test", "distribution_channels.#", "0",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccNewStoreConfigWithChannels(name, key, languages),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.test", "distribution_channels.#", "1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_store.test", "distribution_channels.0", "TEST",
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccStoreConfig(name string, key string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_store" "standard" {
-		name = {
-			en = "%[1]s"
-			nl = "%[1]s"
-		}
-		key = "%[2]s"
-	}`, name, key)
-}
+// func testAccStoreConfig(name string, key string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_store" "standard" {
+// 		name = {
+// 			en = "%[1]s"
+// 			nl = "%[1]s"
+// 		}
+// 		key = "%[2]s"
+// 	}`, name, key)
+// }
 
-func testAccStoreConfigWithLanguages(name string, key string, languages []string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_store" "standard" {
-		name = {
-			en = "%[1]s"
-			nl = "%[1]s"
-		}
-		key = "%[2]s"
-		languages = %[3]q
-	}`, name, key, languages)
-}
+// func testAccStoreConfigWithLanguages(name string, key string, languages []string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_store" "standard" {
+// 		name = {
+// 			en = "%[1]s"
+// 			nl = "%[1]s"
+// 		}
+// 		key = "%[2]s"
+// 		languages = %[3]q
+// 	}`, name, key, languages)
+// }
 
-func testAccNewStoreConfigWithLanguages(name string, key string, languages []string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_store" "standard" {
-		name = {
-			en = "%[1]s"
-			nl = "%[1]s"
-		}
-		key = "%[2]s"
-		languages = %[3]q
-	}`, name, key, languages)
-}
+// func testAccNewStoreConfigWithLanguages(name string, key string, languages []string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_store" "standard" {
+// 		name = {
+// 			en = "%[1]s"
+// 			nl = "%[1]s"
+// 		}
+// 		key = "%[2]s"
+// 		languages = %[3]q
+// 	}`, name, key, languages)
+// }
 
-func testAccNewStoreConfigWithChannels(name string, key string, languages []string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_channel" "test_channel" {
-		key = "TEST"
-		roles = ["ProductDistribution"]
-	}
+// func testAccNewStoreConfigWithChannels(name string, key string, languages []string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_channel" "test_channel" {
+// 		key = "TEST"
+// 		roles = ["ProductDistribution"]
+// 	}
 
-	resource "commercetools_store" "test" {
-		name = {
-			en = "%[1]s"
-			nl = "%[1]s"
-		}
-		key = "%[2]s"
-		languages = %[3]q
-		distribution_channels = [commercetools_channel.test_channel.key]
-	}
-	`, name, key, languages)
-}
+// 	resource "commercetools_store" "test" {
+// 		name = {
+// 			en = "%[1]s"
+// 			nl = "%[1]s"
+// 		}
+// 		key = "%[2]s"
+// 		languages = %[3]q
+// 		distribution_channels = [commercetools_channel.test_channel.key]
+// 	}
+// 	`, name, key, languages)
+// }
 
-func testAccNewStoreConfigWithoutChannels(name string, key string, languages []string) string {
-	return fmt.Sprintf(`
-	resource "commercetools_channel" "test_channel" {
-		key = "TEST"
-		roles = ["ProductDistribution"]
-	}
+// func testAccNewStoreConfigWithoutChannels(name string, key string, languages []string) string {
+// 	return fmt.Sprintf(`
+// 	resource "commercetools_channel" "test_channel" {
+// 		key = "TEST"
+// 		roles = ["ProductDistribution"]
+// 	}
 
-	resource "commercetools_store" "test" {
-		name = {
-			en = "%[1]s"
-			nl = "%[1]s"
-		}
-		key = "%[2]s"
-		languages = %[3]q
-	}
-	`, name, key, languages)
-}
+// 	resource "commercetools_store" "test" {
+// 		name = {
+// 			en = "%[1]s"
+// 			nl = "%[1]s"
+// 		}
+// 		key = "%[2]s"
+// 		languages = %[3]q
+// 	}
+// 	`, name, key, languages)
+// }
 
-func testAccCheckStoreDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckStoreDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		switch rs.Type {
-		case "commercetools_store":
-			{
-				response, err := client.Stores().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
-						return fmt.Errorf("store (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
+// 	for _, rs := range s.RootModule().Resources {
+// 		switch rs.Type {
+// 		case "commercetools_store":
+// 			{
+// 				response, err := client.Stores().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
+// 						return fmt.Errorf("store (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
 
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		case "commercetools_channel":
-			{
-				response, err := client.Channels().WithId(rs.Primary.ID).Get().Execute(context.Background())
-				if err == nil {
-					if response != nil && response.ID == rs.Primary.ID {
-						return fmt.Errorf("supply channel (%s) still exists", rs.Primary.ID)
-					}
-					continue
-				}
-				if newErr := checkApiResult(err); newErr != nil {
-					return newErr
-				}
-			}
-		default:
-			continue
-		}
-	}
-	return nil
-}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		case "commercetools_channel":
+// 			{
+// 				response, err := client.Channels().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 				if err == nil {
+// 					if response != nil && response.ID == rs.Primary.ID {
+// 						return fmt.Errorf("supply channel (%s) still exists", rs.Primary.ID)
+// 					}
+// 					continue
+// 				}
+// 				if newErr := checkApiResult(err); newErr != nil {
+// 					return newErr
+// 				}
+// 			}
+// 		default:
+// 			continue
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_subscription.go
+++ b/commercetools/resource_subscription.go
@@ -1,789 +1,789 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"strings"
-	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
-
-const (
-	// Destinations
-	subSQS             = "SQS"
-	subSNS             = "SNS"
-	subEventBridge     = "event_bridge"
-	subAzureEventGrid  = "azure_eventgrid"
-	subAzureServiceBus = "azure_servicebus"
-	subGooglePubSub    = "google_pubsub"
-
-	// Formats
-	cloudEvents = "cloud_events"
-	fmtPlatform = "platform"
-)
-
-var destinationFields = map[string][]string{
-	subSQS: {
-		"queue_url",
-		"access_key",
-		"access_secret",
-		"region",
-	},
-	subSNS: {
-		"topic_arn",
-		"access_key",
-		"access_secret",
-	},
-	subEventBridge: {
-		"region",
-		"account_id",
-	},
-	subAzureEventGrid: {
-		"uri",
-		"access_key",
-	},
-	subAzureServiceBus: {
-		"connection_string",
-	},
-	subGooglePubSub: {
-		"project_id",
-		"topic",
-	},
-}
-
-var formatFields = map[string][]string{
-	cloudEvents: {
-		"cloud_events_version",
-	},
-	fmtPlatform: {},
-}
-
-func resourceSubscription() *schema.Resource {
-	return &schema.Resource{
-		Description: "Subscriptions allow you to be notified of new messages or changes via a Message Queue of your " +
-			"choice. Subscriptions are used to trigger an asynchronous background process in response to an event on " +
-			"the commercetools platform. Common use cases include sending an Order Confirmation Email, charging a " +
-			"Credit Card after the delivery has been made, or synchronizing customer accounts to a Customer " +
-			"Relationship Management (CRM) system.\n\n" +
-			"See also the [Subscriptions API Documentation](https://docs.commercetools.com/api/projects/subscriptions)",
-		Create: resourceSubscriptionCreate,
-		Read:   resourceSubscriptionRead,
-		Update: resourceSubscriptionUpdate,
-		Delete: resourceSubscriptionDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    resourceSubscriptionResourceV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: migrateSubscriptionStateV0toV1,
-				Version: 0,
-			},
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for the subscription",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"destination": {
-				Description: "The Message Queue into which the notifications are to be sent" +
-					"See also the [Destination API Docs](https://docs.commercetools.com/api/projects/subscriptions#destination)",
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: func(d interface{}, v string) ([]string, []error) {
-								allowed := []string{
-									subSQS,
-									subSNS,
-									subEventBridge,
-									subAzureEventGrid,
-									subAzureServiceBus,
-									subGooglePubSub,
-								}
-
-								if !stringInSlice(d.(string), allowed) {
-									return []string{}, []error{
-										fmt.Errorf("Invalid destination type %s. Accepted are %s",
-											d.(string), strings.Join(allowed, ", "),
-										),
-									}
-								}
-
-								return []string{}, []error{}
-							},
-						},
-						"topic_arn": {
-							Description:      "For AWS SNS",
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subSNS),
-						},
-						"queue_url": {
-							Description:      "For AWS SQS",
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subSQS),
-						},
-						"region": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subSQS, subEventBridge),
-						},
-						"account_id": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subEventBridge),
-						},
-						"access_key": {
-							Description:      "For AWS SNS / SQS / Azure Event Grid",
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subSQS, subSNS, subAzureEventGrid),
-						},
-						"access_secret": {
-							Description:      "For AWS SNS / SQS",
-							Type:             schema.TypeString,
-							Optional:         true,
-							Sensitive:        true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subSQS, subSNS),
-						},
-						"uri": {
-							Description:      "For Azure Event Grid",
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subAzureEventGrid),
-						},
-						"connection_string": {
-							Description:      "For Azure Service Bus",
-							Type:             schema.TypeString,
-							Optional:         true,
-							ForceNew:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subAzureServiceBus),
-						},
-						"project_id": {
-							Description:      "For Google Pub Sub",
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subGooglePubSub),
-						},
-						"topic": {
-							Description:      "For Google Pub Sub",
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotDestinationType(subGooglePubSub),
-						},
-					},
-				},
-			},
-			"format": {
-				Description: "The [format](https://docs.commercetools.com/api/projects/subscriptions#format) " +
-					"in which the payload is delivered",
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					if k == "format.#" && old == "1" && new == "0" {
-						fmt := d.Get("format.0.type").(string)
-						if strings.ToLower(fmt) == "platform" {
-							return true
-						}
-					}
-					if k == "format.0.type" && strings.ToLower(old) == "platform" && new == "" {
-						return true
-					}
-
-					return false
-				},
-				DefaultFunc: func() (interface{}, error) {
-					return []map[string]string{{
-						"type": "Platform",
-					}}, nil
-				},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"cloud_events_version": {
-							Description:      "For CloudEvents",
-							Type:             schema.TypeString,
-							Optional:         true,
-							DiffSuppressFunc: suppressIfNotFormatType(cloudEvents),
-						},
-					},
-				},
-			},
-			"changes": {
-				Description: "The change notifications subscribed to",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"resource_type_ids": {
-							Description: "[Resource Type ID](https://docs.commercetools.com/api/projects/subscriptions#changesubscription)",
-							Type:        schema.TypeList,
-							Optional:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"message": {
-				Description: "The messages subscribed to",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"resource_type_id": {
-							Description: "[Resource Type ID](https://docs.commercetools.com/api/projects/subscriptions#changesubscription)",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"types": {
-							Description: "types must contain valid message types for this resource, for example for " +
-								"resource type product the message type ProductPublished is valid. If no types of " +
-								"messages are given, the subscription is valid for all messages of this resource",
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
-
-func resourceSubscriptionCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var subscription *platform.Subscription
-
-	if err := validateDestination(d); err != nil {
-		return err
-	}
-	if err := validateFormat(d); err != nil {
-		return err
-	}
-
-	messages := unmarshallSubscriptionMessages(d)
-	changes := unmarshallSubscriptionChanges(d)
-	destination, err := unmarshallSubscriptionDestination(d)
-	if err != nil {
-		return err
-	}
-	format, err := unmarshallSubscriptionFormat(d)
-	if err != nil {
-		return err
-	}
-
-	draft := platform.SubscriptionDraft{
-		Key:         stringRef(d.Get("key")),
-		Destination: destination,
-		Format:      &format,
-		Messages:    messages,
-		Changes:     changes,
-	}
-
-	err = resource.Retry(20*time.Second, func() *resource.RetryError {
-		var err error
-
-		subscription, err = client.Subscriptions().Post(draft).Execute(context.Background())
-		if err != nil {
-			// Some subscription resources might not be ready yet, always keep retrying
-			return resource.RetryableError(err)
-		}
-		return nil
-	})
-
-	if err != nil {
-		return err
-	}
-
-	if subscription == nil {
-		return fmt.Errorf("Error creating subscription")
-	}
-
-	d.SetId(subscription.ID)
-	d.Set("version", subscription.Version)
-
-	return resourceSubscriptionRead(d, m)
-}
-
-func resourceSubscriptionRead(d *schema.ResourceData, m interface{}) error {
-	log.Print("[DEBUG] Reading subscriptions from commercetools")
-	client := getClient(m)
-
-	subscription, err := client.Subscriptions().WithId(d.Id()).Get().Execute(context.Background())
-
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
-
-	if subscription == nil {
-		log.Print("[DEBUG] No subscriptions found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following subscriptions:")
-		log.Print(stringFormatObject(subscription))
-
-		d.Set("version", subscription.Version)
-		d.Set("key", subscription.Key)
-		d.Set("destination", marshallSubscriptionDestination(subscription.Destination, d))
-		d.Set("format", marshallSubscriptionFormat(subscription.Format))
-		d.Set("message", marshallSubscriptionMessages(subscription.Messages))
-		d.Set("changes", marshallSubscriptionChanges(subscription.Changes))
-	}
-	return nil
-}
-
-func resourceSubscriptionUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-
-	if err := validateDestination(d); err != nil {
-		return err
-	}
-	if err := validateFormat(d); err != nil {
-		return err
-	}
-
-	input := platform.SubscriptionUpdate{
-		Version: d.Get("version").(int),
-		Actions: []platform.SubscriptionUpdateAction{},
-	}
-
-	if d.HasChange("destination") {
-		destination, err := unmarshallSubscriptionDestination(d)
-		if err != nil {
-			return err
-		}
-
-		input.Actions = append(
-			input.Actions,
-			&platform.SubscriptionChangeDestinationAction{Destination: destination})
-	}
-
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.SubscriptionSetKeyAction{Key: &newKey})
-	}
-
-	if d.HasChange("message") {
-		messages := unmarshallSubscriptionMessages(d)
-		input.Actions = append(
-			input.Actions,
-			&platform.SubscriptionSetMessagesAction{Messages: messages})
-	}
-
-	if d.HasChange("changes") {
-		changes := unmarshallSubscriptionChanges(d)
-		input.Actions = append(
-			input.Actions,
-			&platform.SubscriptionSetChangesAction{Changes: changes})
-	}
-
-	err := resource.Retry(5*time.Second, func() *resource.RetryError {
-		var err error
-
-		_, err = client.Subscriptions().WithId(d.Id()).Post(input).Execute(context.Background())
-		if err != nil {
-			// Some subscription resources might not be ready yet, always keep retrying
-			return resource.RetryableError(err)
-		}
-		return nil
-	})
-
-	if err != nil {
-		return err
-	}
-
-	return resourceSubscriptionRead(d, m)
-}
-
-func resourceSubscriptionDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.Subscriptions().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeySubscriptionsByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func unmarshallSubscriptionDestination(d *schema.ResourceData) (platform.Destination, error) {
-	dst, err := elementFromList(d, "destination")
-	if err != nil {
-		return nil, err
-	}
-	if dst == nil {
-		return nil, fmt.Errorf("Destination is missing")
-	}
-
-	switch dst["type"] {
-	case subSNS:
-		return platform.SnsDestination{
-			TopicArn:     dst["topic_arn"].(string),
-			AccessKey:    dst["access_key"].(string),
-			AccessSecret: dst["access_secret"].(string),
-		}, nil
-	case subSQS:
-		return platform.SqsDestination{
-			QueueUrl:     dst["queue_url"].(string),
-			AccessKey:    dst["access_key"].(string),
-			AccessSecret: dst["access_secret"].(string),
-			Region:       dst["region"].(string),
-		}, nil
-	case subAzureEventGrid:
-		return platform.AzureEventGridDestination{
-			Uri:       dst["uri"].(string),
-			AccessKey: dst["access_key"].(string),
-		}, nil
-	case subAzureServiceBus:
-		return platform.AzureServiceBusDestination{
-			ConnectionString: dst["connection_string"].(string),
-		}, nil
-	case subGooglePubSub:
-		return platform.GoogleCloudPubSubDestination{
-			ProjectId: dst["project_id"].(string),
-			Topic:     dst["topic"].(string),
-		}, nil
-	case subEventBridge:
-		return platform.EventBridgeDestination{
-			Region:    dst["region"].(string),
-			AccountId: dst["account_id"].(string),
-		}, nil
-	default:
-		return nil, fmt.Errorf("Destination type %s not implemented", dst["type"])
-	}
-}
-
-func marshallSubscriptionDestination(dst platform.Destination, d *schema.ResourceData) []map[string]string {
-
-	// Read the access secret from the current resource data
-	c, _ := unmarshallSubscriptionDestination(d)
-	accessSecret := ""
-	switch current := c.(type) {
-	case platform.SnsDestination:
-		accessSecret = current.AccessSecret
-	case platform.SqsDestination:
-		accessSecret = current.AccessSecret
-	}
-
-	switch v := dst.(type) {
-	case platform.SnsDestination:
-		d.Get("destination")
-		return []map[string]string{{
-			"type":          subSNS,
-			"topic_arn":     v.TopicArn,
-			"access_key":    v.AccessKey,
-			"access_secret": accessSecret,
-		}}
-	case platform.SqsDestination:
-		return []map[string]string{{
-			"type":          subSQS,
-			"queue_url":     v.QueueUrl,
-			"access_key":    v.AccessKey,
-			"access_secret": accessSecret,
-			"region":        v.Region,
-		}}
-	case platform.AzureEventGridDestination:
-		return []map[string]string{{
-			"type":       subAzureEventGrid,
-			"uri":        v.Uri,
-			"access_key": v.AccessKey,
-		}}
-	case platform.AzureServiceBusDestination:
-		return []map[string]string{{
-			"type":              subAzureServiceBus,
-			"connection_string": v.ConnectionString,
-		}}
-	case platform.GoogleCloudPubSubDestination:
-		return []map[string]string{{
-			"type":       subGooglePubSub,
-			"project_id": v.ProjectId,
-			"topic":      v.Topic,
-		}}
-	case platform.EventBridgeDestination:
-		return []map[string]string{{
-			"type":       subEventBridge,
-			"region":     v.Region,
-			"account_id": v.AccountId,
-		}}
-	}
-	return []map[string]string{}
-}
-
-func marshallSubscriptionFormat(f platform.DeliveryFormat) []map[string]string {
-	switch v := f.(type) {
-	case platform.DeliveryPlatformFormat:
-		return []map[string]string{{
-			"type": "Platform",
-		}}
-	case platform.DeliveryCloudEventsFormat:
-		return []map[string]string{{
-			"type":                 "CloudEvents",
-			"cloud_events_version": v.CloudEventsVersion,
-		}}
-	}
-	return []map[string]string{}
-}
-
-func unmarshallSubscriptionFormat(d *schema.ResourceData) (platform.DeliveryFormat, error) {
-	input := d.Get("format").([]interface{})
-
-	if len(input) == 1 {
-		format := input[0].(map[string]interface{})
-
-		switch format["type"] {
-		case cloudEvents:
-			return platform.DeliveryCloudEventsFormat{
-				CloudEventsVersion: format["cloud_events_version"].(string),
-			}, nil
-		case fmtPlatform:
-			return platform.DeliveryPlatformFormat{}, nil
-		}
-	}
-
-	return nil, nil
-}
-
-func marshallSubscriptionChanges(m []platform.ChangeSubscription) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, 1)
-
-	for _, raw := range m {
-		result = append(result, map[string]interface{}{
-			"resource_type_ids": raw.ResourceTypeId,
-		})
-	}
-	return result
-}
-
-func unmarshallSubscriptionChanges(d *schema.ResourceData) []platform.ChangeSubscription {
-	var result []platform.ChangeSubscription
-	input := d.Get("changes").([]interface{})
-	if len(input) > 0 {
-		for _, raw := range input {
-			i := raw.(map[string]interface{})
-			rawTypeIds := expandStringArray(i["resource_type_ids"].([]interface{}))
-
-			for _, item := range rawTypeIds {
-				result = append(result, platform.ChangeSubscription{
-					ResourceTypeId: item,
-				})
-			}
-		}
-	}
-	return result
-}
-
-func marshallSubscriptionMessages(m []platform.MessageSubscription) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(m))
-	for _, raw := range m {
-		result = append(result, map[string]interface{}{
-			"resource_type_id": raw.ResourceTypeId,
-			"types":            raw.Types,
-		})
-	}
-	return result
-}
-
-func unmarshallSubscriptionMessages(d *schema.ResourceData) []platform.MessageSubscription {
-	input := d.Get("message").([]interface{})
-	var messageObjects []platform.MessageSubscription
-	for _, raw := range input {
-		i := raw.(map[string]interface{})
-		messageObjects = append(messageObjects, platform.MessageSubscription{
-			ResourceTypeId: i["resource_type_id"].(string),
-			Types:          expandStringArray(i["types"].([]interface{})),
-		})
-	}
-
-	return messageObjects
-}
-
-func validateDestination(d *schema.ResourceData) error {
-	input := d.Get("destination").([]interface{})
-
-	if len(input) != 1 {
-		return fmt.Errorf("Destination is missing")
-	}
-
-	dst := input[0].(map[string]interface{})
-
-	dstType := dst["type"].(string)
-	requiredFields, ok := destinationFields[dstType]
-	if !ok {
-		return fmt.Errorf("Invalid type for destination: '%v'", dstType)
-	}
-
-	for _, field := range requiredFields {
-		value, ok := dst[field].(string)
-		if !ok {
-			return fmt.Errorf("Required property '%v' missing", field)
-		} else if len(value) == 0 {
-			return fmt.Errorf("Required property '%v' is empty", field)
-		}
-	}
-	return nil
-}
-
-func validateFormat(d *schema.ResourceData) error {
-	input := d.Get("format").([]interface{})
-	if len(input) < 1 {
-		return nil
-	}
-
-	dst := input[0].(map[string]interface{})
-
-	dstType := dst["type"].(string)
-	requiredFields, ok := formatFields[dstType]
-	if !ok {
-		return fmt.Errorf("Invalid type for format: '%v'", dstType)
-	}
-
-	for _, field := range requiredFields {
-		value, ok := dst[field].(string)
-		if !ok {
-			return fmt.Errorf("Required property '%v' missing", field)
-		} else if len(value) == 0 {
-			return fmt.Errorf("Required property '%v' is empty", field)
-		}
-	}
-	return nil
-
-}
-
-func suppressFuncForAttribute(attribute string, t ...string) schema.SchemaDiffSuppressFunc {
-	return func(k string, old string, new string, d *schema.ResourceData) bool {
-		switch input := d.Get(attribute).(type) {
-		case []interface{}:
-			for _, dest := range input {
-				for _, val := range t {
-					if val == dest.(map[string]interface{})["type"] {
-						return false
-					}
-				}
-			}
-		case map[string]interface{}:
-			for _, val := range t {
-				if val == input["type"] {
-					return false
-				}
-			}
-		}
-		return true
-	}
-}
-
-func suppressIfNotDestinationType(t ...string) schema.SchemaDiffSuppressFunc {
-	return suppressFuncForAttribute("destination", t...)
-}
-
-func suppressIfNotFormatType(t ...string) schema.SchemaDiffSuppressFunc {
-	return suppressFuncForAttribute("format", t...)
-}
-
-func resourceSubscriptionResourceV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for the subscription",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"destination": {
-				Description: "The Message Queue into which the notifications are to be sent" +
-					"See also the [Destination API Docs](https://docs.commercetools.com/api/projects/subscriptions#destination)",
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{},
-				},
-			},
-			"format": {
-				Description: "The [format](https://docs.commercetools.com/api/projects/subscriptions#format) " +
-					"in which the payload is delivered",
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"changes": {
-				Description: "The change notifications subscribed to",
-				Type:        schema.TypeList,
-				Optional:    true,
-				MaxItems:    1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"resource_type_ids": {
-							Description: "[Resource Type ID](https://docs.commercetools.com/api/projects/subscriptions#changesubscription)",
-							Type:        schema.TypeList,
-							Optional:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"message": {
-				Description: "The messages subscribed to",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"resource_type_id": {
-							Description: "[Resource Type ID](https://docs.commercetools.com/api/projects/subscriptions#changesubscription)",
-							Type:        schema.TypeString,
-							Optional:    true,
-						},
-						"types": {
-							Description: "types must contain valid message types for this resource, for example for " +
-								"resource type product the message type ProductPublished is valid. If no types of " +
-								"messages are given, the subscription is valid for all messages of this resource",
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
-
-func migrateSubscriptionStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	transformToList(rawState, "destination")
-	transformToList(rawState, "format")
-	return rawState, nil
-}
+// import (
+// 	"context"
+// 	"fmt"
+// 	"log"
+// 	"strings"
+// 	"time"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
+
+// const (
+// 	// Destinations
+// 	subSQS             = "SQS"
+// 	subSNS             = "SNS"
+// 	subEventBridge     = "event_bridge"
+// 	subAzureEventGrid  = "azure_eventgrid"
+// 	subAzureServiceBus = "azure_servicebus"
+// 	subGooglePubSub    = "google_pubsub"
+
+// 	// Formats
+// 	cloudEvents = "cloud_events"
+// 	fmtPlatform = "platform"
+// )
+
+// var destinationFields = map[string][]string{
+// 	subSQS: {
+// 		"queue_url",
+// 		"access_key",
+// 		"access_secret",
+// 		"region",
+// 	},
+// 	subSNS: {
+// 		"topic_arn",
+// 		"access_key",
+// 		"access_secret",
+// 	},
+// 	subEventBridge: {
+// 		"region",
+// 		"account_id",
+// 	},
+// 	subAzureEventGrid: {
+// 		"uri",
+// 		"access_key",
+// 	},
+// 	subAzureServiceBus: {
+// 		"connection_string",
+// 	},
+// 	subGooglePubSub: {
+// 		"project_id",
+// 		"topic",
+// 	},
+// }
+
+// var formatFields = map[string][]string{
+// 	cloudEvents: {
+// 		"cloud_events_version",
+// 	},
+// 	fmtPlatform: {},
+// }
+
+// func resourceSubscription() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Subscriptions allow you to be notified of new messages or changes via a Message Queue of your " +
+// 			"choice. Subscriptions are used to trigger an asynchronous background process in response to an event on " +
+// 			"the commercetools platform. Common use cases include sending an Order Confirmation Email, charging a " +
+// 			"Credit Card after the delivery has been made, or synchronizing customer accounts to a Customer " +
+// 			"Relationship Management (CRM) system.\n\n" +
+// 			"See also the [Subscriptions API Documentation](https://docs.commercetools.com/api/projects/subscriptions)",
+// 		Create: resourceSubscriptionCreate,
+// 		Read:   resourceSubscriptionRead,
+// 		Update: resourceSubscriptionUpdate,
+// 		Delete: resourceSubscriptionDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		SchemaVersion: 1,
+// 		StateUpgraders: []schema.StateUpgrader{
+// 			{
+// 				Type:    resourceSubscriptionResourceV0().CoreConfigSchema().ImpliedType(),
+// 				Upgrade: migrateSubscriptionStateV0toV1,
+// 				Version: 0,
+// 			},
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for the subscription",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"destination": {
+// 				Description: "The Message Queue into which the notifications are to be sent" +
+// 					"See also the [Destination API Docs](https://docs.commercetools.com/api/projects/subscriptions#destination)",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				MaxItems: 1,
+// 				Required: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Type:     types.StringType,
+// 							Required: true,
+// 							ValidateFunc: func(d interface{}, v string) ([]string, []error) {
+// 								allowed := []string{
+// 									subSQS,
+// 									subSNS,
+// 									subEventBridge,
+// 									subAzureEventGrid,
+// 									subAzureServiceBus,
+// 									subGooglePubSub,
+// 								}
+
+// 								if !stringInSlice(d.(string), allowed) {
+// 									return []string{}, []error{
+// 										fmt.Errorf("Invalid destination type %s. Accepted are %s",
+// 											d.(string), strings.Join(allowed, ", "),
+// 										),
+// 									}
+// 								}
+
+// 								return []string{}, []error{}
+// 							},
+// 						},
+// 						"topic_arn": {
+// 							Description:      "For AWS SNS",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subSNS),
+// 						},
+// 						"queue_url": {
+// 							Description:      "For AWS SQS",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subSQS),
+// 						},
+// 						"region": {
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subSQS, subEventBridge),
+// 						},
+// 						"account_id": {
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subEventBridge),
+// 						},
+// 						"access_key": {
+// 							Description:      "For AWS SNS / SQS / Azure Event Grid",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subSQS, subSNS, subAzureEventGrid),
+// 						},
+// 						"access_secret": {
+// 							Description:      "For AWS SNS / SQS",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							Sensitive:        true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subSQS, subSNS),
+// 						},
+// 						"uri": {
+// 							Description:      "For Azure Event Grid",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subAzureEventGrid),
+// 						},
+// 						"connection_string": {
+// 							Description:      "For Azure Service Bus",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							ForceNew:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subAzureServiceBus),
+// 						},
+// 						"project_id": {
+// 							Description:      "For Google Pub Sub",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subGooglePubSub),
+// 						},
+// 						"topic": {
+// 							Description:      "For Google Pub Sub",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotDestinationType(subGooglePubSub),
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"format": {
+// 				Description: "The [format](https://docs.commercetools.com/api/projects/subscriptions#format) " +
+// 					"in which the payload is delivered",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				MaxItems: 1,
+// 				Optional: true,
+// 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+// 					if k == "format.#" && old == "1" && new == "0" {
+// 						fmt := d.Get("format.0.type").(string)
+// 						if strings.ToLower(fmt) == "platform" {
+// 							return true
+// 						}
+// 					}
+// 					if k == "format.0.type" && strings.ToLower(old) == "platform" && new == "" {
+// 						return true
+// 					}
+
+// 					return false
+// 				},
+// 				DefaultFunc: func() (interface{}, error) {
+// 					return []map[string]string{{
+// 						"type": "Platform",
+// 					}}, nil
+// 				},
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Type:     types.StringType,
+// 							Required: true,
+// 						},
+// 						"cloud_events_version": {
+// 							Description:      "For CloudEvents",
+// 							Type:             types.StringType,
+// 							Optional:         true,
+// 							DiffSuppressFunc: suppressIfNotFormatType(cloudEvents),
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"changes": {
+// 				Description: "The change notifications subscribed to",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"resource_type_ids": {
+// 							Description: "[Resource Type ID](https://docs.commercetools.com/api/projects/subscriptions#changesubscription)",
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Optional:    true,
+// 							Elem:        &schema.Schema{Type: types.StringType},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"message": {
+// 				Description: "The messages subscribed to",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"resource_type_id": {
+// 							Description: "[Resource Type ID](https://docs.commercetools.com/api/projects/subscriptions#changesubscription)",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 						"types": {
+// 							Description: "types must contain valid message types for this resource, for example for " +
+// 								"resource type product the message type ProductPublished is valid. If no types of " +
+// 								"messages are given, the subscription is valid for all messages of this resource",
+// 							Type:     types.ListType{ElemType: types.StringType},
+// 							Optional: true,
+// 							Elem:     &schema.Schema{Type: types.StringType},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
+
+// func resourceSubscriptionCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var subscription *platform.Subscription
+
+// 	if err := validateDestination(d); err != nil {
+// 		return err
+// 	}
+// 	if err := validateFormat(d); err != nil {
+// 		return err
+// 	}
+
+// 	messages := unmarshallSubscriptionMessages(d)
+// 	changes := unmarshallSubscriptionChanges(d)
+// 	destination, err := unmarshallSubscriptionDestination(d)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	format, err := unmarshallSubscriptionFormat(d)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	draft := platform.SubscriptionDraft{
+// 		Key:         stringRef(d.Get("key")),
+// 		Destination: destination,
+// 		Format:      &format,
+// 		Messages:    messages,
+// 		Changes:     changes,
+// 	}
+
+// 	err = resource.Retry(20*time.Second, func() *resource.RetryError {
+// 		var err error
+
+// 		subscription, err = client.Subscriptions().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			// Some subscription resources might not be ready yet, always keep retrying
+// 			return resource.RetryableError(err)
+// 		}
+// 		return nil
+// 	})
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	if subscription == nil {
+// 		return fmt.Errorf("Error creating subscription")
+// 	}
+
+// 	d.SetId(subscription.ID)
+// 	d.Set("version", subscription.Version)
+
+// 	return resourceSubscriptionRead(d, m)
+// }
+
+// func resourceSubscriptionRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Print("[DEBUG] Reading subscriptions from commercetools")
+// 	client := getClient(m)
+
+// 	subscription, err := client.Subscriptions().WithId(d.Id()).Get().Execute(context.Background())
+
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
+
+// 	if subscription == nil {
+// 		log.Print("[DEBUG] No subscriptions found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following subscriptions:")
+// 		log.Print(stringFormatObject(subscription))
+
+// 		d.Set("version", subscription.Version)
+// 		d.Set("key", subscription.Key)
+// 		d.Set("destination", marshallSubscriptionDestination(subscription.Destination, d))
+// 		d.Set("format", marshallSubscriptionFormat(subscription.Format))
+// 		d.Set("message", marshallSubscriptionMessages(subscription.Messages))
+// 		d.Set("changes", marshallSubscriptionChanges(subscription.Changes))
+// 	}
+// 	return nil
+// }
+
+// func resourceSubscriptionUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+
+// 	if err := validateDestination(d); err != nil {
+// 		return err
+// 	}
+// 	if err := validateFormat(d); err != nil {
+// 		return err
+// 	}
+
+// 	input := platform.SubscriptionUpdate{
+// 		Version: d.Get("version").(int),
+// 		Actions: []platform.SubscriptionUpdateAction{},
+// 	}
+
+// 	if d.HasChange("destination") {
+// 		destination, err := unmarshallSubscriptionDestination(d)
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.SubscriptionChangeDestinationAction{Destination: destination})
+// 	}
+
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.SubscriptionSetKeyAction{Key: &newKey})
+// 	}
+
+// 	if d.HasChange("message") {
+// 		messages := unmarshallSubscriptionMessages(d)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.SubscriptionSetMessagesAction{Messages: messages})
+// 	}
+
+// 	if d.HasChange("changes") {
+// 		changes := unmarshallSubscriptionChanges(d)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.SubscriptionSetChangesAction{Changes: changes})
+// 	}
+
+// 	err := resource.Retry(5*time.Second, func() *resource.RetryError {
+// 		var err error
+
+// 		_, err = client.Subscriptions().WithId(d.Id()).Post(input).Execute(context.Background())
+// 		if err != nil {
+// 			// Some subscription resources might not be ready yet, always keep retrying
+// 			return resource.RetryableError(err)
+// 		}
+// 		return nil
+// 	})
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	return resourceSubscriptionRead(d, m)
+// }
+
+// func resourceSubscriptionDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.Subscriptions().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeySubscriptionsByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	return nil
+// }
+
+// func unmarshallSubscriptionDestination(d *schema.ResourceData) (platform.Destination, error) {
+// 	dst, err := elementFromList(d, "destination")
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	if dst == nil {
+// 		return nil, fmt.Errorf("Destination is missing")
+// 	}
+
+// 	switch dst["type"] {
+// 	case subSNS:
+// 		return platform.SnsDestination{
+// 			TopicArn:     dst["topic_arn"].(string),
+// 			AccessKey:    dst["access_key"].(string),
+// 			AccessSecret: dst["access_secret"].(string),
+// 		}, nil
+// 	case subSQS:
+// 		return platform.SqsDestination{
+// 			QueueUrl:     dst["queue_url"].(string),
+// 			AccessKey:    dst["access_key"].(string),
+// 			AccessSecret: dst["access_secret"].(string),
+// 			Region:       dst["region"].(string),
+// 		}, nil
+// 	case subAzureEventGrid:
+// 		return platform.AzureEventGridDestination{
+// 			Uri:       dst["uri"].(string),
+// 			AccessKey: dst["access_key"].(string),
+// 		}, nil
+// 	case subAzureServiceBus:
+// 		return platform.AzureServiceBusDestination{
+// 			ConnectionString: dst["connection_string"].(string),
+// 		}, nil
+// 	case subGooglePubSub:
+// 		return platform.GoogleCloudPubSubDestination{
+// 			ProjectId: dst["project_id"].(string),
+// 			Topic:     dst["topic"].(string),
+// 		}, nil
+// 	case subEventBridge:
+// 		return platform.EventBridgeDestination{
+// 			Region:    dst["region"].(string),
+// 			AccountId: dst["account_id"].(string),
+// 		}, nil
+// 	default:
+// 		return nil, fmt.Errorf("Destination type %s not implemented", dst["type"])
+// 	}
+// }
+
+// func marshallSubscriptionDestination(dst platform.Destination, d *schema.ResourceData) []map[string]string {
+
+// 	// Read the access secret from the current resource data
+// 	c, _ := unmarshallSubscriptionDestination(d)
+// 	accessSecret := ""
+// 	switch current := c.(type) {
+// 	case platform.SnsDestination:
+// 		accessSecret = current.AccessSecret
+// 	case platform.SqsDestination:
+// 		accessSecret = current.AccessSecret
+// 	}
+
+// 	switch v := dst.(type) {
+// 	case platform.SnsDestination:
+// 		d.Get("destination")
+// 		return []map[string]string{{
+// 			"type":          subSNS,
+// 			"topic_arn":     v.TopicArn,
+// 			"access_key":    v.AccessKey,
+// 			"access_secret": accessSecret,
+// 		}}
+// 	case platform.SqsDestination:
+// 		return []map[string]string{{
+// 			"type":          subSQS,
+// 			"queue_url":     v.QueueUrl,
+// 			"access_key":    v.AccessKey,
+// 			"access_secret": accessSecret,
+// 			"region":        v.Region,
+// 		}}
+// 	case platform.AzureEventGridDestination:
+// 		return []map[string]string{{
+// 			"type":       subAzureEventGrid,
+// 			"uri":        v.Uri,
+// 			"access_key": v.AccessKey,
+// 		}}
+// 	case platform.AzureServiceBusDestination:
+// 		return []map[string]string{{
+// 			"type":              subAzureServiceBus,
+// 			"connection_string": v.ConnectionString,
+// 		}}
+// 	case platform.GoogleCloudPubSubDestination:
+// 		return []map[string]string{{
+// 			"type":       subGooglePubSub,
+// 			"project_id": v.ProjectId,
+// 			"topic":      v.Topic,
+// 		}}
+// 	case platform.EventBridgeDestination:
+// 		return []map[string]string{{
+// 			"type":       subEventBridge,
+// 			"region":     v.Region,
+// 			"account_id": v.AccountId,
+// 		}}
+// 	}
+// 	return []map[string]string{}
+// }
+
+// func marshallSubscriptionFormat(f platform.DeliveryFormat) []map[string]string {
+// 	switch v := f.(type) {
+// 	case platform.DeliveryPlatformFormat:
+// 		return []map[string]string{{
+// 			"type": "Platform",
+// 		}}
+// 	case platform.DeliveryCloudEventsFormat:
+// 		return []map[string]string{{
+// 			"type":                 "CloudEvents",
+// 			"cloud_events_version": v.CloudEventsVersion,
+// 		}}
+// 	}
+// 	return []map[string]string{}
+// }
+
+// func unmarshallSubscriptionFormat(d *schema.ResourceData) (platform.DeliveryFormat, error) {
+// 	input := d.Get("format").([]interface{})
+
+// 	if len(input) == 1 {
+// 		format := input[0].(map[string]interface{})
+
+// 		switch format["type"] {
+// 		case cloudEvents:
+// 			return platform.DeliveryCloudEventsFormat{
+// 				CloudEventsVersion: format["cloud_events_version"].(string),
+// 			}, nil
+// 		case fmtPlatform:
+// 			return platform.DeliveryPlatformFormat{}, nil
+// 		}
+// 	}
+
+// 	return nil, nil
+// }
+
+// func marshallSubscriptionChanges(m []platform.ChangeSubscription) []map[string]interface{} {
+// 	result := make([]map[string]interface{}, 0, 1)
+
+// 	for _, raw := range m {
+// 		result = append(result, map[string]interface{}{
+// 			"resource_type_ids": raw.ResourceTypeId,
+// 		})
+// 	}
+// 	return result
+// }
+
+// func unmarshallSubscriptionChanges(d *schema.ResourceData) []platform.ChangeSubscription {
+// 	var result []platform.ChangeSubscription
+// 	input := d.Get("changes").([]interface{})
+// 	if len(input) > 0 {
+// 		for _, raw := range input {
+// 			i := raw.(map[string]interface{})
+// 			rawTypeIds := expandStringArray(i["resource_type_ids"].([]interface{}))
+
+// 			for _, item := range rawTypeIds {
+// 				result = append(result, platform.ChangeSubscription{
+// 					ResourceTypeId: item,
+// 				})
+// 			}
+// 		}
+// 	}
+// 	return result
+// }
+
+// func marshallSubscriptionMessages(m []platform.MessageSubscription) []map[string]interface{} {
+// 	result := make([]map[string]interface{}, 0, len(m))
+// 	for _, raw := range m {
+// 		result = append(result, map[string]interface{}{
+// 			"resource_type_id": raw.ResourceTypeId,
+// 			"types":            raw.Types,
+// 		})
+// 	}
+// 	return result
+// }
+
+// func unmarshallSubscriptionMessages(d *schema.ResourceData) []platform.MessageSubscription {
+// 	input := d.Get("message").([]interface{})
+// 	var messageObjects []platform.MessageSubscription
+// 	for _, raw := range input {
+// 		i := raw.(map[string]interface{})
+// 		messageObjects = append(messageObjects, platform.MessageSubscription{
+// 			ResourceTypeId: i["resource_type_id"].(string),
+// 			Types:          expandStringArray(i["types"].([]interface{})),
+// 		})
+// 	}
+
+// 	return messageObjects
+// }
+
+// func validateDestination(d *schema.ResourceData) error {
+// 	input := d.Get("destination").([]interface{})
+
+// 	if len(input) != 1 {
+// 		return fmt.Errorf("Destination is missing")
+// 	}
+
+// 	dst := input[0].(map[string]interface{})
+
+// 	dstType := dst["type"].(string)
+// 	requiredFields, ok := destinationFields[dstType]
+// 	if !ok {
+// 		return fmt.Errorf("Invalid type for destination: '%v'", dstType)
+// 	}
+
+// 	for _, field := range requiredFields {
+// 		value, ok := dst[field].(string)
+// 		if !ok {
+// 			return fmt.Errorf("Required property '%v' missing", field)
+// 		} else if len(value) == 0 {
+// 			return fmt.Errorf("Required property '%v' is empty", field)
+// 		}
+// 	}
+// 	return nil
+// }
+
+// func validateFormat(d *schema.ResourceData) error {
+// 	input := d.Get("format").([]interface{})
+// 	if len(input) < 1 {
+// 		return nil
+// 	}
+
+// 	dst := input[0].(map[string]interface{})
+
+// 	dstType := dst["type"].(string)
+// 	requiredFields, ok := formatFields[dstType]
+// 	if !ok {
+// 		return fmt.Errorf("Invalid type for format: '%v'", dstType)
+// 	}
+
+// 	for _, field := range requiredFields {
+// 		value, ok := dst[field].(string)
+// 		if !ok {
+// 			return fmt.Errorf("Required property '%v' missing", field)
+// 		} else if len(value) == 0 {
+// 			return fmt.Errorf("Required property '%v' is empty", field)
+// 		}
+// 	}
+// 	return nil
+
+// }
+
+// func suppressFuncForAttribute(attribute string, t ...string) schema.SchemaDiffSuppressFunc {
+// 	return func(k string, old string, new string, d *schema.ResourceData) bool {
+// 		switch input := d.Get(attribute).(type) {
+// 		case []interface{}:
+// 			for _, dest := range input {
+// 				for _, val := range t {
+// 					if val == dest.(map[string]interface{})["type"] {
+// 						return false
+// 					}
+// 				}
+// 			}
+// 		case map[string]interface{}:
+// 			for _, val := range t {
+// 				if val == input["type"] {
+// 					return false
+// 				}
+// 			}
+// 		}
+// 		return true
+// 	}
+// }
+
+// func suppressIfNotDestinationType(t ...string) schema.SchemaDiffSuppressFunc {
+// 	return suppressFuncForAttribute("destination", t...)
+// }
+
+// func suppressIfNotFormatType(t ...string) schema.SchemaDiffSuppressFunc {
+// 	return suppressFuncForAttribute("format", t...)
+// }
+
+// func resourceSubscriptionResourceV0() *schema.Resource {
+// 	return &schema.Resource{
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for the subscription",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"destination": {
+// 				Description: "The Message Queue into which the notifications are to be sent" +
+// 					"See also the [Destination API Docs](https://docs.commercetools.com/api/projects/subscriptions#destination)",
+// 				Type:     schema.TypeMap,
+// 				Optional: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{},
+// 				},
+// 			},
+// 			"format": {
+// 				Description: "The [format](https://docs.commercetools.com/api/projects/subscriptions#format) " +
+// 					"in which the payload is delivered",
+// 				Type:     schema.TypeMap,
+// 				Optional: true,
+// 				Elem: &schema.Schema{
+// 					Type: types.StringType,
+// 				},
+// 			},
+// 			"changes": {
+// 				Description: "The change notifications subscribed to",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				MaxItems:    1,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"resource_type_ids": {
+// 							Description: "[Resource Type ID](https://docs.commercetools.com/api/projects/subscriptions#changesubscription)",
+// 							Type:        types.ListType{ElemType: types.StringType},
+// 							Optional:    true,
+// 							Elem:        &schema.Schema{Type: types.StringType},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"message": {
+// 				Description: "The messages subscribed to",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"resource_type_id": {
+// 							Description: "[Resource Type ID](https://docs.commercetools.com/api/projects/subscriptions#changesubscription)",
+// 							Type:        types.StringType,
+// 							Optional:    true,
+// 						},
+// 						"types": {
+// 							Description: "types must contain valid message types for this resource, for example for " +
+// 								"resource type product the message type ProductPublished is valid. If no types of " +
+// 								"messages are given, the subscription is valid for all messages of this resource",
+// 							Type:     types.ListType{ElemType: types.StringType},
+// 							Optional: true,
+// 							Elem:     &schema.Schema{Type: types.StringType},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
+
+// func migrateSubscriptionStateV0toV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+// 	transformToList(rawState, "destination")
+// 	transformToList(rawState, "format")
+// 	return rawState, nil
+// }

--- a/commercetools/resource_subscription_test.go
+++ b/commercetools/resource_subscription_test.go
@@ -1,154 +1,154 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"regexp"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"regexp"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestValidateDestination(t *testing.T) {
-	resource := resourceSubscription()
-	validDestinations := []map[string]interface{}{
-		{
-			"type":          "SQS",
-			"queue_url":     "<queue_url>",
-			"access_key":    "<access_key>",
-			"access_secret": "<access_secret>",
-			"region":        "<region>",
-		},
-		{
-			"type":       "azure_eventgrid",
-			"uri":        "<uri>",
-			"access_key": "<access_key>",
-		},
-		{
-			"type":              "azure_servicebus",
-			"connection_string": "<connection_string>",
-		},
-		{
-			"type":       "google_pubsub",
-			"project_id": "<project_id>",
-			"topic":      "<topic>",
-		},
-		{
-			"type":       "event_bridge",
-			"region":     "<region>",
-			"account_id": "<account_id>",
-		},
-	}
-	for _, validDestination := range validDestinations {
-		rawData := map[string]interface{}{
-			"destination": []interface{}{validDestination},
-		}
-		data := schema.TestResourceDataRaw(t, resource.Schema, rawData)
-		err := validateDestination(data)
-		if err != nil {
-			t.Error("Expected no validation errors, but got ", err)
-		}
-	}
-	invalidDestinations := []map[string]interface{}{
-		{
-			"type": "SQS1",
-		},
-		{
-			"type":          "SQS",
-			"access_key":    "<access_key>",
-			"access_secret": "<access_secret>",
-			"region":        "<region>",
-		},
-		{
-			"type": "azure_servicebus",
-		},
-		{
-			"type":  "google_pubsub",
-			"topic": "<topic>",
-		},
-		{
-			"type":  "event_bridge",
-			"topic": "<region>",
-		},
-	}
-	for _, validDestination := range invalidDestinations {
-		rawData := map[string]interface{}{
-			"destination": []interface{}{validDestination},
-		}
-		data := schema.TestResourceDataRaw(t, resource.Schema, rawData)
-		err := validateDestination(data)
-		if err == nil {
-			t.Error("Expected validation errors, but none was reported")
-		}
-	}
-}
+// func TestValidateDestination(t *testing.T) {
+// 	resource := resourceSubscription()
+// 	validDestinations := []map[string]interface{}{
+// 		{
+// 			"type":          "SQS",
+// 			"queue_url":     "<queue_url>",
+// 			"access_key":    "<access_key>",
+// 			"access_secret": "<access_secret>",
+// 			"region":        "<region>",
+// 		},
+// 		{
+// 			"type":       "azure_eventgrid",
+// 			"uri":        "<uri>",
+// 			"access_key": "<access_key>",
+// 		},
+// 		{
+// 			"type":              "azure_servicebus",
+// 			"connection_string": "<connection_string>",
+// 		},
+// 		{
+// 			"type":       "google_pubsub",
+// 			"project_id": "<project_id>",
+// 			"topic":      "<topic>",
+// 		},
+// 		{
+// 			"type":       "event_bridge",
+// 			"region":     "<region>",
+// 			"account_id": "<account_id>",
+// 		},
+// 	}
+// 	for _, validDestination := range validDestinations {
+// 		rawData := map[string]interface{}{
+// 			"destination": []interface{}{validDestination},
+// 		}
+// 		data := schema.TestResourceDataRaw(t, resource.Schema, rawData)
+// 		err := validateDestination(data)
+// 		if err != nil {
+// 			t.Error("Expected no validation errors, but got ", err)
+// 		}
+// 	}
+// 	invalidDestinations := []map[string]interface{}{
+// 		{
+// 			"type": "SQS1",
+// 		},
+// 		{
+// 			"type":          "SQS",
+// 			"access_key":    "<access_key>",
+// 			"access_secret": "<access_secret>",
+// 			"region":        "<region>",
+// 		},
+// 		{
+// 			"type": "azure_servicebus",
+// 		},
+// 		{
+// 			"type":  "google_pubsub",
+// 			"topic": "<topic>",
+// 		},
+// 		{
+// 			"type":  "event_bridge",
+// 			"topic": "<region>",
+// 		},
+// 	}
+// 	for _, validDestination := range invalidDestinations {
+// 		rawData := map[string]interface{}{
+// 			"destination": []interface{}{validDestination},
+// 		}
+// 		data := schema.TestResourceDataRaw(t, resource.Schema, rawData)
+// 		err := validateDestination(data)
+// 		if err == nil {
+// 			t.Error("Expected validation errors, but none was reported")
+// 		}
+// 	}
+// }
 
-func TestAccSubscription_basic(t *testing.T) {
-	rName := acctest.RandString(5)
+// func TestAccSubscription_basic(t *testing.T) {
+// 	rName := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSubscriptionDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccSubscriptionConfig(rName),
-				ExpectError: regexp.MustCompile(".*A test message could not be delivered to this destination: SQS.*"),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckSubscriptionDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config:      testAccSubscriptionConfig(rName),
+// 				ExpectError: regexp.MustCompile(".*A test message could not be delivered to this destination: SQS.*"),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccSubscriptionConfig(rName string) string {
-	queueURL := "https://sqs.eu-west-1.amazonaws.com/0000000000/some-queue"
-	accessKey := "some-access-key"
-	secretKey := "some-secret-key"
+// func testAccSubscriptionConfig(rName string) string {
+// 	queueURL := "https://sqs.eu-west-1.amazonaws.com/0000000000/some-queue"
+// 	accessKey := "some-access-key"
+// 	secretKey := "some-secret-key"
 
-	return fmt.Sprintf(`
-resource "commercetools_subscription" "subscription_%[1]s" {
-	key = "commercetools-acc-%[1]s"
+// 	return fmt.Sprintf(`
+// resource "commercetools_subscription" "subscription_%[1]s" {
+// 	key = "commercetools-acc-%[1]s"
 
-	destination {
-		type          = "SQS"
-		queue_url     = "%[2]s"
-		access_key    = "%[3]s"
-		access_secret = "%[4]s"
-		region        = "eu-west-1"
-	}
+// 	destination {
+// 		type          = "SQS"
+// 		queue_url     = "%[2]s"
+// 		access_key    = "%[3]s"
+// 		access_secret = "%[4]s"
+// 		region        = "eu-west-1"
+// 	}
 
-	changes {
-		resource_type_ids = ["customer"]
-	}
+// 	changes {
+// 		resource_type_ids = ["customer"]
+// 	}
 
-	message {
-		resource_type_id = "product"
+// 	message {
+// 		resource_type_id = "product"
 
-		types = ["ProductPublished", "ProductCreated"]
-	}
-}
-`, rName, queueURL, accessKey, secretKey)
-}
+// 		types = ["ProductPublished", "ProductCreated"]
+// 	}
+// }
+// `, rName, queueURL, accessKey, secretKey)
+// }
 
-func testAccCheckSubscriptionDestroy(s *terraform.State) error {
-	conn := getClient(testAccProvider.Meta())
+// func testAccCheckSubscriptionDestroy(s *terraform.State) error {
+// 	conn := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_subscription" {
-			continue
-		}
-		response, err := conn.Subscriptions().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("subscription (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_subscription" {
+// 			continue
+// 		}
+// 		response, err := conn.Subscriptions().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("subscription (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_tax_category.go
+++ b/commercetools/resource_tax_category.go
@@ -1,184 +1,184 @@
 package commercetools
 
-import (
-	"context"
-	"log"
-	"time"
+// import (
+// 	"context"
+// 	"log"
+// 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func resourceTaxCategory() *schema.Resource {
-	return &schema.Resource{
-		Description: "Tax Categories define how products are to be taxed in different countries.\n\n" +
-			"See also the [Tax Category API Documentation](https://docs.commercetools.com/api/projects/taxCategories)",
-		Create: resourceTaxCategoryCreate,
-		Read:   resourceTaxCategoryRead,
-		Update: resourceTaxCategoryUpdate,
-		Delete: resourceTaxCategoryDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "User-specific unique identifier for the category",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-	}
-}
+// func resourceTaxCategory() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Tax Categories define how products are to be taxed in different countries.\n\n" +
+// 			"See also the [Tax Category API Documentation](https://docs.commercetools.com/api/projects/taxCategories)",
+// 		Create: resourceTaxCategoryCreate,
+// 		Read:   resourceTaxCategoryRead,
+// 		Update: resourceTaxCategoryUpdate,
+// 		Delete: resourceTaxCategoryDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "User-specific unique identifier for the category",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"name": {
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"description": {
+// 				Type:     types.StringType,
+// 				Optional: true,
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 	}
+// }
 
-func resourceTaxCategoryCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var taxCategory *platform.TaxCategory
-	emptyTaxRates := []platform.TaxRateDraft{}
+// func resourceTaxCategoryCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var taxCategory *platform.TaxCategory
+// 	emptyTaxRates := []platform.TaxRateDraft{}
 
-	draft := platform.TaxCategoryDraft{
-		Key:         stringRef(d.Get("key")),
-		Name:        d.Get("name").(string),
-		Description: stringRef(d.Get("description")),
-		Rates:       emptyTaxRates,
-	}
+// 	draft := platform.TaxCategoryDraft{
+// 		Key:         stringRef(d.Get("key")),
+// 		Name:        d.Get("name").(string),
+// 		Description: stringRef(d.Get("description")),
+// 		Rates:       emptyTaxRates,
+// 	}
 
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
+// 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
 
-		taxCategory, err = client.TaxCategories().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
+// 		taxCategory, err = client.TaxCategories().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
 
-	if err != nil {
-		return err
-	}
+// 	if err != nil {
+// 		return err
+// 	}
 
-	if taxCategory == nil {
-		log.Fatal("No tax category created?")
-	}
+// 	if taxCategory == nil {
+// 		log.Fatal("No tax category created?")
+// 	}
 
-	d.SetId(taxCategory.ID)
-	d.Set("version", taxCategory.Version)
+// 	d.SetId(taxCategory.ID)
+// 	d.Set("version", taxCategory.Version)
 
-	return resourceTaxCategoryRead(d, m)
-}
+// 	return resourceTaxCategoryRead(d, m)
+// }
 
-func resourceTaxCategoryRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Reading tax category from commercetools, with taxCategory id: %s", d.Id())
-	client := getClient(m)
+// func resourceTaxCategoryRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Printf("[DEBUG] Reading tax category from commercetools, with taxCategory id: %s", d.Id())
+// 	client := getClient(m)
 
-	taxCategory, err := client.TaxCategories().WithId(d.Id()).Get().Execute(context.Background())
+// 	taxCategory, err := client.TaxCategories().WithId(d.Id()).Get().Execute(context.Background())
 
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
 
-	if taxCategory == nil {
-		log.Print("[DEBUG] No tax category found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following tax category:")
-		log.Print(stringFormatObject(taxCategory))
+// 	if taxCategory == nil {
+// 		log.Print("[DEBUG] No tax category found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following tax category:")
+// 		log.Print(stringFormatObject(taxCategory))
 
-		d.Set("version", taxCategory.Version)
-		d.Set("key", taxCategory.Key)
-		d.Set("name", taxCategory.Name)
-		d.Set("description", taxCategory.Description)
-	}
-	return nil
-}
+// 		d.Set("version", taxCategory.Version)
+// 		d.Set("key", taxCategory.Key)
+// 		d.Set("name", taxCategory.Name)
+// 		d.Set("description", taxCategory.Description)
+// 	}
+// 	return nil
+// }
 
-func resourceTaxCategoryUpdate(d *schema.ResourceData, m interface{}) error {
-	// Lock to prevent concurrent updates due to Version number conflicts
-	ctMutexKV.Lock(d.Id())
-	defer ctMutexKV.Unlock(d.Id())
+// func resourceTaxCategoryUpdate(d *schema.ResourceData, m interface{}) error {
+// 	// Lock to prevent concurrent updates due to Version number conflicts
+// 	ctMutexKV.Lock(d.Id())
+// 	defer ctMutexKV.Unlock(d.Id())
 
-	client := getClient(m)
-	taxCategory, err := client.TaxCategories().WithId(d.Id()).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	client := getClient(m)
+// 	taxCategory, err := client.TaxCategories().WithId(d.Id()).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	input := platform.TaxCategoryUpdate{
-		Version: taxCategory.Version,
-		Actions: []platform.TaxCategoryUpdateAction{},
-	}
+// 	input := platform.TaxCategoryUpdate{
+// 		Version: taxCategory.Version,
+// 		Actions: []platform.TaxCategoryUpdateAction{},
+// 	}
 
-	if d.HasChange("name") {
-		newName := d.Get("name").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.TaxCategoryChangeNameAction{Name: newName})
-	}
+// 	if d.HasChange("name") {
+// 		newName := d.Get("name").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.TaxCategoryChangeNameAction{Name: newName})
+// 	}
 
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.TaxCategorySetKeyAction{Key: &newKey})
-	}
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.TaxCategorySetKeyAction{Key: &newKey})
+// 	}
 
-	if d.HasChange("description") {
-		newDescription := d.Get("description").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.TaxCategorySetDescriptionAction{Description: &newDescription})
-	}
+// 	if d.HasChange("description") {
+// 		newDescription := d.Get("description").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.TaxCategorySetDescriptionAction{Description: &newDescription})
+// 	}
 
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
 
-	_, err = client.TaxCategories().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
+// 	_, err = client.TaxCategories().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
 
-	return resourceTaxCategoryRead(d, m)
-}
+// 	return resourceTaxCategoryRead(d, m)
+// }
 
-func resourceTaxCategoryDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
+// func resourceTaxCategoryDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
 
-	// Lock to prevent concurrent updates due to Version number conflicts
-	ctMutexKV.Lock(d.Id())
-	defer ctMutexKV.Unlock(d.Id())
+// 	// Lock to prevent concurrent updates due to Version number conflicts
+// 	ctMutexKV.Lock(d.Id())
+// 	defer ctMutexKV.Unlock(d.Id())
 
-	taxCategory, err := client.TaxCategories().WithId(d.Id()).Get().Execute(context.Background())
-	if err != nil {
-		return err
-	}
-	_, err = client.TaxCategories().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyTaxCategoriesByIDRequestMethodDeleteInput{
-		Version: taxCategory.Version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
+// 	taxCategory, err := client.TaxCategories().WithId(d.Id()).Get().Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+// 	_, err = client.TaxCategories().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyTaxCategoriesByIDRequestMethodDeleteInput{
+// 		Version: taxCategory.Version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }

--- a/commercetools/resource_tax_category_rate.go
+++ b/commercetools/resource_tax_category_rate.go
@@ -1,408 +1,408 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
-
-func resourceTaxCategoryRate() *schema.Resource {
-	return &schema.Resource{
-		Description: "Tax rate for Tax Category. \n\n" +
-			"See also [Tax Rate API Documentation](https://docs.commercetools.com/api/projects/taxCategories#taxrate)",
-		Create: resourceTaxCategoryRateCreate,
-		Read:   resourceTaxCategoryRateRead,
-		Update: resourceTaxCategoryRateUpdate,
-		Delete: resourceTaxCategoryRateDelete,
-		Importer: &schema.ResourceImporter{
-			State: resourceTaxCategoryRateImportState,
-		},
-		Schema: map[string]*schema.Schema{
-			"tax_category_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"amount": {
-				Description: "Number Percentage in the range of [0..1]. The sum of the amounts of all subRates, " +
-					"if there are any",
-				Type:         schema.TypeFloat,
-				Optional:     true,
-				ValidateFunc: validateTaxRateAmount,
-			},
-			"included_in_price": {
-				Type:     schema.TypeBool,
-				Required: true,
-			},
-			"country": {
-				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"state": {
-				Description: "The state in the country",
-				Type:        schema.TypeString,
-				Optional:    true,
-			},
-			"sub_rate": {
-				Description: "For countries (for example the US) where the total tax is a combination of multiple " +
-					"taxes (for example state and local taxes)",
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"amount": {
-							Description:  "Number Percentage in the range of [0..1]",
-							Type:         schema.TypeFloat,
-							Required:     true,
-							ValidateFunc: validateTaxRateAmount,
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func resourceTaxCategoryRateImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := getClient(meta)
-	taxRateID := d.Id()
-	// Arbitrary number, safe to assume there won't be more than 500 tax categories...
-	taxCategoriesQuery, err := client.TaxCategories().Get().WithQueryParams(platform.ByProjectKeyTaxCategoriesRequestMethodGetInput{
-		Limit: intRef(500),
-	}).Execute(context.Background())
-	if err != nil {
-		return nil, err
-	}
-
-	taxCategory, taxRate := findTaxRate(taxRateID, taxCategoriesQuery.Results)
-
-	if taxRate == nil {
-		return nil, fmt.Errorf("Tax rate %s does not seem to exist", taxRateID)
-	}
-
-	results := make([]*schema.ResourceData, 0)
-	taxRateState := resourceTaxCategoryRate().Data(nil)
-
-	taxRateState.SetId(*taxRate.ID)
-	taxRateState.SetType("commercetools_tax_category_rate")
-	taxRateState.Set("tax_category_id", taxCategory.ID)
-
-	setTaxRateState(taxRateState, taxRate)
-
-	results = append(results, taxRateState)
-
-	log.Printf("[DEBUG] Importing results: %#v", results)
-
-	return results, nil
-}
-
-func resourceTaxCategoryRateGetSubRates(input []interface{}) ([]platform.SubRate, error) {
-	result := []platform.SubRate{}
-
-	for _, raw := range input {
-		raw := raw.(map[string]interface{})
-		amount := raw["amount"].(float64)
-		result = append(result, platform.SubRate{
-			Name:   raw["name"].(string),
-			Amount: amount,
-		})
-	}
-	return result, nil
-}
-
-func resourceTaxCategoryRateCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	taxCategoryID := d.Get("tax_category_id").(string)
-
-	// Lock to prevent concurrent updates due to Version number conflicts
-	ctMutexKV.Lock(taxCategoryID)
-	defer ctMutexKV.Unlock(taxCategoryID)
-
-	taxCategory, err := client.TaxCategories().WithId(taxCategoryID).Get().Execute(context.Background())
-
-	if err != nil {
-		return err
-	}
-
-	oldTaxRateIds := getTaxRateIds(taxCategory)
-
-	input := platform.TaxCategoryUpdate{
-		Version: taxCategory.Version,
-		Actions: []platform.TaxCategoryUpdateAction{},
-	}
-
-	taxRateDraft, err := createTaxRateDraft(d)
-	if err != nil {
-		return err
-	}
-
-	input.Actions = append(input.Actions, platform.TaxCategoryAddTaxRateAction{TaxRate: *taxRateDraft})
-
-	err = resource.Retry(30*time.Second, func() *resource.RetryError {
-		taxCategory, err = client.TaxCategories().WithId(taxCategoryID).Post(input).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
-
-	if err != nil {
-		return err
-	}
-
-	// Refresh the taxCategory. When a tax rate is added the ID is different
-	// then the ID returned in the response
-	updatedTaxCategory, err := client.TaxCategories().WithId(taxCategoryID).Get().Execute(context.Background())
-	newTaxRate := findNewTaxRate(updatedTaxCategory, oldTaxRateIds)
-
-	if newTaxRate == nil {
-		log.Fatal("No tax category rate created?")
-	}
-
-	d.SetId(*newTaxRate.ID)
-	d.Set("tax_category_id", taxCategory.ID)
-
-	return resourceTaxCategoryRateRead(d, m)
-}
-
-func resourceTaxCategoryRateRead(d *schema.ResourceData, m interface{}) error {
-	log.Printf("[DEBUG] Current tax rate state: %s and m: %s", stringFormatObject(d), stringFormatObject(m))
-	_, taxRate, err := readResourcesFromStateIDs(d, m)
-
-	if err != nil {
-		d.SetId("")
-		return nil
-	}
-
-	setTaxRateState(d, taxRate)
-
-	return nil
-}
-
-func setTaxRateState(d *schema.ResourceData, taxRate *platform.TaxRate) {
-	log.Printf("[DEBUG] Setting state: %s to taxRate: %s", stringFormatObject(d), stringFormatObject(taxRate))
-	d.Set("name", taxRate.Name)
-	d.Set("amount", taxRate.Amount)
-	d.Set("included_in_price", taxRate.IncludedInPrice)
-	d.Set("country", taxRate.Country)
-	d.Set("state", taxRate.State)
-
-	subRateData := make([]map[string]interface{}, len(taxRate.SubRates))
-	for srIndex, subrate := range taxRate.SubRates {
-		subRateData[srIndex] = map[string]interface{}{
-			"name":   subrate.Name,
-			"amount": subrate.Amount,
-		}
-	}
-	d.Set("sub_rate", subRateData)
-
-	log.Printf("[DEBUG] Updated state to: %s", stringFormatObject(d))
-}
-
-func resourceTaxCategoryRateUpdate(d *schema.ResourceData, m interface{}) error {
-	taxCategoryID := d.Get("tax_category_id").(string)
-
-	// Lock to prevent concurrent updates due to Version number conflicts
-	ctMutexKV.Lock(taxCategoryID)
-	defer ctMutexKV.Unlock(taxCategoryID)
-
-	taxCategory, _, err := readResourcesFromStateIDs(d, m)
-	if err != nil {
-		return err
-	}
-
-	oldTaxRateIds := getTaxRateIds(taxCategory)
-
-	input := platform.TaxCategoryUpdate{
-		Version: taxCategory.Version,
-		Actions: []platform.TaxCategoryUpdateAction{},
-	}
-
-	if d.HasChange("name") || d.HasChange("amount") || d.HasChange("included_in_price") || d.HasChange("country") || d.HasChange("state") || d.HasChange("sub_rate") {
-		taxRateDraft, err := createTaxRateDraft(d)
-		if err != nil {
-			return err
-		}
-		input.Actions = append(input.Actions, platform.TaxCategoryReplaceTaxRateAction{
-			TaxRateId: d.Id(),
-			TaxRate:   *taxRateDraft,
-		})
-	}
-
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
-
-	client := getClient(m)
-	taxCategory, err = client.TaxCategories().WithId(taxCategory.ID).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
-
-	// Refresh the taxCategory. When a tax rate is added the ID is different
-	// then the ID returned in the response
-	updatedTaxCategory, err := client.TaxCategories().WithId(taxCategoryID).Get().Execute(context.Background())
-
-	newTaxRate := findNewTaxRate(updatedTaxCategory, oldTaxRateIds)
-
-	if newTaxRate == nil {
-		log.Fatal("No tax category rate created?")
-	}
-
-	d.SetId(*newTaxRate.ID)
-
-	return resourceTaxCategoryRateRead(d, m)
-}
-
-func createTaxRateDraft(d *schema.ResourceData) (*platform.TaxRateDraft, error) {
-	var subrates []platform.SubRate
-	var err error
-	if subRateRaw, ok := d.GetOk("sub_rate"); ok {
-		subrates, err = resourceTaxCategoryRateGetSubRates(subRateRaw.([]interface{}))
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	var countryCode string
-	if value, ok := d.Get("country").(string); ok {
-		countryCode = value
-	}
-
-	amountRaw := d.Get("amount").(float64)
-
-	log.Printf("[DEBUG] Got amount: %f", amountRaw)
-
-	taxRateDraft := platform.TaxRateDraft{
-		Name:            d.Get("name").(string),
-		Amount:          &amountRaw,
-		IncludedInPrice: d.Get("included_in_price").(bool),
-		Country:         countryCode,
-		State:           stringRef(d.Get("state")),
-		SubRates:        subrates,
-	}
-
-	log.Printf("[DEBUG] Created tax rate draft: %#v from input %#v", taxRateDraft, d)
-
-	return &taxRateDraft, nil
-}
-
-func resourceTaxCategoryRateDelete(d *schema.ResourceData, m interface{}) error {
-	taxCategoryID := d.Get("tax_category_id").(string)
-
-	// Lock to prevent concurrent updates due to Version number conflicts
-	ctMutexKV.Lock(taxCategoryID)
-	defer ctMutexKV.Unlock(taxCategoryID)
-
-	taxCategory, taxRate, err := readResourcesFromStateIDs(d, m)
-	if err != nil {
-		return err
-	}
-
-	input := platform.TaxCategoryUpdate{
-		Version: taxCategory.Version,
-		Actions: []platform.TaxCategoryUpdateAction{},
-	}
-
-	removeAction := platform.TaxCategoryRemoveTaxRateAction{
-		TaxRateId: *taxRate.ID,
-	}
-	input.Actions = append(input.Actions, removeAction)
-
-	client := getClient(m)
-	_, err = client.TaxCategories().WithId(taxCategory.ID).Post(input).Execute(context.Background())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func readResourcesFromStateIDs(d *schema.ResourceData, m interface{}) (*platform.TaxCategory, *platform.TaxRate, error) {
-	client := getClient(m)
-	taxCategoryID := d.Get("tax_category_id").(string)
-	taxRateID := d.Id()
-
-	log.Printf("[DEBUG] Reading tax category from commercetools, taxCategory ID: %s, taxRate ID: %s", taxCategoryID, taxRateID)
-
-	taxCategory, err := client.TaxCategories().WithId(taxCategoryID).Get().Execute(context.Background())
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	log.Print("[DEBUG] Found following tax category:")
-	log.Print(stringFormatObject(taxCategory))
-	taxRate := getTaxRateWithID(taxCategory, taxRateID)
-	if taxRate == nil {
-		return nil, nil, fmt.Errorf("Could not find tax rate %s in tax category %s", taxRateID, taxCategory.ID)
-	}
-	log.Print("[DEBUG] Found following tax rate:")
-	log.Print(stringFormatObject(taxRate))
-
-	return taxCategory, taxRate, nil
-}
-
-func validateTaxRateAmount(val interface{}, key string) (warns []string, errs []error) {
-	v := val.(float64)
-	if v < 0 || v > 1 {
-		errs = append(errs, fmt.Errorf("%q must be between 0 and 1 inclusive, got: %f", key, v))
-	}
-	return
-}
-
-func getTaxRateIds(taxCategory *platform.TaxCategory) []string {
-	taxRateIds := []string{}
-	for _, rate := range taxCategory.Rates {
-		taxRateIds = append(taxRateIds, *rate.ID)
-	}
-
-	return taxRateIds
-}
-
-// Find new tax rate by comparing with tax rate ids created just before adding new tax rate
-func findNewTaxRate(taxCategory *platform.TaxCategory, oldTaxRateIds []string) *platform.TaxRate {
-	for _, taxRate := range taxCategory.Rates {
-		if !stringInSlice(*taxRate.ID, oldTaxRateIds) {
-			return &taxRate
-		}
-	}
-	return nil
-}
-
-func getTaxRateWithID(taxCategory *platform.TaxCategory, taxRateID string) *platform.TaxRate {
-	for _, rate := range taxCategory.Rates {
-		if *rate.ID == taxRateID {
-			return &rate
-		}
-	}
-
-	return nil
-}
-
-func findTaxRate(taxRateID string, taxCategories []platform.TaxCategory) (*platform.TaxCategory, *platform.TaxRate) {
-	for _, taxCategory := range taxCategories {
-		for _, taxRate := range taxCategory.Rates {
-			if *taxRate.ID == taxRateID {
-				return &taxCategory, &taxRate
-			}
-		}
-	}
-	return nil, nil
-}
+// import (
+// 	"context"
+// 	"fmt"
+// 	"log"
+// 	"time"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
+
+// func resourceTaxCategoryRate() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Tax rate for Tax Category. \n\n" +
+// 			"See also [Tax Rate API Documentation](https://docs.commercetools.com/api/projects/taxCategories#taxrate)",
+// 		Create: resourceTaxCategoryRateCreate,
+// 		Read:   resourceTaxCategoryRateRead,
+// 		Update: resourceTaxCategoryRateUpdate,
+// 		Delete: resourceTaxCategoryRateDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: resourceTaxCategoryRateImportState,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"tax_category_id": {
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"name": {
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"amount": {
+// 				Description: "Number Percentage in the range of [0..1]. The sum of the amounts of all subRates, " +
+// 					"if there are any",
+// 				Type:         schema.TypeFloat,
+// 				Optional:     true,
+// 				ValidateFunc: validateTaxRateAmount,
+// 			},
+// 			"included_in_price": {
+// 				Type:     types.BoolType,
+// 				Required: true,
+// 			},
+// 			"country": {
+// 				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"state": {
+// 				Description: "The state in the country",
+// 				Type:        types.StringType,
+// 				Optional:    true,
+// 			},
+// 			"sub_rate": {
+// 				Description: "For countries (for example the US) where the total tax is a combination of multiple " +
+// 					"taxes (for example state and local taxes)",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				Optional: true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"name": {
+// 							Type:     types.StringType,
+// 							Required: true,
+// 						},
+// 						"amount": {
+// 							Description:  "Number Percentage in the range of [0..1]",
+// 							Type:         schema.TypeFloat,
+// 							Required:     true,
+// 							ValidateFunc: validateTaxRateAmount,
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
+// }
+
+// func resourceTaxCategoryRateImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+// 	client := getClient(meta)
+// 	taxRateID := d.Id()
+// 	// Arbitrary number, safe to assume there won't be more than 500 tax categories...
+// 	taxCategoriesQuery, err := client.TaxCategories().Get().WithQueryParams(platform.ByProjectKeyTaxCategoriesRequestMethodGetInput{
+// 		Limit: intRef(500),
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	taxCategory, taxRate := findTaxRate(taxRateID, taxCategoriesQuery.Results)
+
+// 	if taxRate == nil {
+// 		return nil, fmt.Errorf("Tax rate %s does not seem to exist", taxRateID)
+// 	}
+
+// 	results := make([]*schema.ResourceData, 0)
+// 	taxRateState := resourceTaxCategoryRate().Data(nil)
+
+// 	taxRateState.SetId(*taxRate.ID)
+// 	taxRateState.SetType("commercetools_tax_category_rate")
+// 	taxRateState.Set("tax_category_id", taxCategory.ID)
+
+// 	setTaxRateState(taxRateState, taxRate)
+
+// 	results = append(results, taxRateState)
+
+// 	log.Printf("[DEBUG] Importing results: %#v", results)
+
+// 	return results, nil
+// }
+
+// func resourceTaxCategoryRateGetSubRates(input []interface{}) ([]platform.SubRate, error) {
+// 	result := []platform.SubRate{}
+
+// 	for _, raw := range input {
+// 		raw := raw.(map[string]interface{})
+// 		amount := raw["amount"].(float64)
+// 		result = append(result, platform.SubRate{
+// 			Name:   raw["name"].(string),
+// 			Amount: amount,
+// 		})
+// 	}
+// 	return result, nil
+// }
+
+// func resourceTaxCategoryRateCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	taxCategoryID := d.Get("tax_category_id").(string)
+
+// 	// Lock to prevent concurrent updates due to Version number conflicts
+// 	ctMutexKV.Lock(taxCategoryID)
+// 	defer ctMutexKV.Unlock(taxCategoryID)
+
+// 	taxCategory, err := client.TaxCategories().WithId(taxCategoryID).Get().Execute(context.Background())
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	oldTaxRateIds := getTaxRateIds(taxCategory)
+
+// 	input := platform.TaxCategoryUpdate{
+// 		Version: taxCategory.Version,
+// 		Actions: []platform.TaxCategoryUpdateAction{},
+// 	}
+
+// 	taxRateDraft, err := createTaxRateDraft(d)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	input.Actions = append(input.Actions, platform.TaxCategoryAddTaxRateAction{TaxRate: *taxRateDraft})
+
+// 	err = resource.Retry(30*time.Second, func() *resource.RetryError {
+// 		taxCategory, err = client.TaxCategories().WithId(taxCategoryID).Post(input).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	// Refresh the taxCategory. When a tax rate is added the ID is different
+// 	// then the ID returned in the response
+// 	updatedTaxCategory, err := client.TaxCategories().WithId(taxCategoryID).Get().Execute(context.Background())
+// 	newTaxRate := findNewTaxRate(updatedTaxCategory, oldTaxRateIds)
+
+// 	if newTaxRate == nil {
+// 		log.Fatal("No tax category rate created?")
+// 	}
+
+// 	d.SetId(*newTaxRate.ID)
+// 	d.Set("tax_category_id", taxCategory.ID)
+
+// 	return resourceTaxCategoryRateRead(d, m)
+// }
+
+// func resourceTaxCategoryRateRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Printf("[DEBUG] Current tax rate state: %s and m: %s", stringFormatObject(d), stringFormatObject(m))
+// 	_, taxRate, err := readResourcesFromStateIDs(d, m)
+
+// 	if err != nil {
+// 		d.SetId("")
+// 		return nil
+// 	}
+
+// 	setTaxRateState(d, taxRate)
+
+// 	return nil
+// }
+
+// func setTaxRateState(d *schema.ResourceData, taxRate *platform.TaxRate) {
+// 	log.Printf("[DEBUG] Setting state: %s to taxRate: %s", stringFormatObject(d), stringFormatObject(taxRate))
+// 	d.Set("name", taxRate.Name)
+// 	d.Set("amount", taxRate.Amount)
+// 	d.Set("included_in_price", taxRate.IncludedInPrice)
+// 	d.Set("country", taxRate.Country)
+// 	d.Set("state", taxRate.State)
+
+// 	subRateData := make([]map[string]interface{}, len(taxRate.SubRates))
+// 	for srIndex, subrate := range taxRate.SubRates {
+// 		subRateData[srIndex] = map[string]interface{}{
+// 			"name":   subrate.Name,
+// 			"amount": subrate.Amount,
+// 		}
+// 	}
+// 	d.Set("sub_rate", subRateData)
+
+// 	log.Printf("[DEBUG] Updated state to: %s", stringFormatObject(d))
+// }
+
+// func resourceTaxCategoryRateUpdate(d *schema.ResourceData, m interface{}) error {
+// 	taxCategoryID := d.Get("tax_category_id").(string)
+
+// 	// Lock to prevent concurrent updates due to Version number conflicts
+// 	ctMutexKV.Lock(taxCategoryID)
+// 	defer ctMutexKV.Unlock(taxCategoryID)
+
+// 	taxCategory, _, err := readResourcesFromStateIDs(d, m)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	oldTaxRateIds := getTaxRateIds(taxCategory)
+
+// 	input := platform.TaxCategoryUpdate{
+// 		Version: taxCategory.Version,
+// 		Actions: []platform.TaxCategoryUpdateAction{},
+// 	}
+
+// 	if d.HasChange("name") || d.HasChange("amount") || d.HasChange("included_in_price") || d.HasChange("country") || d.HasChange("state") || d.HasChange("sub_rate") {
+// 		taxRateDraft, err := createTaxRateDraft(d)
+// 		if err != nil {
+// 			return err
+// 		}
+// 		input.Actions = append(input.Actions, platform.TaxCategoryReplaceTaxRateAction{
+// 			TaxRateId: d.Id(),
+// 			TaxRate:   *taxRateDraft,
+// 		})
+// 	}
+
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
+
+// 	client := getClient(m)
+// 	taxCategory, err = client.TaxCategories().WithId(taxCategory.ID).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
+
+// 	// Refresh the taxCategory. When a tax rate is added the ID is different
+// 	// then the ID returned in the response
+// 	updatedTaxCategory, err := client.TaxCategories().WithId(taxCategoryID).Get().Execute(context.Background())
+
+// 	newTaxRate := findNewTaxRate(updatedTaxCategory, oldTaxRateIds)
+
+// 	if newTaxRate == nil {
+// 		log.Fatal("No tax category rate created?")
+// 	}
+
+// 	d.SetId(*newTaxRate.ID)
+
+// 	return resourceTaxCategoryRateRead(d, m)
+// }
+
+// func createTaxRateDraft(d *schema.ResourceData) (*platform.TaxRateDraft, error) {
+// 	var subrates []platform.SubRate
+// 	var err error
+// 	if subRateRaw, ok := d.GetOk("sub_rate"); ok {
+// 		subrates, err = resourceTaxCategoryRateGetSubRates(subRateRaw.([]interface{}))
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 	}
+
+// 	var countryCode string
+// 	if value, ok := d.Get("country").(string); ok {
+// 		countryCode = value
+// 	}
+
+// 	amountRaw := d.Get("amount").(float64)
+
+// 	log.Printf("[DEBUG] Got amount: %f", amountRaw)
+
+// 	taxRateDraft := platform.TaxRateDraft{
+// 		Name:            d.Get("name").(string),
+// 		Amount:          &amountRaw,
+// 		IncludedInPrice: d.Get("included_in_price").(bool),
+// 		Country:         countryCode,
+// 		State:           stringRef(d.Get("state")),
+// 		SubRates:        subrates,
+// 	}
+
+// 	log.Printf("[DEBUG] Created tax rate draft: %#v from input %#v", taxRateDraft, d)
+
+// 	return &taxRateDraft, nil
+// }
+
+// func resourceTaxCategoryRateDelete(d *schema.ResourceData, m interface{}) error {
+// 	taxCategoryID := d.Get("tax_category_id").(string)
+
+// 	// Lock to prevent concurrent updates due to Version number conflicts
+// 	ctMutexKV.Lock(taxCategoryID)
+// 	defer ctMutexKV.Unlock(taxCategoryID)
+
+// 	taxCategory, taxRate, err := readResourcesFromStateIDs(d, m)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	input := platform.TaxCategoryUpdate{
+// 		Version: taxCategory.Version,
+// 		Actions: []platform.TaxCategoryUpdateAction{},
+// 	}
+
+// 	removeAction := platform.TaxCategoryRemoveTaxRateAction{
+// 		TaxRateId: *taxRate.ID,
+// 	}
+// 	input.Actions = append(input.Actions, removeAction)
+
+// 	client := getClient(m)
+// 	_, err = client.TaxCategories().WithId(taxCategory.ID).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	return nil
+// }
+
+// func readResourcesFromStateIDs(d *schema.ResourceData, m interface{}) (*platform.TaxCategory, *platform.TaxRate, error) {
+// 	client := getClient(m)
+// 	taxCategoryID := d.Get("tax_category_id").(string)
+// 	taxRateID := d.Id()
+
+// 	log.Printf("[DEBUG] Reading tax category from commercetools, taxCategory ID: %s, taxRate ID: %s", taxCategoryID, taxRateID)
+
+// 	taxCategory, err := client.TaxCategories().WithId(taxCategoryID).Get().Execute(context.Background())
+
+// 	if err != nil {
+// 		return nil, nil, err
+// 	}
+
+// 	log.Print("[DEBUG] Found following tax category:")
+// 	log.Print(stringFormatObject(taxCategory))
+// 	taxRate := getTaxRateWithID(taxCategory, taxRateID)
+// 	if taxRate == nil {
+// 		return nil, nil, fmt.Errorf("Could not find tax rate %s in tax category %s", taxRateID, taxCategory.ID)
+// 	}
+// 	log.Print("[DEBUG] Found following tax rate:")
+// 	log.Print(stringFormatObject(taxRate))
+
+// 	return taxCategory, taxRate, nil
+// }
+
+// func validateTaxRateAmount(val interface{}, key string) (warns []string, errs []error) {
+// 	v := val.(float64)
+// 	if v < 0 || v > 1 {
+// 		errs = append(errs, fmt.Errorf("%q must be between 0 and 1 inclusive, got: %f", key, v))
+// 	}
+// 	return
+// }
+
+// func getTaxRateIds(taxCategory *platform.TaxCategory) []string {
+// 	taxRateIds := []string{}
+// 	for _, rate := range taxCategory.Rates {
+// 		taxRateIds = append(taxRateIds, *rate.ID)
+// 	}
+
+// 	return taxRateIds
+// }
+
+// // Find new tax rate by comparing with tax rate ids created just before adding new tax rate
+// func findNewTaxRate(taxCategory *platform.TaxCategory, oldTaxRateIds []string) *platform.TaxRate {
+// 	for _, taxRate := range taxCategory.Rates {
+// 		if !stringInSlice(*taxRate.ID, oldTaxRateIds) {
+// 			return &taxRate
+// 		}
+// 	}
+// 	return nil
+// }
+
+// func getTaxRateWithID(taxCategory *platform.TaxCategory, taxRateID string) *platform.TaxRate {
+// 	for _, rate := range taxCategory.Rates {
+// 		if *rate.ID == taxRateID {
+// 			return &rate
+// 		}
+// 	}
+
+// 	return nil
+// }
+
+// func findTaxRate(taxRateID string, taxCategories []platform.TaxCategory) (*platform.TaxCategory, *platform.TaxRate) {
+// 	for _, taxCategory := range taxCategories {
+// 		for _, taxRate := range taxCategory.Rates {
+// 			if *taxRate.ID == taxRateID {
+// 				return &taxCategory, &taxRate
+// 			}
+// 		}
+// 	}
+// 	return nil, nil
+// }

--- a/commercetools/resource_tax_category_rate_test.go
+++ b/commercetools/resource_tax_category_rate_test.go
@@ -1,314 +1,314 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccTaxCategoryRate_createAndUpdateWithID(t *testing.T) {
+// func TestAccTaxCategoryRate_createAndUpdateWithID(t *testing.T) {
 
-	name := acctest.RandomWithPrefix("tf-acc-test")
-	amount := 0.2
-	country := "DE"
+// 	name := acctest.RandomWithPrefix("tf-acc-test")
+// 	amount := 0.2
+// 	country := "DE"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTaxCategoryRateConfig(name, amount, true, country),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "included_in_price", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "country", country,
-					),
-				),
-			},
-			{
-				Config: testAccTaxCategoryRateConfig(name, amount, false, country),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "included_in_price", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "country", country,
-					),
-				),
-			},
-			{
-				Config: testAccTaxCategoryRateConfig(name, 0.0, true, country),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "amount", "0",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "included_in_price", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "country", country,
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccTaxCategoryRateConfig(name, amount, true, country),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "included_in_price", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "country", country,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTaxCategoryRateConfig(name, amount, false, country),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "included_in_price", "false",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "country", country,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTaxCategoryRateConfig(name, 0.0, true, country),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "amount", "0",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "included_in_price", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "country", country,
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccTaxCategoryRateConfig(name string, amount float64, includedInPrice bool, country string) string {
-	return fmt.Sprintf(`
-resource "commercetools_tax_category" "standard" {
-	name = "test-rate-category"
-	key = "test-rate-category"
-	description = "Test rate tax"
-}
+// func testAccTaxCategoryRateConfig(name string, amount float64, includedInPrice bool, country string) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_tax_category" "standard" {
+// 	name = "test-rate-category"
+// 	key = "test-rate-category"
+// 	description = "Test rate tax"
+// }
 
-resource "commercetools_tax_category_rate" "test_rate" {
-	tax_category_id = "${commercetools_tax_category.standard.id}"
-	name = "%s"
-	amount = %f
-	included_in_price = %t
-	country = "%s"
-}
-`, name, amount, includedInPrice, country)
-}
+// resource "commercetools_tax_category_rate" "test_rate" {
+// 	tax_category_id = "${commercetools_tax_category.standard.id}"
+// 	name = "%s"
+// 	amount = %f
+// 	included_in_price = %t
+// 	country = "%s"
+// }
+// `, name, amount, includedInPrice, country)
+// }
 
-func TestAccTaxCategoryRate_createAndUpdateSubRates(t *testing.T) {
+// func TestAccTaxCategoryRate_createAndUpdateSubRates(t *testing.T) {
 
-	name := acctest.RandomWithPrefix("tf-acc-test")
-	subRateAmount := 0.3
-	amount := 0.2
-	country := "DE"
+// 	name := acctest.RandomWithPrefix("tf-acc-test")
+// 	subRateAmount := 0.3
+// 	amount := 0.2
+// 	country := "DE"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTaxCategoryRateSubRatesConfig(name, subRateAmount, true, country, true),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "amount", "0.3",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "included_in_price", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "country", country,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "sub_rate.0.amount", "0.2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "sub_rate.0.name", "foo",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "sub_rate.1.amount", "0.1",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "sub_rate.1.name", "foo2",
-					),
-				),
-			},
-			{
-				Config: testAccTaxCategoryRateSubRatesConfig(name, amount, false, country, false),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "included_in_price", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "country", country,
-					),
-					resource.TestCheckNoResourceAttr("commercetools_tax_category_rate.test_rate", "sub_rate"),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccTaxCategoryRateSubRatesConfig(name, subRateAmount, true, country, true),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "amount", "0.3",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "included_in_price", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "country", country,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "sub_rate.0.amount", "0.2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "sub_rate.0.name", "foo",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "sub_rate.1.amount", "0.1",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "sub_rate.1.name", "foo2",
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTaxCategoryRateSubRatesConfig(name, amount, false, country, false),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "included_in_price", "false",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "country", country,
+// 					),
+// 					resource.TestCheckNoResourceAttr("commercetools_tax_category_rate.test_rate", "sub_rate"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccTaxCategoryRateSubRatesConfig(name string, amount float64, includedInPrice bool, country string, addSubrates bool) string {
-	if addSubrates {
-		return fmt.Sprintf(`
-resource "commercetools_tax_category" "standard" {
-	name        = "test-rate-category"
-	key         = "test-rate-category"
-	description = "Test rate tax"
-}
+// func testAccTaxCategoryRateSubRatesConfig(name string, amount float64, includedInPrice bool, country string, addSubrates bool) string {
+// 	if addSubrates {
+// 		return fmt.Sprintf(`
+// resource "commercetools_tax_category" "standard" {
+// 	name        = "test-rate-category"
+// 	key         = "test-rate-category"
+// 	description = "Test rate tax"
+// }
 
-resource "commercetools_tax_category_rate" "test_rate" {
-	tax_category_id = "${commercetools_tax_category.standard.id}"
-	name              = "%s"
-	amount            = %f
-	included_in_price = %t
-	country           = "%s"
-	sub_rate {
-		name = "foo"
-		amount = 0.2
-	}
-	sub_rate {
-		name = "foo2"
-		amount = 0.1
-	}
-}
-`, name, amount, includedInPrice, country)
-	}
-	return fmt.Sprintf(`
-resource "commercetools_tax_category" "standard" {
-	name        = "test-rate-category"
-	key         = "test-rate-category"
-	description = "Test rate tax"
-}
+// resource "commercetools_tax_category_rate" "test_rate" {
+// 	tax_category_id = "${commercetools_tax_category.standard.id}"
+// 	name              = "%s"
+// 	amount            = %f
+// 	included_in_price = %t
+// 	country           = "%s"
+// 	sub_rate {
+// 		name = "foo"
+// 		amount = 0.2
+// 	}
+// 	sub_rate {
+// 		name = "foo2"
+// 		amount = 0.1
+// 	}
+// }
+// `, name, amount, includedInPrice, country)
+// 	}
+// 	return fmt.Sprintf(`
+// resource "commercetools_tax_category" "standard" {
+// 	name        = "test-rate-category"
+// 	key         = "test-rate-category"
+// 	description = "Test rate tax"
+// }
 
-resource "commercetools_tax_category_rate" "test_rate" {
-	tax_category_id = "${commercetools_tax_category.standard.id}"
-	name              = "%s"
-	amount            = %f
-	included_in_price = %t
-	country           = "%s"
-}
-`, name, amount, includedInPrice, country)
-}
+// resource "commercetools_tax_category_rate" "test_rate" {
+// 	tax_category_id = "${commercetools_tax_category.standard.id}"
+// 	name              = "%s"
+// 	amount            = %f
+// 	included_in_price = %t
+// 	country           = "%s"
+// }
+// `, name, amount, includedInPrice, country)
+// }
 
-func TestAccTaxCategoryRate_createAndUpdateBothRateAndTaxCategory(t *testing.T) {
+// func TestAccTaxCategoryRate_createAndUpdateBothRateAndTaxCategory(t *testing.T) {
 
-	name := acctest.RandomWithPrefix("tf-acc-test")
-	amount := 0.2
-	country := "DE"
+// 	name := acctest.RandomWithPrefix("tf-acc-test")
+// 	amount := 0.2
+// 	country := "DE"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTaxCategoryRateDualUpdateConfig("foo", name, amount, true, country),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category.standard", "description", "foo",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "included_in_price", "true",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "country", country,
-					),
-				),
-			},
-			{
-				Config: testAccTaxCategoryRateDualUpdateConfig("bar", name, amount, false, country),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category.standard", "description", "bar",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "included_in_price", "false",
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category_rate.test_rate", "country", country,
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckTaxCategoryRateDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccTaxCategoryRateDualUpdateConfig("foo", name, amount, true, country),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category.standard", "description", "foo",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "included_in_price", "true",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "country", country,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTaxCategoryRateDualUpdateConfig("bar", name, amount, false, country),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category.standard", "description", "bar",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "amount", "0.2",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "included_in_price", "false",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category_rate.test_rate", "country", country,
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccTaxCategoryRateDualUpdateConfig(description string, name string, amount float64, includedInPrice bool, country string) string {
-	return fmt.Sprintf(`
-resource "commercetools_tax_category" "standard" {
-	name = "test-rate-category"
-	key = "test-rate-category"
-	description = "%s"
-}
+// func testAccTaxCategoryRateDualUpdateConfig(description string, name string, amount float64, includedInPrice bool, country string) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_tax_category" "standard" {
+// 	name = "test-rate-category"
+// 	key = "test-rate-category"
+// 	description = "%s"
+// }
 
-resource "commercetools_tax_category_rate" "test_rate" {
-	tax_category_id = "${commercetools_tax_category.standard.id}"
-	name = "%s"
-	amount = %f
-	included_in_price = %t
-	country = "%s"
-}
-`, description, name, amount, includedInPrice, country)
-}
+// resource "commercetools_tax_category_rate" "test_rate" {
+// 	tax_category_id = "${commercetools_tax_category.standard.id}"
+// 	name = "%s"
+// 	amount = %f
+// 	included_in_price = %t
+// 	country = "%s"
+// }
+// `, description, name, amount, includedInPrice, country)
+// }
 
-func testAccCheckTaxCategoryRateDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
-	var rateIDs []string
-	// Because we can't directly query for Tax Categories, we are going to loop over the resources twice. Once to store
-	// the tax rate IDs of any rates present, and once to check the categories and their rates
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_tax_category_rate" {
-			continue
-		}
-		rateIDs = append(rateIDs, rs.Primary.ID)
-	}
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_tax_category" {
-			continue
-		}
-		response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && len(response.Rates) > 0 && response.ID == rs.Primary.ID {
-				var trailingTestRates []string
-				for _, rate := range response.Rates {
-					if stringInSlice(*rate.ID, rateIDs) {
-						trailingTestRates = append(trailingTestRates, *rate.ID)
-					}
-				}
-				return fmt.Errorf("tax category %s still exists with rates (%v)", rs.Primary.ID, trailingTestRates)
-			}
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
-			}
-			continue
-		}
+// func testAccCheckTaxCategoryRateDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
+// 	var rateIDs []string
+// 	// Because we can't directly query for Tax Categories, we are going to loop over the resources twice. Once to store
+// 	// the tax rate IDs of any rates present, and once to check the categories and their rates
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_tax_category_rate" {
+// 			continue
+// 		}
+// 		rateIDs = append(rateIDs, rs.Primary.ID)
+// 	}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_tax_category" {
+// 			continue
+// 		}
+// 		response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && len(response.Rates) > 0 && response.ID == rs.Primary.ID {
+// 				var trailingTestRates []string
+// 				for _, rate := range response.Rates {
+// 					if stringInSlice(*rate.ID, rateIDs) {
+// 						trailingTestRates = append(trailingTestRates, *rate.ID)
+// 					}
+// 				}
+// 				return fmt.Errorf("tax category %s still exists with rates (%v)", rs.Primary.ID, trailingTestRates)
+// 			}
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
+// 			}
+// 			continue
+// 		}
 
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_tax_category_test.go
+++ b/commercetools/resource_tax_category_test.go
@@ -1,87 +1,87 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestAccTaxCategory_createAndUpdateWithID(t *testing.T) {
+// func TestAccTaxCategory_createAndUpdateWithID(t *testing.T) {
 
-	name := "test category"
-	key := "test-category"
-	description := "test category description"
+// 	name := "test category"
+// 	key := "test-category"
+// 	description := "test category description"
 
-	newName := "new test category"
-	newKey := "new-test-category"
-	newDescription := "new test category description"
+// 	newName := "new test category"
+// 	newKey := "new-test-category"
+// 	newDescription := "new test category description"
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTaxCategoryDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTaxCategoryConfig(name, key, description),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category.standard", "name", name,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category.standard", "key", key,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category.standard", "description", description,
-					),
-				),
-			},
-			{
-				Config: testAccTaxCategoryConfig(newName, newKey, newDescription),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category.standard", "name", newName,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category.standard", "key", newKey,
-					),
-					resource.TestCheckResourceAttr(
-						"commercetools_tax_category.standard", "description", newDescription,
-					),
-				),
-			},
-		},
-	})
-}
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckTaxCategoryDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccTaxCategoryConfig(name, key, description),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category.standard", "name", name,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category.standard", "key", key,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category.standard", "description", description,
+// 					),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTaxCategoryConfig(newName, newKey, newDescription),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category.standard", "name", newName,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category.standard", "key", newKey,
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_tax_category.standard", "description", newDescription,
+// 					),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccTaxCategoryConfig(name string, key string, description string) string {
-	return fmt.Sprintf(`
-resource "commercetools_tax_category" "standard" {
-	name = "%s"
-	key = "%s"
-	description = "%s"
-}`, name, key, description)
-}
+// func testAccTaxCategoryConfig(name string, key string, description string) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_tax_category" "standard" {
+// 	name = "%s"
+// 	key = "%s"
+// 	description = "%s"
+// }`, name, key, description)
+// }
 
-func testAccCheckTaxCategoryDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckTaxCategoryDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_tax_category" {
-			continue
-		}
-		response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_tax_category" {
+// 			continue
+// 		}
+// 		response, err := client.TaxCategories().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("tax category (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_type.go
+++ b/commercetools/resource_type.go
@@ -1,774 +1,769 @@
 package commercetools
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"reflect"
-	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
-)
-
-func resourceType() *schema.Resource {
-	return &schema.Resource{
-		Description: "Types define custom fields that are used to enhance resources as you need. Use Types to model " +
-			"your own CustomFields on resources, like Category and Customer.\n\n" +
-			"In case you want to customize products, please use product types instead that serve a similar purpose, " +
-			"but tailored to products.\n\n" +
-			"See also the [Types Api Documentation](https://docs.commercetools.com/api/projects/types)",
-		Create: resourceTypeCreate,
-		Read:   resourceTypeRead,
-		Update: resourceTypeUpdate,
-		Delete: resourceTypeDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Description: "Identifier for the type (max. 256 characters)",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"name": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Required:    true,
-			},
-			"description": {
-				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
-				Type:        TypeLocalizedString,
-				Optional:    true,
-			},
-			"resource_type_ids": {
-				Description: "Defines for which [resources](https://docs.commercetools.com/api/projects/custom-fields#customizable-resources)" +
-					" the type is valid",
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"field": {
-				Description: "[Field definition](https://docs.commercetools.com/api/projects/types#fielddefinition)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Description: "Describes the [type](https://docs.commercetools.com/api/projects/types#fieldtype)" +
-								" of the field",
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Required: true,
-							Elem:     fieldTypeElement(true),
-						},
-						"name": {
-							Description: "The name of the field.\nThe name must be between two and 36 characters long " +
-								"and can contain the ASCII letters A to Z in lowercase or uppercase, digits, " +
-								"underscores (_) and the hyphen-minus (-).\nThe name must be unique for a given " +
-								"resource type ID. In case there is a field with the same name in another type it has " +
-								"to have the same FieldType also",
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"label": {
-							Description: "A human-readable label for the field",
-							Type:        TypeLocalizedString,
-							Required:    true,
-						},
-						"required": {
-							Description: "Whether the field is required to have a value",
-							Type:        schema.TypeBool,
-							Optional:    true,
-							Default:     false,
-						},
-						"input_hint": {
-							Description: "[TextInputHint](https://docs.commercetools.com/api/projects/types#textinputhint)" +
-								" Provides a visual representation type for this field. It is only relevant for " +
-								"string-based field types like StringType and LocalizedStringType",
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  platform.TextInputHintSingleLine,
-						},
-					},
-				},
-			},
-			"version": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-		},
-		CustomizeDiff: customdiff.All(
-			customdiff.ValidateChange("field", func(ctx context.Context, old, new, meta interface{}) error {
-				log.Printf("[DEBUG] Start field validation")
-				oldLookup := createLookup(old.([]interface{}), "name")
-				newV := new.([]interface{})
-
-				for _, field := range newV {
-					newF := field.(map[string]interface{})
-					name := newF["name"].(string)
-					oldF, ok := oldLookup[name].(map[string]interface{})
-					if !ok {
-						// It means this is a new field, that's ok.
-						log.Printf("[DEBUG] Found new field: %s", name)
-						continue
-					}
-
-					log.Printf("[DEBUG] Checking %s", oldF["name"])
-					oldType := oldF["type"].([]interface{})[0].(map[string]interface{})
-					newType := newF["type"].([]interface{})[0].(map[string]interface{})
-
-					if oldType["name"] != newType["name"] {
-						if oldType["name"] != "" || newType["name"] == "" {
-							continue
-						}
-						return fmt.Errorf(
-							"Field '%s' type changed from %s to %s. Changing types is not supported; please remove the field first and re-define it later",
-							name, oldType["name"], newType["name"])
-					}
-
-					if oldF["required"] != newF["required"] {
-						return fmt.Errorf(
-							"Error on the '%s' attribute: Updating the 'required' attribute is not supported. Consider removing the attribute first and then re-adding it",
-							name)
-					}
-				}
-				return nil
-			}),
-		),
-	}
-}
-
-func localizedValueElement() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"label": {
-				Type:     TypeLocalizedString,
-				Required: true,
-			},
-		},
-	}
-}
-
-func fieldTypeElement(setsAllowed bool) *schema.Resource {
-	result := map[string]*schema.Schema{
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-				v := val.(string)
-				if !setsAllowed && v == "Set" {
-					errs = append(errs, fmt.Errorf("Sets in another Set are not allowed"))
-				}
-				return
-			},
-		},
-		"values": {
-			Type:     schema.TypeMap,
-			Optional: true,
-		},
-		// Or, alternatively, we could go with the following
-		// to have it more consistent with localized_value.
-		// However, this is the difference between:
-		// |	values = {
-		// |		value1 = "Value 1"
-		// |		value2 = "Value 2"
-		// |	}
-		//  and
-		// |	value {
-		// |		key = "value1"
-		// |		label = "Value 1"
-		// |	}
-		// |	value {
-		// |		key = "value2"
-		// |		label = "Value 2"
-		// |	}
-		// "value": {
-		// 	Type:     schema.TypeSet,
-		// 	Optional: true,
-		// 	Elem: &schema.Resource{
-		// 		Schema: map[string]*schema.Schema{
-		// 			"key": {
-		// 				Type:     schema.TypeString,
-		// 				Required: true,
-		// 			},
-		// 			"label": {
-		// 				Type:     schema.TypeString,
-		// 				Required: true,
-		// 			},
-		// 		},
-		// 	},
-		// },
-		"localized_value": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem:     localizedValueElement(),
-		},
-		"reference_type_id": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-	}
-
-	if setsAllowed {
-		result["element_type"] = &schema.Schema{
-			Type:     schema.TypeList,
-			MaxItems: 1,
-			Optional: true,
-			Elem:     fieldTypeElement(false),
-		}
-	}
-
-	return &schema.Resource{Schema: result}
-}
-
-func resourceTypeCreate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	var ctType *platform.Type
-
-	name := platform.LocalizedString(
-		expandStringMap(d.Get("name").(map[string]interface{})))
-	description := platform.LocalizedString(
-		expandStringMap(d.Get("description").(map[string]interface{})))
-
-	resourceTypeIds := []platform.ResourceTypeId{}
-	for _, item := range expandStringArray(d.Get("resource_type_ids").([]interface{})) {
-		resourceTypeIds = append(resourceTypeIds, platform.ResourceTypeId(item))
-
-	}
-	fields, err := resourceTypeGetFieldDefinitions(d)
-
-	if err != nil {
-		return err
-	}
-
-	draft := platform.TypeDraft{
-		Key:              d.Get("key").(string),
-		Name:             name,
-		Description:      &description,
-		ResourceTypeIds:  resourceTypeIds,
-		FieldDefinitions: fields,
-	}
-
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		var err error
-
-		ctType, err = client.Types().Post(draft).Execute(context.Background())
-		if err != nil {
-			return handleCommercetoolsError(err)
-		}
-		return nil
-	})
-
-	if err != nil {
-		return err
-	}
-
-	if ctType == nil {
-		log.Fatal("No type created?")
-	}
-
-	d.SetId(ctType.ID)
-	d.Set("version", ctType.Version)
-
-	return resourceTypeRead(d, m)
-}
-
-func resourceTypeRead(d *schema.ResourceData, m interface{}) error {
-	log.Print("[DEBUG] Reading type from commercetools")
-	client := getClient(m)
-
-	ctType, err := client.Types().WithId(d.Id()).Get().Execute(context.Background())
-
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			if ctErr.StatusCode == 404 {
-				d.SetId("")
-				return nil
-			}
-		}
-		return err
-	}
-
-	if ctType == nil {
-		log.Print("[DEBUG] No type found")
-		d.SetId("")
-	} else {
-		log.Print("[DEBUG] Found following type:")
-		log.Print(stringFormatObject(ctType))
-
-		d.Set("version", ctType.Version)
-		d.Set("key", ctType.Key)
-		d.Set("name", ctType.Name)
-		if ctType.Description != nil {
-			d.Set("description", ctType.Description)
-		}
-		d.Set("resource_type_ids", ctType.ResourceTypeIds)
-
-		if fields, err := marshallTypeFields(ctType); err == nil {
-			d.Set("field", fields)
-		} else {
-			return err
-		}
-	}
-	return nil
-}
-
-func resourceTypeUpdate(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-
-	input := platform.TypeUpdate{
-		Version: d.Get("version").(int),
-		Actions: []platform.TypeUpdateAction{},
-	}
-
-	if d.HasChange("key") {
-		newKey := d.Get("key").(string)
-		input.Actions = append(
-			input.Actions,
-			&platform.TypeChangeKeyAction{Key: newKey})
-	}
-
-	if d.HasChange("name") {
-		newName := platform.LocalizedString(
-			expandStringMap(d.Get("name").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.TypeChangeNameAction{Name: newName})
-	}
-
-	if d.HasChange("description") {
-		newDescr := platform.LocalizedString(
-			expandStringMap(d.Get("description").(map[string]interface{})))
-		input.Actions = append(
-			input.Actions,
-			&platform.TypeSetDescriptionAction{
-				Description: &newDescr})
-	}
-
-	if d.HasChange("field") {
-		old, new := d.GetChange("field")
-		fieldChangeActions, err := resourceTypeFieldChangeActions(old.([]interface{}), new.([]interface{}))
-		if err != nil {
-			return err
-		}
-		input.Actions = append(input.Actions, fieldChangeActions...)
-	}
-	log.Printf(
-		"[DEBUG] Will perform update operation with the following actions:\n%s",
-		stringFormatActions(input.Actions))
-
-	_, err := client.Types().WithId(d.Id()).Post(input).Execute(context.Background())
-	if err != nil {
-		if ctErr, ok := err.(platform.ErrorResponse); ok {
-			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
-		}
-		return err
-	}
-
-	return resourceTypeRead(d, m)
-}
-
-// Generate a list of actions needed for updating the fields value in
-// commercetools so that it matches the terraform file
-func resourceTypeFieldChangeActions(oldValues []interface{}, newValues []interface{}) ([]platform.TypeUpdateAction, error) {
-	oldLookup := createLookup(oldValues, "name")
-	newLookup := createLookup(newValues, "name")
-	actions := []platform.TypeUpdateAction{}
-	checkAttributeOrder := true
-
-	log.Printf("[DEBUG] Construction Field change actions")
-
-	// Check if we have fields which are removed and generate the corresponding
-	// remove field actions
-	for name := range oldLookup {
-		if _, ok := newLookup[name]; !ok {
-			log.Printf("[DEBUG] Field deleted: %s", name)
-			actions = append(actions, platform.TypeRemoveFieldDefinitionAction{FieldName: name})
-			// checkAttributeOrder = false
-		}
-	}
-
-	for i := range newValues {
-		newV := newValues[i].(map[string]interface{})
-		name := newV["name"].(string)
-		oldValue, existingField := oldLookup[name]
-
-		fieldDef, err := resourceTypeGetFieldDefinition(newV)
-		if err != nil {
-			return nil, err
-		}
-
-		// A new field is added. Create the update action skip the rest of the
-		// loop since there cannot be any change if the field didn't exist yet.
-		if !existingField {
-			log.Printf("[DEBUG] Field added: %s", name)
-			actions = append(
-				actions,
-				platform.TypeAddFieldDefinitionAction{FieldDefinition: *fieldDef})
-			// checkAttributeOrder = false
-			continue
-		}
-
-		// Check if we need to update the field label
-		oldV := oldValue.(map[string]interface{})
-		if !reflect.DeepEqual(oldV["label"], newV["label"]) {
-			newLabel := platform.LocalizedString(
-				expandStringMap(newV["label"].(map[string]interface{})))
-			actions = append(
-				actions,
-				platform.TypeChangeLabelAction{FieldName: name, Label: newLabel})
-		}
-
-		// Update the input hint if this is changed
-		if !reflect.DeepEqual(oldV["input_hint"], newV["input_hint"]) {
-			var newInputHint platform.TypeTextInputHint
-			switch newV["input_hint"].(string) {
-			case "SingleLine":
-				newInputHint = platform.TypeTextInputHintSingleLine
-			case "MultiLine":
-				newInputHint = platform.TypeTextInputHintMultiLine
-			}
-
-			actions = append(
-				actions,
-				platform.TypeChangeInputHintAction{FieldName: name, InputHint: newInputHint})
-		}
-
-		newFieldType := fieldDef.Type
-		oldFieldType := oldV["type"].([]interface{})[0].(map[string]interface{})
-
-		if enumType, ok := newFieldType.(platform.CustomFieldSetType); ok {
-
-			myOldFieldType := oldFieldType["element_type"].([]interface{})[0].(map[string]interface{})
-			actions = resourceTypeHandleEnumTypeChanges(enumType.ElementType, myOldFieldType, actions, name)
-
-			log.Printf("[DEBUG] Set detected: %s", name)
-			log.Print(len(myOldFieldType))
-		}
-
-		actions = resourceTypeHandleEnumTypeChanges(newFieldType, oldFieldType, actions, name)
-	}
-
-	oldNames := make([]string, len(oldValues))
-	newNames := make([]string, len(newValues))
-
-	for i := range oldValues {
-		v := oldValues[i].(map[string]interface{})
-		oldNames[i] = v["name"].(string)
-	}
-
-	for i := range newValues {
-		v := newValues[i].(map[string]interface{})
-		newNames[i] = v["name"].(string)
-	}
-
-	if checkAttributeOrder && !reflect.DeepEqual(oldNames, newNames) {
-		log.Printf("[DEBUG] Field ordering: %s", newNames)
-
-		actions = append(
-			actions,
-			platform.TypeChangeFieldDefinitionOrderAction{
-				FieldNames: newNames,
-			})
-	}
-
-	return actions, nil
-}
-
-func resourceTypeHandleEnumTypeChanges(newFieldType platform.FieldType, oldFieldType map[string]interface{}, actions []platform.TypeUpdateAction, name string) []platform.TypeUpdateAction {
-	if enumType, ok := newFieldType.(platform.CustomFieldEnumType); ok {
-		oldEnumV := oldFieldType["values"].(map[string]interface{})
-
-		for i := range enumType.Values {
-			if _, ok := oldEnumV[enumType.Values[i].Key]; !ok {
-				// Key does not appear in old enum values, so we'll add it
-				actions = append(
-					actions,
-					platform.TypeAddEnumValueAction{
-						FieldName: name,
-						Value:     enumType.Values[i],
-					})
-				continue
-			}
-
-			if oldEnumV[enumType.Values[i].Key].(string) != enumType.Values[i].Label {
-				//label for this key is changed
-				actions = append(
-					actions,
-					platform.TypeChangeEnumValueLabelAction{
-						FieldName: name,
-						Value:     enumType.Values[i],
-					})
-			}
-		}
-
-		// Action: changeEnumValueOrder
-		// TODO: Change the order of EnumValues: https://docs.commercetools.com/http-api-projects-types.html#change-the-order-of-fielddefinitions
-
-	} else if enumType, ok := newFieldType.(platform.CustomFieldLocalizedEnumType); ok {
-		oldEnumV := oldFieldType["localized_value"].([]interface{})
-		oldEnumKeys := make(map[string]map[string]interface{}, len(oldEnumV))
-
-		for i := range oldEnumV {
-			v := oldEnumV[i].(map[string]interface{})
-			oldEnumKeys[v["key"].(string)] = v
-		}
-
-		for i, enumValue := range enumType.Values {
-			if _, ok := oldEnumKeys[enumValue.Key]; !ok {
-				// Key does not appear in old enum values, so we'll add it
-				actions = append(
-					actions,
-					platform.TypeAddLocalizedEnumValueAction{
-						FieldName: name,
-						Value:     enumType.Values[i],
-					})
-			}
-		}
-
-		// Action: changeLocalizedEnumValueOrder
-		// TODO: Change the order of LocalizedEnumValues: https://docs.commercetools.com/http-api-projects-types.html#change-the-order-of-localizedenumvalues
-	}
-	return actions
-}
-
-func resourceTypeDelete(d *schema.ResourceData, m interface{}) error {
-	client := getClient(m)
-	version := d.Get("version").(int)
-	_, err := client.Types().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyTypesByIDRequestMethodDeleteInput{
-		Version: version,
-	}).Execute(context.Background())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func resourceTypeGetFieldDefinitions(d *schema.ResourceData) ([]platform.FieldDefinition, error) {
-	input := d.Get("field").([]interface{})
-	result := make([]platform.FieldDefinition, len(input))
-
-	for i := range input {
-		raw := input[i].(map[string]interface{})
-		fieldDef, err := resourceTypeGetFieldDefinition(raw)
-
-		if err != nil {
-			return nil, err
-		}
-
-		result[i] = *fieldDef
-	}
-
-	return result, nil
-}
-
-func resourceTypeGetFieldDefinition(input map[string]interface{}) (*platform.FieldDefinition, error) {
-	fieldTypes := input["type"].([]interface{})
-	fieldType, err := getFieldType(fieldTypes[0])
-	if err != nil {
-		return nil, err
-	}
-
-	label := platform.LocalizedString(
-		expandStringMap(input["label"].(map[string]interface{})))
-
-	inputHint := platform.TypeTextInputHint(input["input_hint"].(string))
-	return &platform.FieldDefinition{
-		Type:      fieldType,
-		Name:      input["name"].(string),
-		Label:     label,
-		Required:  input["required"].(bool),
-		InputHint: &inputHint,
-	}, nil
-}
-
-func getFieldType(input interface{}) (platform.FieldType, error) {
-	config := input.(map[string]interface{})
-	typeName, ok := config["name"].(string)
-
-	if !ok {
-		return nil, fmt.Errorf("No 'name' for type object given")
-	}
-
-	switch typeName {
-	case "Boolean":
-		return platform.CustomFieldBooleanType{}, nil
-	case "String":
-		return platform.CustomFieldStringType{}, nil
-	case "LocalizedString":
-		return platform.CustomFieldLocalizedStringType{}, nil
-	case "Enum":
-		valuesInput, valuesOk := config["values"].(map[string]interface{})
-		if !valuesOk {
-			return nil, fmt.Errorf("No values specified for Enum type: %+v", valuesInput)
-		}
-		var values []platform.CustomFieldEnumValue
-		for k, v := range valuesInput {
-			values = append(values, platform.CustomFieldEnumValue{
-				Key:   k,
-				Label: v.(string),
-			})
-		}
-		return platform.CustomFieldEnumType{Values: values}, nil
-	case "LocalizedEnum":
-		valuesInput, valuesOk := config["localized_value"]
-		if !valuesOk {
-			return nil, fmt.Errorf("No localized_value elements specified for LocalizedEnum type")
-		}
-		var values []platform.CustomFieldLocalizedEnumValue
-		for _, value := range valuesInput.([]interface{}) {
-			v := value.(map[string]interface{})
-			labels := platform.LocalizedString(
-				expandStringMap(v["label"].(map[string]interface{})))
-			values = append(values, platform.CustomFieldLocalizedEnumValue{
-				Key:   v["key"].(string),
-				Label: labels,
-			})
-		}
-		return platform.CustomFieldLocalizedEnumType{Values: values}, nil
-	case "Number":
-		return platform.CustomFieldNumberType{}, nil
-	case "Money":
-		return platform.CustomFieldMoneyType{}, nil
-	case "Date":
-		return platform.CustomFieldDateType{}, nil
-	case "Time":
-		return platform.CustomFieldTimeType{}, nil
-	case "DateTime":
-		return platform.CustomFieldDateTimeType{}, nil
-	case "Reference":
-		refTypeID, refTypeIDOk := config["reference_type_id"].(string)
-		if !refTypeIDOk {
-			return nil, fmt.Errorf("No reference_type_id specified for Reference type")
-		}
-		return platform.CustomFieldReferenceType{
-			ReferenceTypeId: platform.ReferenceTypeId(refTypeID),
-		}, nil
-	case "Set":
-		elementTypes, elementTypesOk := config["element_type"]
-		if !elementTypesOk {
-			return nil, fmt.Errorf("No element_type specified for Set type")
-		}
-		elementTypeList := elementTypes.([]interface{})
-		if len(elementTypeList) == 0 {
-			return nil, fmt.Errorf("No element_type specified for Set type")
-		}
-
-		setFieldType, err := getFieldType(elementTypeList[0])
-		if err != nil {
-			return nil, err
-		}
-
-		return platform.CustomFieldSetType{
-			ElementType: setFieldType,
-		}, nil
-	}
-
-	return nil, fmt.Errorf("Unknown FieldType %s", typeName)
-}
-
-func marshallTypeFields(t *platform.Type) ([]map[string]interface{}, error) {
-	fields := make([]map[string]interface{}, len(t.FieldDefinitions))
-	for i, fieldDef := range t.FieldDefinitions {
-		fieldData := make(map[string]interface{})
-		log.Printf("[DEBUG] reading field: %s: %#v", fieldDef.Name, fieldDef)
-		fieldType, err := marshallTypeFieldType(fieldDef.Type, true)
-		if err != nil {
-			return nil, err
-		}
-		fieldData["type"] = fieldType
-		fieldData["name"] = fieldDef.Name
-		if fieldDef.Label != nil {
-			fieldData["label"] = fieldDef.Label
-		} else {
-			fieldData["label"] = nil
-		}
-		fieldData["required"] = fieldDef.Required
-		fieldData["input_hint"] = fieldDef.InputHint
-
-		fields[i] = fieldData
-	}
-	return fields, nil
-}
-
-func marshallTypeFieldType(fieldType platform.FieldType, setsAllowed bool) ([]interface{}, error) {
-	typeData := make(map[string]interface{})
-
-	switch val := fieldType.(type) {
-
-	case platform.CustomFieldBooleanType:
-		typeData["name"] = "Boolean"
-
-	case platform.CustomFieldStringType:
-		typeData["name"] = "String"
-
-	case platform.CustomFieldLocalizedStringType:
-		typeData["name"] = "LocalizedString"
-
-	case platform.CustomFieldEnumType:
-		enumValues := make(map[string]interface{}, len(val.Values))
-		for _, value := range val.Values {
-			enumValues[value.Key] = value.Label
-		}
-		typeData["name"] = "Enum"
-		typeData["values"] = enumValues
-
-	case platform.CustomFieldLocalizedEnumType:
-		typeData["name"] = "LocalizedEnum"
-		typeData["localized_value"] = marshallTypeLocalizedEnum(val.Values)
-
-	case platform.CustomFieldNumberType:
-		typeData["name"] = "Number"
-
-	case platform.CustomFieldMoneyType:
-		typeData["name"] = "Money"
-
-	case platform.CustomFieldDateType:
-		typeData["name"] = "Date"
-
-	case platform.CustomFieldTimeType:
-		typeData["name"] = "Time"
-
-	case platform.CustomFieldDateTimeType:
-		typeData["name"] = "DateTime"
-
-	case platform.CustomFieldReferenceType:
-		typeData["name"] = "Reference"
-		typeData["reference_type_id"] = val.ReferenceTypeId
-
-	case platform.CustomFieldSetType:
-		typeData["name"] = "Set"
-		if setsAllowed {
-			elemType, err := marshallTypeFieldType(val.ElementType, false)
-			if err != nil {
-				return nil, err
-			}
-			typeData["element_type"] = elemType
-		}
-
-	default:
-		return nil, fmt.Errorf("Unknown resource Type %T: %#v", fieldType, fieldType)
-	}
-
-	return []interface{}{typeData}, nil
-}
-
-func marshallTypeLocalizedEnum(values []platform.CustomFieldLocalizedEnumValue) []interface{} {
-	enumValues := make([]interface{}, len(values))
-	for i := range values {
-		enumValues[i] = map[string]interface{}{
-			"key":   values[i].Key,
-			"label": values[i].Label,
-		}
-	}
-	return enumValues
-}
+// import (
+// 	"context"
+// 	"fmt"
+// 	"log"
+// 	"reflect"
+// 	"time"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
+
+// func resourceType() *schema.Resource {
+// 	return &schema.Resource{
+// 		Description: "Types define custom fields that are used to enhance resources as you need. Use Types to model " +
+// 			"your own CustomFields on resources, like Category and Customer.\n\n" +
+// 			"In case you want to customize products, please use product types instead that serve a similar purpose, " +
+// 			"but tailored to products.\n\n" +
+// 			"See also the [Types Api Documentation](https://docs.commercetools.com/api/projects/types)",
+// 		Create: resourceTypeCreate,
+// 		Read:   resourceTypeRead,
+// 		Update: resourceTypeUpdate,
+// 		Delete: resourceTypeDelete,
+// 		Importer: &schema.ResourceImporter{
+// 			State: schema.ImportStatePassthrough,
+// 		},
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Description: "Identifier for the type (max. 256 characters)",
+// 				Type:        types.StringType,
+// 				Required:    true,
+// 			},
+// 			"name": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Required:    true,
+// 			},
+// 			"description": {
+// 				Description: "[LocalizedString](https://docs.commercetools.com/api/types#localizedstring)",
+// 				Type:        TypeLocalizedString,
+// 				Optional:    true,
+// 			},
+// 			"resource_type_ids": {
+// 				Description: "Defines for which [resources](https://docs.commercetools.com/api/projects/custom-fields#customizable-resources)" +
+// 					" the type is valid",
+// 				Type:     types.ListType{ElemType: types.StringType},
+// 				Required: true,
+// 				ForceNew: true,
+// 				Elem:     &schema.Schema{Type: types.StringType},
+// 			},
+// 			"field": {
+// 				Description: "[Field definition](https://docs.commercetools.com/api/projects/types#fielddefinition)",
+// 				Type:        types.ListType{ElemType: types.StringType},
+// 				Optional:    true,
+// 				Elem: &schema.Resource{
+// 					Schema: map[string]*schema.Schema{
+// 						"type": {
+// 							Description: "Describes the [type](https://docs.commercetools.com/api/projects/types#fieldtype)" +
+// 								" of the field",
+// 							Type:     types.ListType{ElemType: types.StringType},
+// 							MaxItems: 1,
+// 							Required: true,
+// 							Elem:     fieldTypeElement(true),
+// 						},
+// 						"name": {
+// 							Description: "The name of the field.\nThe name must be between two and 36 characters long " +
+// 								"and can contain the ASCII letters A to Z in lowercase or uppercase, digits, " +
+// 								"underscores (_) and the hyphen-minus (-).\nThe name must be unique for a given " +
+// 								"resource type ID. In case there is a field with the same name in another type it has " +
+// 								"to have the same FieldType also",
+// 							Type:     types.StringType,
+// 							Required: true,
+// 						},
+// 						"label": {
+// 							Description: "A human-readable label for the field",
+// 							Type:        TypeLocalizedString,
+// 							Required:    true,
+// 						},
+// 						"required": {
+// 							Description: "Whether the field is required to have a value",
+// 							Type:        types.BoolType,
+// 							Optional:    true,
+// 							Default:     false,
+// 						},
+// 						"input_hint": {
+// 							Description: "[TextInputHint](https://docs.commercetools.com/api/projects/types#textinputhint)" +
+// 								" Provides a visual representation type for this field. It is only relevant for " +
+// 								"string-based field types like StringType and LocalizedStringType",
+// 							Type:     types.StringType,
+// 							Optional: true,
+// 							Default:  platform.TextInputHintSingleLine,
+// 						},
+// 					},
+// 				},
+// 			},
+// 			"version": {
+// 				Type:     types.Int64Type,
+// 				Computed: true,
+// 			},
+// 		},
+// 		CustomizeDiff: customdiff.All(
+// 			customdiff.ValidateChange("field", func(ctx context.Context, old, new, meta interface{}) error {
+// 				log.Printf("[DEBUG] Start field validation")
+// 				oldLookup := createLookup(old.([]interface{}), "name")
+// 				newV := new.([]interface{})
+
+// 				for _, field := range newV {
+// 					newF := field.(map[string]interface{})
+// 					name := newF["name"].(string)
+// 					oldF, ok := oldLookup[name].(map[string]interface{})
+// 					if !ok {
+// 						// It means this is a new field, that's ok.
+// 						log.Printf("[DEBUG] Found new field: %s", name)
+// 						continue
+// 					}
+
+// 					log.Printf("[DEBUG] Checking %s", oldF["name"])
+// 					oldType := oldF["type"].([]interface{})[0].(map[string]interface{})
+// 					newType := newF["type"].([]interface{})[0].(map[string]interface{})
+
+// 					if oldType["name"] != newType["name"] {
+// 						if oldType["name"] != "" || newType["name"] == "" {
+// 							continue
+// 						}
+// 						return fmt.Errorf(
+// 							"Field '%s' type changed from %s to %s. Changing types is not supported; please remove the field first and re-define it later",
+// 							name, oldType["name"], newType["name"])
+// 					}
+
+// 					if oldF["required"] != newF["required"] {
+// 						return fmt.Errorf(
+// 							"Error on the '%s' attribute: Updating the 'required' attribute is not supported. Consider removing the attribute first and then re-adding it",
+// 							name)
+// 					}
+// 				}
+// 				return nil
+// 			}),
+// 		),
+// 	}
+// }
+
+// func localizedValueElement() *schema.Resource {
+// 	return &schema.Resource{
+// 		Schema: map[string]*schema.Schema{
+// 			"key": {
+// 				Type:     types.StringType,
+// 				Required: true,
+// 			},
+// 			"label": {
+// 				Type:     TypeLocalizedString,
+// 				Required: true,
+// 			},
+// 		},
+// 	}
+// }
+
+// func fieldTypeElement(setsAllowed bool) *schema.Resource {
+// 	result := map[string]*schema.Schema{
+// 		"name": {
+// 			Type:     types.StringType,
+// 			Required: true,
+// 			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+// 				v := val.(string)
+// 				if !setsAllowed && v == "Set" {
+// 					errs = append(errs, fmt.Errorf("Sets in another Set are not allowed"))
+// 				}
+// 				return
+// 			},
+// 		},
+// 		"values": {
+// 			Type:     schema.TypeMap,
+// 			Optional: true,
+// 		},
+// 		// Or, alternatively, we could go with the following
+// 		// to have it more consistent with localized_value.
+// 		// However, this is the difference between:
+// 		// |	values = {
+// 		// |		value1 = "Value 1"
+// 		// |		value2 = "Value 2"
+// 		// |	}
+// 		//  and
+// 		// |	value {
+// 		// |		key = "value1"
+// 		// |		label = "Value 1"
+// 		// |	}
+// 		// |	value {
+// 		// |		key = "value2"
+// 		// |		label = "Value 2"
+// 		// |	}
+// 		// "value": {
+// 		// 	Type:     schema.TypeSet,
+// 		// 	Optional: true,
+// 		// 	Elem: &schema.Resource{
+// 		// 		Schema: map[string]*schema.Schema{
+// 		// 			"key": {
+// 		// 				Type:     types.StringType,
+// 		// 				Required: true,
+// 		// 			},
+// 		// 			"label": {
+// 		// 				Type:     types.StringType,
+// 		// 				Required: true,
+// 		// 			},
+// 		// 		},
+// 		// 	},
+// 		// },
+// 		"localized_value": {
+// 			Type:     types.ListType{ElemType: types.StringType},
+// 			Optional: true,
+// 			Elem:     localizedValueElement(),
+// 		},
+// 		"reference_type_id": {
+// 			Type:     types.StringType,
+// 			Optional: true,
+// 		},
+// 	}
+
+// 	if setsAllowed {
+// 		result["element_type"] = &schema.Schema{
+// 			Type:     types.ListType{ElemType: types.StringType},
+// 			MaxItems: 1,
+// 			Optional: true,
+// 			Elem:     fieldTypeElement(false),
+// 		}
+// 	}
+
+// 	return &schema.Resource{Schema: result}
+// }
+
+// func resourceTypeCreate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	var ctType *platform.Type
+
+// 	name := platform.LocalizedString(
+// 		expandStringMap(d.Get("name").(map[string]interface{})))
+// 	description := platform.LocalizedString(
+// 		expandStringMap(d.Get("description").(map[string]interface{})))
+
+// 	resourceTypeIds := []platform.ResourceTypeId{}
+// 	for _, item := range expandStringArray(d.Get("resource_type_ids").([]interface{})) {
+// 		resourceTypeIds = append(resourceTypeIds, platform.ResourceTypeId(item))
+
+// 	}
+// 	fields, err := resourceTypeGetFieldDefinitions(d)
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	draft := platform.TypeDraft{
+// 		Key:              d.Get("key").(string),
+// 		Name:             name,
+// 		Description:      &description,
+// 		ResourceTypeIds:  resourceTypeIds,
+// 		FieldDefinitions: fields,
+// 	}
+
+// 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+// 		var err error
+
+// 		ctType, err = client.Types().Post(draft).Execute(context.Background())
+// 		if err != nil {
+// 			return handleCommercetoolsError(err)
+// 		}
+// 		return nil
+// 	})
+
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	if ctType == nil {
+// 		log.Fatal("No type created?")
+// 	}
+
+// 	d.SetId(ctType.ID)
+// 	d.Set("version", ctType.Version)
+
+// 	return resourceTypeRead(d, m)
+// }
+
+// func resourceTypeRead(d *schema.ResourceData, m interface{}) error {
+// 	log.Print("[DEBUG] Reading type from commercetools")
+// 	client := getClient(m)
+
+// 	ctType, err := client.Types().WithId(d.Id()).Get().Execute(context.Background())
+
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			if ctErr.StatusCode == 404 {
+// 				d.SetId("")
+// 				return nil
+// 			}
+// 		}
+// 		return err
+// 	}
+
+// 	if ctType == nil {
+// 		log.Print("[DEBUG] No type found")
+// 		d.SetId("")
+// 	} else {
+// 		log.Print("[DEBUG] Found following type:")
+// 		log.Print(stringFormatObject(ctType))
+
+// 		d.Set("version", ctType.Version)
+// 		d.Set("key", ctType.Key)
+// 		d.Set("name", ctType.Name)
+// 		if ctType.Description != nil {
+// 			d.Set("description", ctType.Description)
+// 		}
+// 		d.Set("resource_type_ids", ctType.ResourceTypeIds)
+
+// 		if fields, err := marshallTypeFields(ctType); err == nil {
+// 			d.Set("field", fields)
+// 		} else {
+// 			return err
+// 		}
+// 	}
+// 	return nil
+// }
+
+// func resourceTypeUpdate(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+
+// 	input := platform.TypeUpdate{
+// 		Version: d.Get("version").(int),
+// 		Actions: []platform.TypeUpdateAction{},
+// 	}
+
+// 	if d.HasChange("key") {
+// 		newKey := d.Get("key").(string)
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.TypeChangeKeyAction{Key: newKey})
+// 	}
+
+// 	if d.HasChange("name") {
+// 		newName := platform.LocalizedString(
+// 			expandStringMap(d.Get("name").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.TypeChangeNameAction{Name: newName})
+// 	}
+
+// 	if d.HasChange("description") {
+// 		newDescr := platform.LocalizedString(
+// 			expandStringMap(d.Get("description").(map[string]interface{})))
+// 		input.Actions = append(
+// 			input.Actions,
+// 			&platform.TypeSetDescriptionAction{
+// 				Description: &newDescr})
+// 	}
+
+// 	if d.HasChange("field") {
+// 		old, new := d.GetChange("field")
+// 		fieldChangeActions, err := resourceTypeFieldChangeActions(old.([]interface{}), new.([]interface{}))
+// 		if err != nil {
+// 			return err
+// 		}
+// 		input.Actions = append(input.Actions, fieldChangeActions...)
+// 	}
+// 	log.Printf(
+// 		"[DEBUG] Will perform update operation with the following actions:\n%s",
+// 		stringFormatActions(input.Actions))
+
+// 	_, err := client.Types().WithId(d.Id()).Post(input).Execute(context.Background())
+// 	if err != nil {
+// 		if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 			log.Printf("[DEBUG] %v: %v", ctErr, stringFormatErrorExtras(ctErr))
+// 		}
+// 		return err
+// 	}
+
+// 	return resourceTypeRead(d, m)
+// }
+
+// // Generate a list of actions needed for updating the fields value in
+// // commercetools so that it matches the terraform file
+// func resourceTypeFieldChangeActions(oldValues []interface{}, newValues []interface{}) ([]platform.TypeUpdateAction, error) {
+// 	oldLookup := createLookup(oldValues, "name")
+// 	newLookup := createLookup(newValues, "name")
+// 	actions := []platform.TypeUpdateAction{}
+// 	checkAttributeOrder := true
+
+// 	log.Printf("[DEBUG] Construction Field change actions")
+
+// 	// Check if we have fields which are removed
+// 	for name := range oldLookup {
+// 		if _, ok := newLookup[name]; !ok {
+// 			log.Printf("[DEBUG] Field deleted: %s", name)
+// 			actions = append(actions, platform.TypeRemoveFieldDefinitionAction{FieldName: name})
+// 			checkAttributeOrder = false
+// 		}
+// 	}
+
+// 	for _, value := range newValues {
+// 		newV := value.(map[string]interface{})
+// 		name := newV["name"].(string)
+// 		oldValue, existingField := oldLookup[name]
+
+// 		fieldDef, err := resourceTypeGetFieldDefinition(newV)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		// A new field is added. Create the update action skip the rest of the
+// 		// loop since there cannot be any change if the field didn't exist yet.
+// 		if !existingField {
+// 			log.Printf("[DEBUG] Field added: %s", name)
+// 			actions = append(
+// 				actions,
+// 				platform.TypeAddFieldDefinitionAction{FieldDefinition: *fieldDef})
+// 			checkAttributeOrder = false
+// 			continue
+// 		}
+
+// 		// Check if we need to update the field label
+// 		oldV := oldValue.(map[string]interface{})
+// 		if !reflect.DeepEqual(oldV["label"], newV["label"]) {
+// 			newLabel := platform.LocalizedString(
+// 				expandStringMap(newV["label"].(map[string]interface{})))
+// 			actions = append(
+// 				actions,
+// 				platform.TypeChangeLabelAction{FieldName: name, Label: newLabel})
+// 		}
+
+// 		// Update the input hint if this is changed
+// 		if !reflect.DeepEqual(oldV["input_hint"], newV["input_hint"]) {
+// 			var newInputHint platform.TypeTextInputHint
+// 			switch newV["input_hint"].(string) {
+// 			case "SingleLine":
+// 				newInputHint = platform.TypeTextInputHintSingleLine
+// 			case "MultiLine":
+// 				newInputHint = platform.TypeTextInputHintMultiLine
+// 			}
+
+// 			actions = append(
+// 				actions,
+// 				platform.TypeChangeInputHintAction{FieldName: name, InputHint: newInputHint})
+// 		}
+
+// 		newFieldType := fieldDef.Type
+// 		oldFieldType := oldV["type"].([]interface{})[0].(map[string]interface{})
+
+// 		if enumType, ok := newFieldType.(platform.CustomFieldSetType); ok {
+
+// 			myOldFieldType := oldFieldType["element_type"].([]interface{})[0].(map[string]interface{})
+// 			actions = resourceTypeHandleEnumTypeChanges(enumType.ElementType, myOldFieldType, actions, name)
+
+// 			log.Printf("[DEBUG] Set detected: %s", name)
+// 			log.Print(len(myOldFieldType))
+// 		}
+
+// 		actions = resourceTypeHandleEnumTypeChanges(newFieldType, oldFieldType, actions, name)
+// 	}
+
+// 	oldNames := make([]string, len(oldValues))
+// 	newNames := make([]string, len(newValues))
+
+// 	for i, value := range oldValues {
+// 		v := value.(map[string]interface{})
+// 		oldNames[i] = v["name"].(string)
+// 	}
+// 	for i, value := range newValues {
+// 		v := value.(map[string]interface{})
+// 		newNames[i] = v["name"].(string)
+// 	}
+
+// 	if checkAttributeOrder && !reflect.DeepEqual(oldNames, newNames) {
+// 		actions = append(
+// 			actions,
+// 			platform.TypeChangeFieldDefinitionOrderAction{
+// 				FieldNames: newNames,
+// 			})
+// 	}
+
+// 	return actions, nil
+// }
+
+// func resourceTypeHandleEnumTypeChanges(newFieldType platform.FieldType, oldFieldType map[string]interface{}, actions []platform.TypeUpdateAction, name string) []platform.TypeUpdateAction {
+// 	if enumType, ok := newFieldType.(platform.CustomFieldEnumType); ok {
+// 		oldEnumV := oldFieldType["values"].(map[string]interface{})
+
+// 		for i, enumValue := range enumType.Values {
+// 			if _, ok := oldEnumV[enumValue.Key]; !ok {
+// 				// Key does not appear in old enum values, so we'll add it
+// 				actions = append(
+// 					actions,
+// 					platform.TypeAddEnumValueAction{
+// 						FieldName: name,
+// 						Value:     enumType.Values[i],
+// 					})
+// 				continue
+// 			}
+
+// 			if oldEnumV[enumValue.Key].(string) != enumValue.Label {
+// 				//label for this key is changed
+// 				actions = append(
+// 					actions,
+// 					platform.TypeChangeEnumValueLabelAction{
+// 						FieldName: name,
+// 						Value:     enumType.Values[i],
+// 					})
+// 			}
+// 		}
+
+// 		// Action: changeEnumValueOrder
+// 		// TODO: Change the order of EnumValues: https://docs.commercetools.com/http-api-projects-types.html#change-the-order-of-fielddefinitions
+
+// 	} else if enumType, ok := newFieldType.(platform.CustomFieldLocalizedEnumType); ok {
+// 		oldEnumV := oldFieldType["localized_value"].([]interface{})
+// 		oldEnumKeys := make(map[string]map[string]interface{}, len(oldEnumV))
+
+// 		for _, value := range oldEnumV {
+// 			v := value.(map[string]interface{})
+// 			oldEnumKeys[v["key"].(string)] = v
+// 		}
+
+// 		for i, enumValue := range enumType.Values {
+// 			if _, ok := oldEnumKeys[enumValue.Key]; !ok {
+// 				// Key does not appear in old enum values, so we'll add it
+// 				actions = append(
+// 					actions,
+// 					platform.TypeAddLocalizedEnumValueAction{
+// 						FieldName: name,
+// 						Value:     enumType.Values[i],
+// 					})
+// 			}
+// 		}
+
+// 		// Action: changeLocalizedEnumValueOrder
+// 		// TODO: Change the order of LocalizedEnumValues: https://docs.commercetools.com/http-api-projects-types.html#change-the-order-of-localizedenumvalues
+// 	}
+// 	return actions
+// }
+
+// func resourceTypeDelete(d *schema.ResourceData, m interface{}) error {
+// 	client := getClient(m)
+// 	version := d.Get("version").(int)
+// 	_, err := client.Types().WithId(d.Id()).Delete().WithQueryParams(platform.ByProjectKeyTypesByIDRequestMethodDeleteInput{
+// 		Version: version,
+// 	}).Execute(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	return nil
+// }
+
+// func resourceTypeGetFieldDefinitions(d *schema.ResourceData) ([]platform.FieldDefinition, error) {
+// 	input := d.Get("field").([]interface{})
+// 	var result []platform.FieldDefinition
+
+// 	for _, raw := range input {
+// 		fieldDef, err := resourceTypeGetFieldDefinition(raw.(map[string]interface{}))
+
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		result = append(result, *fieldDef)
+// 	}
+
+// 	return result, nil
+// }
+
+// func resourceTypeGetFieldDefinition(input map[string]interface{}) (*platform.FieldDefinition, error) {
+// 	fieldTypes := input["type"].([]interface{})
+// 	fieldType, err := getFieldType(fieldTypes[0])
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	label := platform.LocalizedString(
+// 		expandStringMap(input["label"].(map[string]interface{})))
+
+// 	inputHint := platform.TypeTextInputHint(input["input_hint"].(string))
+// 	return &platform.FieldDefinition{
+// 		Type:      fieldType,
+// 		Name:      input["name"].(string),
+// 		Label:     label,
+// 		Required:  input["required"].(bool),
+// 		InputHint: &inputHint,
+// 	}, nil
+// }
+
+// func getFieldType(input interface{}) (platform.FieldType, error) {
+// 	config := input.(map[string]interface{})
+// 	typeName, ok := config["name"].(string)
+
+// 	if !ok {
+// 		return nil, fmt.Errorf("No 'name' for type object given")
+// 	}
+
+// 	switch typeName {
+// 	case "Boolean":
+// 		return platform.CustomFieldBooleanType{}, nil
+// 	case "String":
+// 		return platform.CustomFieldStringType{}, nil
+// 	case "LocalizedString":
+// 		return platform.CustomFieldLocalizedStringType{}, nil
+// 	case "Enum":
+// 		valuesInput, valuesOk := config["values"].(map[string]interface{})
+// 		if !valuesOk {
+// 			return nil, fmt.Errorf("No values specified for Enum type: %+v", valuesInput)
+// 		}
+// 		var values []platform.CustomFieldEnumValue
+// 		for k, v := range valuesInput {
+// 			values = append(values, platform.CustomFieldEnumValue{
+// 				Key:   k,
+// 				Label: v.(string),
+// 			})
+// 		}
+// 		return platform.CustomFieldEnumType{Values: values}, nil
+// 	case "LocalizedEnum":
+// 		valuesInput, valuesOk := config["localized_value"]
+// 		if !valuesOk {
+// 			return nil, fmt.Errorf("No localized_value elements specified for LocalizedEnum type")
+// 		}
+// 		var values []platform.CustomFieldLocalizedEnumValue
+// 		for _, value := range valuesInput.([]interface{}) {
+// 			v := value.(map[string]interface{})
+// 			labels := platform.LocalizedString(
+// 				expandStringMap(v["label"].(map[string]interface{})))
+// 			values = append(values, platform.CustomFieldLocalizedEnumValue{
+// 				Key:   v["key"].(string),
+// 				Label: labels,
+// 			})
+// 		}
+// 		return platform.CustomFieldLocalizedEnumType{Values: values}, nil
+// 	case "Number":
+// 		return platform.CustomFieldNumberType{}, nil
+// 	case "Money":
+// 		return platform.CustomFieldMoneyType{}, nil
+// 	case "Date":
+// 		return platform.CustomFieldDateType{}, nil
+// 	case "Time":
+// 		return platform.CustomFieldTimeType{}, nil
+// 	case "DateTime":
+// 		return platform.CustomFieldDateTimeType{}, nil
+// 	case "Reference":
+// 		refTypeID, refTypeIDOk := config["reference_type_id"].(string)
+// 		if !refTypeIDOk {
+// 			return nil, fmt.Errorf("No reference_type_id specified for Reference type")
+// 		}
+// 		return platform.CustomFieldReferenceType{
+// 			ReferenceTypeId: platform.ReferenceTypeId(refTypeID),
+// 		}, nil
+// 	case "Set":
+// 		elementTypes, elementTypesOk := config["element_type"]
+// 		if !elementTypesOk {
+// 			return nil, fmt.Errorf("No element_type specified for Set type")
+// 		}
+// 		elementTypeList := elementTypes.([]interface{})
+// 		if len(elementTypeList) == 0 {
+// 			return nil, fmt.Errorf("No element_type specified for Set type")
+// 		}
+
+// 		setFieldType, err := getFieldType(elementTypeList[0])
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		return platform.CustomFieldSetType{
+// 			ElementType: setFieldType,
+// 		}, nil
+// 	}
+
+// 	return nil, fmt.Errorf("Unknown FieldType %s", typeName)
+// }
+
+// func marshallTypeFields(t *platform.Type) ([]map[string]interface{}, error) {
+// 	fields := make([]map[string]interface{}, len(t.FieldDefinitions))
+// 	for i, fieldDef := range t.FieldDefinitions {
+// 		fieldData := make(map[string]interface{})
+// 		log.Printf("[DEBUG] reading field: %s: %#v", fieldDef.Name, fieldDef)
+// 		fieldType, err := marshallTypeFieldType(fieldDef.Type, true)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		fieldData["type"] = fieldType
+// 		fieldData["name"] = fieldDef.Name
+// 		if fieldDef.Label != nil {
+// 			fieldData["label"] = fieldDef.Label
+// 		} else {
+// 			fieldData["label"] = nil
+// 		}
+// 		fieldData["required"] = fieldDef.Required
+// 		fieldData["input_hint"] = fieldDef.InputHint
+
+// 		fields[i] = fieldData
+// 	}
+// 	return fields, nil
+// }
+
+// func marshallTypeFieldType(fieldType platform.FieldType, setsAllowed bool) ([]interface{}, error) {
+// 	typeData := make(map[string]interface{})
+
+// 	switch val := fieldType.(type) {
+
+// 	case platform.CustomFieldBooleanType:
+// 		typeData["name"] = "Boolean"
+
+// 	case platform.CustomFieldStringType:
+// 		typeData["name"] = "String"
+
+// 	case platform.CustomFieldLocalizedStringType:
+// 		typeData["name"] = "LocalizedString"
+
+// 	case platform.CustomFieldEnumType:
+// 		enumValues := make(map[string]interface{}, len(val.Values))
+// 		for _, value := range val.Values {
+// 			enumValues[value.Key] = value.Label
+// 		}
+// 		typeData["name"] = "Enum"
+// 		typeData["values"] = enumValues
+
+// 	case platform.CustomFieldLocalizedEnumType:
+// 		typeData["name"] = "LocalizedEnum"
+// 		typeData["localized_value"] = marshallTypeLocalizedEnum(val.Values)
+
+// 	case platform.CustomFieldNumberType:
+// 		typeData["name"] = "Number"
+
+// 	case platform.CustomFieldMoneyType:
+// 		typeData["name"] = "Money"
+
+// 	case platform.CustomFieldDateType:
+// 		typeData["name"] = "Date"
+
+// 	case platform.CustomFieldTimeType:
+// 		typeData["name"] = "Time"
+
+// 	case platform.CustomFieldDateTimeType:
+// 		typeData["name"] = "DateTime"
+
+// 	case platform.CustomFieldReferenceType:
+// 		typeData["name"] = "Reference"
+// 		typeData["reference_type_id"] = val.ReferenceTypeId
+
+// 	case platform.CustomFieldSetType:
+// 		typeData["name"] = "Set"
+// 		if setsAllowed {
+// 			elemType, err := marshallTypeFieldType(val.ElementType, false)
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			typeData["element_type"] = elemType
+// 		}
+
+// 	default:
+// 		return nil, fmt.Errorf("Unknown resource Type %T: %#v", fieldType, fieldType)
+// 	}
+
+// 	return []interface{}{typeData}, nil
+// }
+
+// func marshallTypeLocalizedEnum(values []platform.CustomFieldLocalizedEnumValue) []interface{} {
+// 	enumValues := make([]interface{}, len(values))
+// 	for i, value := range values {
+// 		enumValues[i] = map[string]interface{}{
+// 			"key":   value.Key,
+// 			"label": value.Label,
+// 		}
+// 	}
+// 	return enumValues
+// }

--- a/commercetools/resource_type_test.go
+++ b/commercetools/resource_type_test.go
@@ -1,398 +1,398 @@
 package commercetools
 
-import (
-	"bytes"
-	"context"
-	"fmt"
-	"testing"
+// import (
+// 	"bytes"
+// 	"context"
+// 	"fmt"
+// 	"testing"
 
-	"github.com/labd/commercetools-go-sdk/platform"
-	"github.com/stretchr/testify/assert"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// 	"github.com/stretchr/testify/assert"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-)
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+// )
 
-func TestFieldTypeElement(t *testing.T) {
-	elem := fieldTypeElement(true)
-	elemType, ok := elem.Schema["element_type"]
+// func TestFieldTypeElement(t *testing.T) {
+// 	elem := fieldTypeElement(true)
+// 	elemType, ok := elem.Schema["element_type"]
 
-	if !ok {
-		t.Error("element_type does not appear in the Schema")
-	}
+// 	if !ok {
+// 		t.Error("element_type does not appear in the Schema")
+// 	}
 
-	elemTypeResource := elemType.Elem.(*schema.Resource)
+// 	elemTypeResource := elemType.Elem.(*schema.Resource)
 
-	// The element_type itself may not contain an 'element_type'.
-	// This is because we don't allow infinite nested 'Set' elements
-	if _, ok := elemTypeResource.Schema["name"]; !ok {
-		t.Error("element_type Schema does not contain 'name' field")
-	}
-	if _, ok := elemTypeResource.Schema["element_type"]; ok {
-		t.Error("element_type Sxhema should not include another 'element_type' field")
-	}
-}
+// 	// The element_type itself may not contain an 'element_type'.
+// 	// This is because we don't allow infinite nested 'Set' elements
+// 	if _, ok := elemTypeResource.Schema["name"]; !ok {
+// 		t.Error("element_type Schema does not contain 'name' field")
+// 	}
+// 	if _, ok := elemTypeResource.Schema["element_type"]; ok {
+// 		t.Error("element_type Sxhema should not include another 'element_type' field")
+// 	}
+// }
 
-func TestResourceTypeGetFieldDefinition(t *testing.T) {
-	input := map[string]interface{}{
-		"name": "test",
-		"label": map[string]interface{}{
-			"en": "Test",
-			"nl": "Test",
-		},
-		"type": []interface{}{
-			map[string]interface{}{
-				"name": "String",
-			},
-		},
-		"required":   false,
-		"input_hint": "SingleLine",
-	}
+// func TestResourceTypeGetFieldDefinition(t *testing.T) {
+// 	input := map[string]interface{}{
+// 		"name": "test",
+// 		"label": map[string]interface{}{
+// 			"en": "Test",
+// 			"nl": "Test",
+// 		},
+// 		"type": []interface{}{
+// 			map[string]interface{}{
+// 				"name": "String",
+// 			},
+// 		},
+// 		"required":   false,
+// 		"input_hint": "SingleLine",
+// 	}
 
-	_, err := resourceTypeGetFieldDefinition(input)
-	if err != nil {
-		t.Error("Got an unexpected error")
-	}
-}
+// 	_, err := resourceTypeGetFieldDefinition(input)
+// 	if err != nil {
+// 		t.Error("Got an unexpected error")
+// 	}
+// }
 
-func TestGetFieldType(t *testing.T) {
-	// Test Boolean
-	input := map[string]interface{}{
-		"name": "Boolean",
-	}
-	result, err := getFieldType(input)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if _, ok := result.(platform.CustomFieldBooleanType); !ok {
-		t.Error("Expected Boolean type")
-	}
+// func TestGetFieldType(t *testing.T) {
+// 	// Test Boolean
+// 	input := map[string]interface{}{
+// 		"name": "Boolean",
+// 	}
+// 	result, err := getFieldType(input)
+// 	if err != nil {
+// 		t.Errorf("Unexpected error: %s", err)
+// 	}
+// 	if _, ok := result.(platform.CustomFieldBooleanType); !ok {
+// 		t.Error("Expected Boolean type")
+// 	}
 
-	// Test Enum
-	input = map[string]interface{}{
-		"name": "Enum",
-	}
-	_, err = getFieldType(input)
-	if err == nil {
-		t.Error("No error returned while Enum requires values")
-	}
-	input = map[string]interface{}{
-		"name": "Enum",
-		"values": map[string]interface{}{
-			"value1": "Value 1",
-			"value2": "Value 2",
-		},
-	}
-	result, err = getFieldType(input)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if field, ok := result.(platform.CustomFieldEnumType); ok {
-		assert.ElementsMatch(t, field.Values, []platform.CustomFieldEnumValue{
-			{Key: "value1", Label: "Value 1"},
-			{Key: "value2", Label: "Value 2"},
-		})
-	} else {
-		t.Error("Expected Enum type")
-	}
+// 	// Test Enum
+// 	input = map[string]interface{}{
+// 		"name": "Enum",
+// 	}
+// 	_, err = getFieldType(input)
+// 	if err == nil {
+// 		t.Error("No error returned while Enum requires values")
+// 	}
+// 	input = map[string]interface{}{
+// 		"name": "Enum",
+// 		"values": map[string]interface{}{
+// 			"value1": "Value 1",
+// 			"value2": "Value 2",
+// 		},
+// 	}
+// 	result, err = getFieldType(input)
+// 	if err != nil {
+// 		t.Errorf("Unexpected error: %s", err)
+// 	}
+// 	if field, ok := result.(platform.CustomFieldEnumType); ok {
+// 		assert.ElementsMatch(t, field.Values, []platform.CustomFieldEnumValue{
+// 			{Key: "value1", Label: "Value 1"},
+// 			{Key: "value2", Label: "Value 2"},
+// 		})
+// 	} else {
+// 		t.Error("Expected Enum type")
+// 	}
 
-	// Test Reference
-	input = map[string]interface{}{
-		"name": "Reference",
-	}
-	_, err = getFieldType(input)
-	if err == nil {
-		t.Error("No error returned while Reference requires reference_type_id")
-	}
-	input = map[string]interface{}{
-		"name":              "Reference",
-		"reference_type_id": "product",
-	}
-	result, err = getFieldType(input)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if field, ok := result.(platform.CustomFieldReferenceType); ok {
-		assert.EqualValues(t, field.ReferenceTypeId, "product")
-	} else {
-		t.Error("Expected Reference type")
-	}
+// 	// Test Reference
+// 	input = map[string]interface{}{
+// 		"name": "Reference",
+// 	}
+// 	_, err = getFieldType(input)
+// 	if err == nil {
+// 		t.Error("No error returned while Reference requires reference_type_id")
+// 	}
+// 	input = map[string]interface{}{
+// 		"name":              "Reference",
+// 		"reference_type_id": "product",
+// 	}
+// 	result, err = getFieldType(input)
+// 	if err != nil {
+// 		t.Errorf("Unexpected error: %s", err)
+// 	}
+// 	if field, ok := result.(platform.CustomFieldReferenceType); ok {
+// 		assert.EqualValues(t, field.ReferenceTypeId, "product")
+// 	} else {
+// 		t.Error("Expected Reference type")
+// 	}
 
-	// Test Set
-	input = map[string]interface{}{
-		"name": "Set",
-	}
-	_, err = getFieldType(input)
-	if err == nil {
-		t.Error("No error returned while Set requires element_type")
-	}
-}
+// 	// Test Set
+// 	input = map[string]interface{}{
+// 		"name": "Set",
+// 	}
+// 	_, err = getFieldType(input)
+// 	if err == nil {
+// 		t.Error("No error returned while Set requires element_type")
+// 	}
+// }
 
-func TestAccTypes_basic(t *testing.T) {
-	name := "acctest_type"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTypesDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTypeConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccTypeExists("acctest_type"),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "key", name),
-				),
-			},
-		},
-	})
-}
+// func TestAccTypes_basic(t *testing.T) {
+// 	name := "acctest_type"
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckTypesDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccTypeConfig(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccTypeExists("acctest_type"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "key", name),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func TestAccTypes_UpdateWithID(t *testing.T) {
-	name := "acctest_type"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTypesDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTypeConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccTypeExists("acctest_type"),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "key", name),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.1.name", "existing_enum"),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.1.type.0.element_type.0.values.%", "2"),
-				),
-			},
-			{
-				Config: testAccTypeUpdateWithID(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccTypeExists("acctest_type"),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "key", name),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.#", "11"),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.1.name", "existing_enum"),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.1.type.0.element_type.0.values.%", "3"),
-					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.1.type.0.element_type.0.values.evening", "Evening Changed"),
-				),
-			},
-		},
-	})
-}
+// func TestAccTypes_UpdateWithID(t *testing.T) {
+// 	name := "acctest_type"
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:     func() { testAccPreCheck(t) },
+// 		Providers:    testAccProviders,
+// 		CheckDestroy: testAccCheckTypesDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccTypeConfig(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccTypeExists("acctest_type"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "key", name),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "field.1.name", "existing_enum"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "field.1.type.0.element_type.0.values.%", "2"),
+// 				),
+// 			},
+// 			{
+// 				Config: testAccTypeUpdateWithID(name),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					testAccTypeExists("acctest_type"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "key", name),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "field.#", "11"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "field.1.name", "existing_enum"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "field.1.type.0.element_type.0.values.%", "3"),
+// 					resource.TestCheckResourceAttr(
+// 						"commercetools_type.acctest_type", "field.1.type.0.element_type.0.values.evening", "Evening Changed"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
 
-func testAccTypeConfig(name string) string {
-	return fmt.Sprintf(`
-resource "commercetools_type" "%s" {
-	key = "%s"
-	name = {
-		en = "Contact info"
-		nl = "Contact informatie"
-	}
-	description = {
-		en = "All things related communication"
-		nl = "Alle communicatie-gerelateerde zaken"
-	}
+// func testAccTypeConfig(name string) string {
+// 	return fmt.Sprintf(`
+// resource "commercetools_type" "%s" {
+// 	key = "%s"
+// 	name = {
+// 		en = "Contact info"
+// 		nl = "Contact informatie"
+// 	}
+// 	description = {
+// 		en = "All things related communication"
+// 		nl = "Alle communicatie-gerelateerde zaken"
+// 	}
 
-	resource_type_ids = ["customer"]
+// 	resource_type_ids = ["customer"]
 
-	field {
-		name = "skype_name"
-		label = {
-			en = "Skype name"
-			nl = "Skype naam"
-		}
-		type {
-			name = "String"
-		}
-	}
+// 	field {
+// 		name = "skype_name"
+// 		label = {
+// 			en = "Skype name"
+// 			nl = "Skype naam"
+// 		}
+// 		type {
+// 			name = "String"
+// 		}
+// 	}
 
-	field {
-		name = "existing_enum"
-		label = {
-			en = "existing enum"
-			de = "existierendes enum"
-		}
-		type {
-			name = "Set"
-			element_type {
-				name = "Enum"
-				values = {
-					day = "Daytime"
-					evening = "Evening"
-				}
-			}
-		}
-	}
+// 	field {
+// 		name = "existing_enum"
+// 		label = {
+// 			en = "existing enum"
+// 			de = "existierendes enum"
+// 		}
+// 		type {
+// 			name = "Set"
+// 			element_type {
+// 				name = "Enum"
+// 				values = {
+// 					day = "Daytime"
+// 					evening = "Evening"
+// 				}
+// 			}
+// 		}
+// 	}
 
-}`, name, name)
-}
+// }`, name, name)
+// }
 
-func testAccTypeUpdateWithID(name string) string {
-	newFields := []string{
-		"Boolean",
-		"LocalizedString",
-		"Number",
-		"Money",
-		"Date",
-		"Time",
-		"DateTime",
-	}
-	var newFieldsBuffer bytes.Buffer
-	for _, newType := range newFields {
-		newFieldsBuffer.WriteString(
-			fmt.Sprintf(`
-		field {
-			name = "%[1]s"
-			label = {
-				en = "%[1]s"
-				nl = "%[1]s"
-			}
+// func testAccTypeUpdateWithID(name string) string {
+// 	newFields := []string{
+// 		"Boolean",
+// 		"LocalizedString",
+// 		"Number",
+// 		"Money",
+// 		"Date",
+// 		"Time",
+// 		"DateTime",
+// 	}
+// 	var newFieldsBuffer bytes.Buffer
+// 	for _, newType := range newFields {
+// 		newFieldsBuffer.WriteString(
+// 			fmt.Sprintf(`
+// 		field {
+// 			name = "%[1]s"
+// 			label = {
+// 				en = "%[1]s"
+// 				nl = "%[1]s"
+// 			}
 
-			type {
-				name = "%[1]s"
-			}
-		}
-		`, newType))
-	}
+// 			type {
+// 				name = "%[1]s"
+// 			}
+// 		}
+// 		`, newType))
+// 	}
 
-	return fmt.Sprintf(`
-resource "commercetools_type" "%s" {
-	key = "%s"
-	name = {
-		en = "Contact info"
-		nl = "Contact informatie"
-	}
-	description = {
-		en = "All things related communication"
-		nl = "Alle communicatie-gerelateerde zaken"
-	}
+// 	return fmt.Sprintf(`
+// resource "commercetools_type" "%s" {
+// 	key = "%s"
+// 	name = {
+// 		en = "Contact info"
+// 		nl = "Contact informatie"
+// 	}
+// 	description = {
+// 		en = "All things related communication"
+// 		nl = "Alle communicatie-gerelateerde zaken"
+// 	}
 
-	resource_type_ids = ["customer"]
+// 	resource_type_ids = ["customer"]
 
-	field {
-		name = "skype_name"
-		label = {
-			en = "Skype name"
-			nl = "Skype naam"
-		}
-		type {
-			name = "String"
-		}
-	}
+// 	field {
+// 		name = "skype_name"
+// 		label = {
+// 			en = "Skype name"
+// 			nl = "Skype naam"
+// 		}
+// 		type {
+// 			name = "String"
+// 		}
+// 	}
 
-	field {
-		name = "new_enum"
-		label = {
-			en = "new enum"
-			nl = "nieuwe enum"
-		}
-		type {
-			name = "Enum"
-			values = {
-				day = "Daytime"
-				evening = "Evening"
-			}
-		}
-	}
+// 	field {
+// 		name = "new_enum"
+// 		label = {
+// 			en = "new enum"
+// 			nl = "nieuwe enum"
+// 		}
+// 		type {
+// 			name = "Enum"
+// 			values = {
+// 				day = "Daytime"
+// 				evening = "Evening"
+// 			}
+// 		}
+// 	}
 
-	field {
-		name = "existing_enum"
-		label = {
-			en = "existing enum"
-			de = "existierendes enum"
-		}
-		type {
-			name = "Set"
-			element_type {
-				name = "Enum"
-				values = {
-					day = "Daytime"
-					evening = "Evening Changed"
-					later   = "later"
-				}
-			}
-		}
-	}
+// 	field {
+// 		name = "existing_enum"
+// 		label = {
+// 			en = "existing enum"
+// 			de = "existierendes enum"
+// 		}
+// 		type {
+// 			name = "Set"
+// 			element_type {
+// 				name = "Enum"
+// 				values = {
+// 					day = "Daytime"
+// 					evening = "Evening Changed"
+// 					later   = "later"
+// 				}
+// 			}
+// 		}
+// 	}
 
-	field {
-		name = "new_localized_enum"
-		input_hint = "MultiLine"
-		label = {
-			en = "New localized enum"
-			nl = "Nieuwe localized enum"
-		}
-		type {
-			name = "LocalizedEnum"
-			localized_value {
-				key = "phone"
-				label = {
-					en = "Phone"
-					nl = "Telefoon"
-				}
-			}
-			localized_value {
-				key = "skype"
-				label = {
-					en = "Skype"
-					nl = "Skype"
-				}
-			}
-		}
-	}
+// 	field {
+// 		name = "new_localized_enum"
+// 		input_hint = "MultiLine"
+// 		label = {
+// 			en = "New localized enum"
+// 			nl = "Nieuwe localized enum"
+// 		}
+// 		type {
+// 			name = "LocalizedEnum"
+// 			localized_value {
+// 				key = "phone"
+// 				label = {
+// 					en = "Phone"
+// 					nl = "Telefoon"
+// 				}
+// 			}
+// 			localized_value {
+// 				key = "skype"
+// 				label = {
+// 					en = "Skype"
+// 					nl = "Skype"
+// 				}
+// 			}
+// 		}
+// 	}
 
-	%s
-}`, name, name, newFieldsBuffer.String())
-}
+// 	%s
+// }`, name, name, newFieldsBuffer.String())
+// }
 
-func testAccTypeExists(n string) resource.TestCheckFunc {
-	name := fmt.Sprintf("commercetools_type.%s", n)
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
+// func testAccTypeExists(n string) resource.TestCheckFunc {
+// 	name := fmt.Sprintf("commercetools_type.%s", n)
+// 	return func(s *terraform.State) error {
+// 		rs, ok := s.RootModule().Resources[name]
+// 		if !ok {
+// 			return fmt.Errorf("Not found: %s", name)
+// 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Type ID is set")
-		}
+// 		if rs.Primary.ID == "" {
+// 			return fmt.Errorf("No Type ID is set")
+// 		}
 
-		client := getClient(testAccProvider.Meta())
-		result, err := client.Types().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err != nil {
-			return err
-		}
-		if result == nil {
-			return fmt.Errorf("Type not found")
-		}
+// 		client := getClient(testAccProvider.Meta())
+// 		result, err := client.Types().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err != nil {
+// 			return err
+// 		}
+// 		if result == nil {
+// 			return fmt.Errorf("Type not found")
+// 		}
 
-		return nil
-	}
-}
+// 		return nil
+// 	}
+// }
 
-func testAccCheckTypesDestroy(s *terraform.State) error {
-	client := getClient(testAccProvider.Meta())
+// func testAccCheckTypesDestroy(s *terraform.State) error {
+// 	client := getClient(testAccProvider.Meta())
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "commercetools_type" {
-			continue
-		}
-		response, err := client.Types().WithId(rs.Primary.ID).Get().Execute(context.Background())
-		if err == nil {
-			if response != nil && response.ID == rs.Primary.ID {
-				return fmt.Errorf("type (%s) still exists", rs.Primary.ID)
-			}
-			return nil
-		}
-		if newErr := checkApiResult(err); newErr != nil {
-			return newErr
-		}
-	}
-	return nil
-}
+// 	for _, rs := range s.RootModule().Resources {
+// 		if rs.Type != "commercetools_type" {
+// 			continue
+// 		}
+// 		response, err := client.Types().WithId(rs.Primary.ID).Get().Execute(context.Background())
+// 		if err == nil {
+// 			if response != nil && response.ID == rs.Primary.ID {
+// 				return fmt.Errorf("type (%s) still exists", rs.Primary.ID)
+// 			}
+// 			return nil
+// 		}
+// 		if newErr := checkApiResult(err); newErr != nil {
+// 			return newErr
+// 		}
+// 	}
+// 	return nil
+// }

--- a/commercetools/resource_type_test.go
+++ b/commercetools/resource_type_test.go
@@ -176,11 +176,11 @@ func TestAccTypes_UpdateWithID(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_type.acctest_type", "field.#", "11"),
 					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.2.name", "existing_enum"),
+						"commercetools_type.acctest_type", "field.1.name", "existing_enum"),
 					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.2.type.0.element_type.0.values.%", "3"),
+						"commercetools_type.acctest_type", "field.1.type.0.element_type.0.values.%", "3"),
 					resource.TestCheckResourceAttr(
-						"commercetools_type.acctest_type", "field.2.type.0.element_type.0.values.evening", "Evening Changed"),
+						"commercetools_type.acctest_type", "field.1.type.0.element_type.0.values.evening", "Evening Changed"),
 				),
 			},
 		},

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -1,10 +1,12 @@
 package commercetools
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // import (
@@ -26,10 +28,40 @@ func TypeLocalizedString() types.MapType {
 	return types.MapType{ElemType: types.StringType}
 }
 
-func transformStringSlice(v []string) []types.String {
+func marshallStringSlice(v []string) []types.String {
 	result := make([]types.String, len(v))
 	for idx := range v {
 		result[idx] = types.String{Value: v[idx]}
+	}
+	return result
+}
+
+func unmarshallStringSlice(v []types.String) []string {
+	result := make([]string, len(v))
+	for idx := range v {
+		result[idx] = v[idx].Value
+	}
+	return result
+}
+
+func marshallStringMap(v map[string]string) types.Map {
+	result := types.Map{ElemType: types.StringType}
+	for idx := range v {
+		result.Elems[idx] = types.String{Value: v[idx]}
+	}
+	return result
+}
+
+func unmarshallStringMap(v types.Map) map[string]string {
+	result := map[string]string{}
+
+	data, err := v.ToTerraformValue(context.Background())
+	if err != nil {
+		panic(err)
+	}
+
+	for idx, val := range data.(map[string]tftypes.Value) {
+		result[idx] = val.String()
 	}
 	return result
 }

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -3,81 +3,98 @@ package commercetools
 import (
 	"encoding/json"
 	"fmt"
-	"log"
-	"strings"
-	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/labd/commercetools-go-sdk/platform"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// import (
+// 	"encoding/json"
+// 	"fmt"
+// 	"log"
+// 	"strings"
+// 	"time"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
 // TypeLocalizedString defined merely for documentation,
 // it basically is just a normal TypeMap but clearifies in the code that
 // it should be used to store a LocalizedString
-const TypeLocalizedString = schema.TypeMap
-
-func getClient(m interface{}) *platform.ByProjectKeyRequestBuilder {
-	client := m.(*platform.ByProjectKeyRequestBuilder)
-	return client
+func TypeLocalizedString() types.MapType {
+	return types.MapType{ElemType: types.StringType}
 }
 
-func stringRef(value interface{}) *string {
-	result := value.(string)
-	return &result
-}
-
-func intRef(value interface{}) *int {
-	result := value.(int)
-	return &result
-}
-
-func boolRef(value interface{}) *bool {
-	result := value.(bool)
-	return &result
-}
-
-func handleCommercetoolsError(err error) *resource.RetryError {
-	if ctErr, ok := err.(platform.ErrorResponse); ok {
-		return resource.NonRetryableError(ctErr)
-	}
-
-	log.Printf("[DEBUG] Received error: %s", err)
-	return resource.RetryableError(err)
-}
-
-func expandStringArray(input []interface{}) []string {
-	s := make([]string, len(input))
-	for i, v := range input {
-		s[i] = fmt.Sprint(v)
-	}
-	return s
-}
-
-func expandStringMap(input map[string]interface{}) map[string]string {
-	s := make(map[string]string)
-	for k, v := range input {
-		s[k] = fmt.Sprint(v)
-	}
-	return s
-}
-
-func localizedStringCompare(a platform.LocalizedString, b map[string]interface{}) bool {
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func localizedStringToMap(input platform.LocalizedString) map[string]string {
-	result := make(map[string]string, len(input))
-	for k, v := range input {
-		result[k] = v
+func transformStringSlice(v []string) []types.String {
+	result := make([]types.String, len(v))
+	for idx := range v {
+		result[idx] = types.String{Value: v[idx]}
 	}
 	return result
 }
+
+// func getClient(m interface{}) *platform.ByProjectKeyRequestBuilder {
+// 	client := m.(*platform.ByProjectKeyRequestBuilder)
+// 	return client
+// }
+
+// func stringRef(value interface{}) *string {
+// 	result := value.(string)
+// 	return &result
+// }
+
+// func intRef(value interface{}) *int {
+// 	result := value.(int)
+// 	return &result
+// }
+
+// func boolRef(value interface{}) *bool {
+// 	result := value.(bool)
+// 	return &result
+// }
+
+// func handleCommercetoolsError(err error) *resource.RetryError {
+// 	if ctErr, ok := err.(platform.ErrorResponse); ok {
+// 		return resource.NonRetryableError(ctErr)
+// 	}
+
+// 	log.Printf("[DEBUG] Received error: %s", err)
+// 	return resource.RetryableError(err)
+// }
+
+// func expandStringArray(input []interface{}) []string {
+// 	s := make([]string, len(input))
+// 	for i, v := range input {
+// 		s[i] = fmt.Sprint(v)
+// 	}
+// 	return s
+// }
+
+// func expandStringMap(input map[string]interface{}) map[string]string {
+// 	s := make(map[string]string)
+// 	for k, v := range input {
+// 		s[k] = fmt.Sprint(v)
+// 	}
+// 	return s
+// }
+
+// func localizedStringCompare(a platform.LocalizedString, b map[string]interface{}) bool {
+// 	for i, v := range a {
+// 		if v != b[i] {
+// 			return false
+// 		}
+// 	}
+// 	return true
+// }
+
+// func localizedStringToMap(input platform.LocalizedString) map[string]string {
+// 	result := make(map[string]string, len(input))
+// 	for k, v := range input {
+// 		result[k] = v
+// 	}
+// 	return result
+// }
 
 func stringFormatObject(object interface{}) string {
 	data, err := json.MarshalIndent(object, "", "    ")
@@ -88,287 +105,287 @@ func stringFormatObject(object interface{}) string {
 	return string(append(data, '\n'))
 }
 
-func stringFormatErrorExtras(err platform.ErrorResponse) string {
-	switch len(err.Errors) {
-	case 0:
-		return ""
-	case 1:
-		return "temp" // stringFormatObject(err.Errors[0].Error())
-	default:
-		{
-			messages := make([]string, len(err.Errors))
-			for i, item := range err.Errors {
-				messages[i] = fmt.Sprintf("%v", item)
-				//messages[i] = fmt.Sprintf(" %d. %s", i+1, stringFormatObject(item.Extra()))
-			}
-			return strings.Join(messages, "\n")
-		}
-	}
-}
+// func stringFormatErrorExtras(err platform.ErrorResponse) string {
+// 	switch len(err.Errors) {
+// 	case 0:
+// 		return ""
+// 	case 1:
+// 		return "temp" // stringFormatObject(err.Errors[0].Error())
+// 	default:
+// 		{
+// 			messages := make([]string, len(err.Errors))
+// 			for i, item := range err.Errors {
+// 				messages[i] = fmt.Sprintf("%v", item)
+// 				//messages[i] = fmt.Sprintf(" %d. %s", i+1, stringFormatObject(item.Extra()))
+// 			}
+// 			return strings.Join(messages, "\n")
+// 		}
+// 	}
+// }
 
-func stringFormatActions(actions ...interface{}) string {
-	lines := []string{}
-	for i, action := range actions {
-		lines = append(
-			lines,
-			fmt.Sprintf("%d: %s", i, stringFormatObject(action)))
+// func stringFormatActions(actions ...interface{}) string {
+// 	lines := []string{}
+// 	for i, action := range actions {
+// 		lines = append(
+// 			lines,
+// 			fmt.Sprintf("%d: %s", i, stringFormatObject(action)))
 
-	}
-	return strings.Join(lines, "\n")
-}
+// 	}
+// 	return strings.Join(lines, "\n")
+// }
 
-func createLookup(objects []interface{}, key string) map[string]interface{} {
-	lookup := make(map[string]interface{})
-	for _, field := range objects {
-		f := field.(map[string]interface{})
-		lookup[f[key].(string)] = field
-	}
-	return lookup
-}
+// func createLookup(objects []interface{}, key string) map[string]interface{} {
+// 	lookup := make(map[string]interface{})
+// 	for _, field := range objects {
+// 		f := field.(map[string]interface{})
+// 		lookup[f[key].(string)] = field
+// 	}
+// 	return lookup
+// }
 
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
+// func stringInSlice(a string, list []string) bool {
+// 	for _, b := range list {
+// 		if b == a {
+// 			return true
+// 		}
+// 	}
+// 	return false
+// }
 
-var currencyCodes = map[string]bool{
-	"AED": true,
-	"AFN": true,
-	"ALL": true,
-	"AMD": true,
-	"ANG": true,
-	"AOA": true,
-	"ARS": true,
-	"AUD": true,
-	"AWG": true,
-	"AZN": true,
-	"BAM": true,
-	"BBD": true,
-	"BDT": true,
-	"BGN": true,
-	"BHD": true,
-	"BIF": true,
-	"BMD": true,
-	"BND": true,
-	"BOB": true,
-	"BOV": true,
-	"BRL": true,
-	"BSD": true,
-	"BTN": true,
-	"BWP": true,
-	"BYN": true,
-	"BZD": true,
-	"CAD": true,
-	"CDF": true,
-	"CHE": true,
-	"CHF": true,
-	"CHW": true,
-	"CLF": true,
-	"CLP": true,
-	"CNY": true,
-	"COP": true,
-	"COU": true,
-	"CRC": true,
-	"CUC": true,
-	"CUP": true,
-	"CVE": true,
-	"CZK": true,
-	"DJF": true,
-	"DKK": true,
-	"DOP": true,
-	"DZD": true,
-	"EGP": true,
-	"ERN": true,
-	"ETB": true,
-	"EUR": true,
-	"FJD": true,
-	"FKP": true,
-	"GBP": true,
-	"GEL": true,
-	"GHS": true,
-	"GIP": true,
-	"GMD": true,
-	"GNF": true,
-	"GTQ": true,
-	"GYD": true,
-	"HKD": true,
-	"HNL": true,
-	"HRK": true,
-	"HTG": true,
-	"HUF": true,
-	"IDR": true,
-	"ILS": true,
-	"INR": true,
-	"IQD": true,
-	"IRR": true,
-	"ISK": true,
-	"JMD": true,
-	"JOD": true,
-	"JPY": true,
-	"KES": true,
-	"KGS": true,
-	"KHR": true,
-	"KMF": true,
-	"KPW": true,
-	"KRW": true,
-	"KWD": true,
-	"KYD": true,
-	"KZT": true,
-	"LAK": true,
-	"LBP": true,
-	"LKR": true,
-	"LRD": true,
-	"LSL": true,
-	"LYD": true,
-	"MAD": true,
-	"MDL": true,
-	"MGA": true,
-	"MKD": true,
-	"MMK": true,
-	"MNT": true,
-	"MOP": true,
-	"MRU": true,
-	"MUR": true,
-	"MVR": true,
-	"MWK": true,
-	"MXN": true,
-	"MXV": true,
-	"MYR": true,
-	"MZN": true,
-	"NAD": true,
-	"NGN": true,
-	"NIO": true,
-	"NOK": true,
-	"NPR": true,
-	"NZD": true,
-	"OMR": true,
-	"PAB": true,
-	"PEN": true,
-	"PGK": true,
-	"PHP": true,
-	"PKR": true,
-	"PLN": true,
-	"PYG": true,
-	"QAR": true,
-	"RON": true,
-	"RSD": true,
-	"RUB": true,
-	"RWF": true,
-	"SAR": true,
-	"SBD": true,
-	"SCR": true,
-	"SDG": true,
-	"SEK": true,
-	"SGD": true,
-	"SHP": true,
-	"SLL": true,
-	"SOS": true,
-	"SRD": true,
-	"SSP": true,
-	"STN": true,
-	"SVC": true,
-	"SYP": true,
-	"SZL": true,
-	"THB": true,
-	"TJS": true,
-	"TMT": true,
-	"TND": true,
-	"TOP": true,
-	"TRY": true,
-	"TTD": true,
-	"TWD": true,
-	"TZS": true,
-	"UAH": true,
-	"UGX": true,
-	"USD": true,
-	"USN": true,
-	"UYI": true,
-	"UYU": true,
-	"UZS": true,
-	"VEF": true,
-	"VND": true,
-	"VUV": true,
-	"WST": true,
-	"XAF": true,
-	"XAG": true,
-	"XAU": true,
-	"XBA": true,
-	"XBB": true,
-	"XBC": true,
-	"XBD": true,
-	"XCD": true,
-	"XDR": true,
-	"XOF": true,
-	"XPD": true,
-	"XPF": true,
-	"XPT": true,
-	"XSU": true,
-	"XTS": true,
-	"XUA": true,
-	"YER": true,
-	"ZAR": true,
-	"ZMW": true,
-	"ZWL": true,
-}
+// var currencyCodes = map[string]bool{
+// 	"AED": true,
+// 	"AFN": true,
+// 	"ALL": true,
+// 	"AMD": true,
+// 	"ANG": true,
+// 	"AOA": true,
+// 	"ARS": true,
+// 	"AUD": true,
+// 	"AWG": true,
+// 	"AZN": true,
+// 	"BAM": true,
+// 	"BBD": true,
+// 	"BDT": true,
+// 	"BGN": true,
+// 	"BHD": true,
+// 	"BIF": true,
+// 	"BMD": true,
+// 	"BND": true,
+// 	"BOB": true,
+// 	"BOV": true,
+// 	"BRL": true,
+// 	"BSD": true,
+// 	"BTN": true,
+// 	"BWP": true,
+// 	"BYN": true,
+// 	"BZD": true,
+// 	"CAD": true,
+// 	"CDF": true,
+// 	"CHE": true,
+// 	"CHF": true,
+// 	"CHW": true,
+// 	"CLF": true,
+// 	"CLP": true,
+// 	"CNY": true,
+// 	"COP": true,
+// 	"COU": true,
+// 	"CRC": true,
+// 	"CUC": true,
+// 	"CUP": true,
+// 	"CVE": true,
+// 	"CZK": true,
+// 	"DJF": true,
+// 	"DKK": true,
+// 	"DOP": true,
+// 	"DZD": true,
+// 	"EGP": true,
+// 	"ERN": true,
+// 	"ETB": true,
+// 	"EUR": true,
+// 	"FJD": true,
+// 	"FKP": true,
+// 	"GBP": true,
+// 	"GEL": true,
+// 	"GHS": true,
+// 	"GIP": true,
+// 	"GMD": true,
+// 	"GNF": true,
+// 	"GTQ": true,
+// 	"GYD": true,
+// 	"HKD": true,
+// 	"HNL": true,
+// 	"HRK": true,
+// 	"HTG": true,
+// 	"HUF": true,
+// 	"IDR": true,
+// 	"ILS": true,
+// 	"INR": true,
+// 	"IQD": true,
+// 	"IRR": true,
+// 	"ISK": true,
+// 	"JMD": true,
+// 	"JOD": true,
+// 	"JPY": true,
+// 	"KES": true,
+// 	"KGS": true,
+// 	"KHR": true,
+// 	"KMF": true,
+// 	"KPW": true,
+// 	"KRW": true,
+// 	"KWD": true,
+// 	"KYD": true,
+// 	"KZT": true,
+// 	"LAK": true,
+// 	"LBP": true,
+// 	"LKR": true,
+// 	"LRD": true,
+// 	"LSL": true,
+// 	"LYD": true,
+// 	"MAD": true,
+// 	"MDL": true,
+// 	"MGA": true,
+// 	"MKD": true,
+// 	"MMK": true,
+// 	"MNT": true,
+// 	"MOP": true,
+// 	"MRU": true,
+// 	"MUR": true,
+// 	"MVR": true,
+// 	"MWK": true,
+// 	"MXN": true,
+// 	"MXV": true,
+// 	"MYR": true,
+// 	"MZN": true,
+// 	"NAD": true,
+// 	"NGN": true,
+// 	"NIO": true,
+// 	"NOK": true,
+// 	"NPR": true,
+// 	"NZD": true,
+// 	"OMR": true,
+// 	"PAB": true,
+// 	"PEN": true,
+// 	"PGK": true,
+// 	"PHP": true,
+// 	"PKR": true,
+// 	"PLN": true,
+// 	"PYG": true,
+// 	"QAR": true,
+// 	"RON": true,
+// 	"RSD": true,
+// 	"RUB": true,
+// 	"RWF": true,
+// 	"SAR": true,
+// 	"SBD": true,
+// 	"SCR": true,
+// 	"SDG": true,
+// 	"SEK": true,
+// 	"SGD": true,
+// 	"SHP": true,
+// 	"SLL": true,
+// 	"SOS": true,
+// 	"SRD": true,
+// 	"SSP": true,
+// 	"STN": true,
+// 	"SVC": true,
+// 	"SYP": true,
+// 	"SZL": true,
+// 	"THB": true,
+// 	"TJS": true,
+// 	"TMT": true,
+// 	"TND": true,
+// 	"TOP": true,
+// 	"TRY": true,
+// 	"TTD": true,
+// 	"TWD": true,
+// 	"TZS": true,
+// 	"UAH": true,
+// 	"UGX": true,
+// 	"USD": true,
+// 	"USN": true,
+// 	"UYI": true,
+// 	"UYU": true,
+// 	"UZS": true,
+// 	"VEF": true,
+// 	"VND": true,
+// 	"VUV": true,
+// 	"WST": true,
+// 	"XAF": true,
+// 	"XAG": true,
+// 	"XAU": true,
+// 	"XBA": true,
+// 	"XBB": true,
+// 	"XBC": true,
+// 	"XBD": true,
+// 	"XCD": true,
+// 	"XDR": true,
+// 	"XOF": true,
+// 	"XPD": true,
+// 	"XPF": true,
+// 	"XPT": true,
+// 	"XSU": true,
+// 	"XTS": true,
+// 	"XUA": true,
+// 	"YER": true,
+// 	"ZAR": true,
+// 	"ZMW": true,
+// 	"ZWL": true,
+// }
 
-// ValidateCurrencyCode checks if a currency string is valid according to https://en.wikipedia.org/wiki/ISO_4217
-func ValidateCurrencyCode(val interface{}, key string) (warns []string, errs []error) {
-	currency := val.(string)
-	if _, exists := currencyCodes[currency]; !exists {
-		errs = append(errs, fmt.Errorf("%q unknown currency code, must be valid ISO 4217 code, got: %s", key, currency))
-	}
-	return
-}
+// // ValidateCurrencyCode checks if a currency string is valid according to https://en.wikipedia.org/wiki/ISO_4217
+// func ValidateCurrencyCode(val interface{}, key string) (warns []string, errs []error) {
+// 	currency := val.(string)
+// 	if _, exists := currencyCodes[currency]; !exists {
+// 		errs = append(errs, fmt.Errorf("%q unknown currency code, must be valid ISO 4217 code, got: %s", key, currency))
+// 	}
+// 	return
+// }
 
-// Replaced by unmarshallTime
-func expandDate(input string) (time.Time, error) {
-	return time.Parse(time.RFC3339, input)
-}
+// // Replaced by unmarshallTime
+// func expandDate(input string) (time.Time, error) {
+// 	return time.Parse(time.RFC3339, input)
+// }
 
-func transformToList(data map[string]interface{}, key string) {
-	newDestination := make([]interface{}, 1, 1)
-	if data[key] != nil {
-		newDestination[0] = data[key]
-	}
-	data[key] = newDestination
-}
+// func transformToList(data map[string]interface{}, key string) {
+// 	newDestination := make([]interface{}, 1, 1)
+// 	if data[key] != nil {
+// 		newDestination[0] = data[key]
+// 	}
+// 	data[key] = newDestination
+// }
 
-func elementFromList(d *schema.ResourceData, key string) (map[string]interface{}, error) {
-	data := d.Get(key).([]interface{})
+// func elementFromList(d *schema.ResourceData, key string) (map[string]interface{}, error) {
+// 	data := d.Get(key).([]interface{})
 
-	if len(data) > 0 {
-		result := data[0].(map[string]interface{})
-		return result, nil
-	}
-	return nil, nil
-}
+// 	if len(data) > 0 {
+// 		result := data[0].(map[string]interface{})
+// 		return result, nil
+// 	}
+// 	return nil, nil
+// }
 
-func elementFromSlice(d map[string]interface{}, key string) (map[string]interface{}, error) {
-	data, ok := d[key]
-	if !ok {
-		return nil, nil
-	}
+// func elementFromSlice(d map[string]interface{}, key string) (map[string]interface{}, error) {
+// 	data, ok := d[key]
+// 	if !ok {
+// 		return nil, nil
+// 	}
 
-	items := data.([]interface{})
-	if len(items) > 0 {
-		result := items[0].(map[string]interface{})
-		return result, nil
-	}
-	return nil, nil
-}
+// 	items := data.([]interface{})
+// 	if len(items) > 0 {
+// 		result := items[0].(map[string]interface{})
+// 		return result, nil
+// 	}
+// 	return nil, nil
+// }
 
-func isNotEmpty(d map[string]interface{}, key string) (interface{}, bool) {
-	val, ok := d[key]
-	if !ok {
-		return nil, false
-	}
+// func isNotEmpty(d map[string]interface{}, key string) (interface{}, bool) {
+// 	val, ok := d[key]
+// 	if !ok {
+// 		return nil, false
+// 	}
 
-	if val != "" {
-		return val, true
-	}
-	return nil, false
-}
+// 	if val != "" {
+// 		return val, true
+// 	}
+// 	return nil, false
+// }

--- a/commercetools/utils_test.go
+++ b/commercetools/utils_test.go
@@ -1,42 +1,42 @@
 package commercetools
 
-import (
-	"fmt"
-	"testing"
+// import (
+// 	"fmt"
+// 	"testing"
 
-	"github.com/labd/commercetools-go-sdk/platform"
-)
+// 	"github.com/labd/commercetools-go-sdk/platform"
+// )
 
-func TestCreateLookup(t *testing.T) {
-	input := []interface{}{
-		map[string]interface{}{
-			"name":  "name1",
-			"value": "Value 1",
-		},
-		map[string]interface{}{
-			"name":  "name2",
-			"value": "Value 2",
-		},
-	}
-	result := createLookup(input, "name")
-	if _, ok := result["name1"]; !ok {
-		t.Error("Could not lookup name1")
-	}
-	if _, ok := result["name2"]; !ok {
-		t.Error("Could not lookup name1")
-	}
-}
+// func TestCreateLookup(t *testing.T) {
+// 	input := []interface{}{
+// 		map[string]interface{}{
+// 			"name":  "name1",
+// 			"value": "Value 1",
+// 		},
+// 		map[string]interface{}{
+// 			"name":  "name2",
+// 			"value": "Value 2",
+// 		},
+// 	}
+// 	result := createLookup(input, "name")
+// 	if _, ok := result["name1"]; !ok {
+// 		t.Error("Could not lookup name1")
+// 	}
+// 	if _, ok := result["name2"]; !ok {
+// 		t.Error("Could not lookup name1")
+// 	}
+// }
 
-func checkApiResult(err error) error {
-	switch v := err.(type) {
-	case platform.GenericRequestError:
-		if v.StatusCode == 404 {
-			return nil
-		}
-		return fmt.Errorf("unhandled error generic error returned (%d)", v.StatusCode)
-	case platform.ResourceNotFoundError:
-		return nil
-	default:
-		return fmt.Errorf("unexpected result returned")
-	}
-}
+// func checkApiResult(err error) error {
+// 	switch v := err.(type) {
+// 	case platform.GenericRequestError:
+// 		if v.StatusCode == 404 {
+// 			return nil
+// 		}
+// 		return fmt.Errorf("unhandled error generic error returned (%d)", v.StatusCode)
+// 	case platform.ResourceNotFoundError:
+// 		return nil
+// 	default:
+// 		return fmt.Errorf("unexpected result returned")
+// 	}
+// }

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.15.0 // indirect
 	github.com/hashicorp/terraform-json v0.13.0 // indirect
+	github.com/hashicorp/terraform-plugin-framework v0.5.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.5.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.2.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/hashicorp/terraform-exec v0.15.0 h1:cqjh4d8HYNQrDoEmlSGelHmg2DYDh5yay
 github.com/hashicorp/terraform-exec v0.15.0/go.mod h1:H4IG8ZxanU+NW0ZpDRNsvh9f0ul7C0nHP+rUR/CHs7I=
 github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniyEi5CM+FWGY=
 github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
+github.com/hashicorp/terraform-plugin-framework v0.5.0 h1:QUBNSZHiRJrQpbjqCdPcw5MRLU1TyzpQCrA4eRId364=
+github.com/hashicorp/terraform-plugin-framework v0.5.0/go.mod h1:rV7pWcX0+tpDLQFl0XuF2SGO1fm8JkVytduSu/HbIbY=
 github.com/hashicorp/terraform-plugin-go v0.5.0 h1:+gCDdF0hcYCm0YBTxrP4+K1NGIS5ZKZBKDORBewLJmg=
 github.com/hashicorp/terraform-plugin-go v0.5.0/go.mod h1:PAVN26PNGpkkmsvva1qfriae5Arky3xl3NfzKa8XFVM=
 github.com/hashicorp/terraform-plugin-log v0.2.0 h1:rjflRuBqCnSk3UHOR25MP1G5BDLKktTA6lNjjcAnBfI=

--- a/main.go
+++ b/main.go
@@ -2,29 +2,14 @@ package main
 
 import (
 	"context"
-	"flag"
-	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
 	"github.com/labd/terraform-provider-commercetools/commercetools"
 )
 
 func main() {
-	var debugMode bool
-
-	flag.BoolVar(&debugMode, "debuggable", false, "set to true to run the provider with support for debuggers like delve")
-	flag.Parse()
-
-	if debugMode {
-		err := plugin.Debug(context.Background(), "registry.terraform.io/labd/commercetools",
-			&plugin.ServeOpts{
-				ProviderFunc: commercetools.Provider,
-			})
-		if err != nil {
-			log.Println(err.Error())
-		}
-	} else {
-		plugin.Serve(&plugin.ServeOpts{
-			ProviderFunc: commercetools.Provider})
-	}
+	tfsdk.Serve(context.Background(), commercetools.New, tfsdk.ServeOpts{
+		Name: "commercetools",
+	})
 }


### PR DESCRIPTION
This is the new terraform plugin SDK which significantly differs from the current SDK / SDK-v2. See https://www.terraform.io/plugin/framework

There are some good reasons to upgrade to this one directly vs the in between step with SDK v2 (#196):
 - The new plugin SDK supports nested attributes. SDK v1 also supported this somewhat, but this was removed in SDK v2. This means we should be able to keep the terraform files 100% backwards compatible
 - Easier infrastructure to marshall/unmarshall objects from commercetools to terrraform state

Progress:
- [ ] resource_api_client
- [ ] resource_api_extension
- [ ] resource_cart_discount
- [ ] resource_category
- [ ] resource_channel
- [ ] resource_custom_object
- [ ] resource_customer_group
- [ ] resource_discount_code
- [ ] resource_product_type
- [ ] resource_project
- [ ] resource_shipping_method
- [ ] resource_shipping_zone
- [ ] resource_shipping_zone_rate
- [ ] resource_state
- [ ] resource_store
- [ ] resource_subscription
- [ ] resource_tax_category
- [ ] resource_tax_category_rate
- [ ] resource_type

