### PR TITLE
project_settings: Fix CT defaults not being computed

### DIFF
--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -45,23 +45,27 @@ func resourceProjectSettings() *schema.Resource {
 				Description: "The name of the project",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"currencies": {
 				Description: "A three-digit currency code as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"countries": {
 				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"languages": {
 				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"messages": {
@@ -113,6 +117,7 @@ func resourceProjectSettings() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"country_tax_rate_fallback_enabled": {


### PR DESCRIPTION
Relates to #209   #128

Since all of its attributes are optional you can create an empty `commercetools_project_settings`.

```hcl
resource "commercetools_project_settings" "t2" {
}
```

When you apply this for the first time, you'll also retrieve some hidden attributes which are set by default on CT.  A newly created [Project](https://docs.commercetools.com/api/projects/project) resource looks like this on the CT API:

```sh
curl \
  -X GET \
  -H "Accept: application/json; charset=utf-8" \
  -H "Authorization: Bearer TOKEN" \
  "https://api.europe-west1.gcp.commercetools.com/PROJECT"
```

Project:

```json
{
  "key": "KEY",
  "name": "NAME",
  "countries": [
    "DE",
    "US"
  ],
  "currencies": [
    "EUR",
    "USD"
  ],
  "languages": [
    "de-DE",
    "en-US"
  ],
  "createdAt": "2022-03-25T11:21:17.933Z",
  "trialUntil": "2022-05",
  "messages": {
    "enabled": false,
    "deleteDaysAfterCreation": 15
  },
  "carts": {
    "deleteDaysAfterLastModification": 90,
    "allowAddingUnpublishedProducts": false,
    "countryTaxRateFallbackEnabled": false
  },
  "shoppingLists": {
    "deleteDaysAfterLastModification": 360
  },
  "version": 3,
  "searchIndexing": {
    "products": {
      "status": "Deactivated"
    }
  }
}
```

If you apply the same empty config, Terraform will try to perform an update with nil values:

```
  # commercetools_project_settings.t2 will be updated in-place
  ~ resource "commercetools_project_settings" "t2" {
      ~ countries                    = [
          - "DE",
          - "US",
        ]
      ~ currencies                   = [
          - "EUR",
          - "USD",
        ]
        id                           = "FOO"
      ~ languages                    = [
          - "de-DE",
          - "en-US",
        ]
      - name                         = "BAR" -> null
        # (3 unchanged attributes hidden)

      - carts {
          - country_tax_rate_fallback_enabled   = false -> null
          - delete_days_after_last_modification = 90 -> null
        }
    }


Plan: 0 to add, 1 to change, 0 to destroy.
```


If you continue you get an error, this update doesn't work since the name can't be set to `null`, and `languages`, `countries`, `currencies` must have at least one item in them.

I'm not sure if there is any specification about project defaults, but these values can never be empty according to the API docs. Therefore the expected behaviour should be computing them from CT defaults when not set.