### PR TITLE
category: Fix new assets not being added

### DIFF
--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -79,6 +79,10 @@ func resourceCategory() *schema.Resource {
 				Description: "Can be used to store images, icons or movies related to this category",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"key": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -191,7 +195,7 @@ func resourceCategoryCreate(ctx context.Context, d *schema.ResourceData, m inter
 	}
 
 	if len(d.Get("assets").([]interface{})) != 0 {
-		assets := unmarshallCategoryAssets(d)
+		assets := unmarshallCategoryAssetDrafts(d)
 		draft.Assets = assets
 	}
 
@@ -348,22 +352,30 @@ func resourceCategoryUpdate(ctx context.Context, d *schema.ResourceData, m inter
 			&platform.CategorySetMetaKeywordsAction{MetaKeywords: &newMetaKeywords})
 	}
 
-	// TODO: This is far from complete. See
-	// https://github.com/labd/terraform-provider-commercetools/issues/205
 	if d.HasChange("assets") {
 		assets := unmarshallCategoryAssets(d)
 		for _, asset := range assets {
-			input.Actions = append(
-				input.Actions,
-				&platform.CategoryChangeAssetNameAction{Name: asset.Name, AssetKey: asset.Key},
-				&platform.CategorySetAssetDescriptionAction{Description: asset.Description, AssetKey: asset.Key},
-				&platform.CategorySetAssetSourcesAction{Sources: asset.Sources, AssetKey: asset.Key},
-			)
-			if len(asset.Tags) > 0 {
+			if asset.ID == "" {
+				input.Actions = append(input.Actions, &platform.CategoryAddAssetAction{Asset: platform.AssetDraft{
+					Key:         asset.Key,
+					Name:        asset.Name,
+					Description: asset.Description,
+					Sources:     asset.Sources,
+					Tags:        asset.Tags,
+				}})
+			} else {
 				input.Actions = append(
 					input.Actions,
-					&platform.CategorySetAssetTagsAction{Tags: asset.Tags, AssetKey: asset.Key},
+					&platform.CategoryChangeAssetNameAction{Name: asset.Name, AssetKey: asset.Key},
+					&platform.CategorySetAssetDescriptionAction{Description: asset.Description, AssetKey: asset.Key},
+					&platform.CategorySetAssetSourcesAction{Sources: asset.Sources, AssetKey: asset.Key},
 				)
+				if len(asset.Tags) > 0 {
+					input.Actions = append(
+						input.Actions,
+						&platform.CategorySetAssetTagsAction{Tags: asset.Tags, AssetKey: asset.Key},
+					)
+				}
 			}
 		}
 	}
@@ -396,13 +408,15 @@ func resourceCategoryDelete(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func marshallCategoryAssets(assets []platform.Asset) []map[string]interface{} {
-
 	result := make([]map[string]interface{}, len(assets))
 
 	for i := range assets {
 		asset := assets[i]
 
 		result[i] = make(map[string]interface{})
+		if asset.ID != "" {
+			result[i]["id"] = asset.ID
+		}
 		result[i]["name"] = asset.Name
 		result[i]["key"] = asset.Key
 		result[i]["sources"] = marshallCategoryAssetSources(asset.Sources)
@@ -418,28 +432,48 @@ func marshallCategoryAssets(assets []platform.Asset) []map[string]interface{} {
 	return result
 }
 
-func unmarshallCategoryAssets(d *schema.ResourceData) []platform.AssetDraft {
+func unmarshallCategoryAssetDraft(u interface{}) *platform.AssetDraft {
+	i := u.(map[string]interface{})
+	name := unmarshallLocalizedString(i["name"])
+	description := unmarshallLocalizedString(i["description"])
+	sources := unmarshallCategoryAssetSources(i)
+	tags := expandStringArray(i["tags"].([]interface{}))
+	key := i["key"].(string)
+	return &platform.AssetDraft{
+		Key:         &key,
+		Name:        name,
+		Description: &description,
+		Sources:     sources,
+		Tags:        tags,
+	}
+}
+
+func unmarshallCategoryAssetDrafts(d *schema.ResourceData) []platform.AssetDraft {
 	input := d.Get("assets").([]interface{})
 	var result []platform.AssetDraft
-
 	for _, raw := range input {
-		i := raw.(map[string]interface{})
-
-		name := unmarshallLocalizedString(i["name"])
-		description := unmarshallLocalizedString(i["description"])
-		sources := unmarshallCategoryAssetSources(i)
-		tags := expandStringArray(i["tags"].([]interface{}))
-
-		key := i["key"].(string)
-		result = append(result, platform.AssetDraft{
-			Key:         &key,
-			Name:        name,
-			Description: &description,
-			Sources:     sources,
-			Tags:        tags,
-		})
+		result = append(result, *unmarshallCategoryAssetDraft(raw))
 	}
+	return result
+}
 
+func unmarshallCategoryAssets(d *schema.ResourceData) []platform.Asset {
+	input := d.Get("assets").([]interface{})
+	var result []platform.Asset
+	for _, raw := range input {
+		draft := unmarshallCategoryAssetDraft(raw)
+		i := raw.(map[string]interface{})
+		id := i["id"].(string)
+		asset := platform.Asset{
+			ID:          id,
+			Key:         draft.Key,
+			Name:        draft.Name,
+			Description: draft.Description,
+			Sources:     draft.Sources,
+			Tags:        draft.Tags,
+		}
+		result = append(result, asset)
+	}
 	return result
 }
 


### PR DESCRIPTION
Fixes #205 

# Problem

Assets are created when you create a `commercetools_category` resource for the first time.

Resource:
```tf
resource "commercetools_category" "my-category" {
  name = {
    en = "Some category"
  }
  slug = {
    en = "some_category"
  }

  assets {
    key = "some_key"
    name = {
      en = "Image name"
    }
    description = {
      en = "Image description"
    }
    sources {
      uri = "https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Flag_of_the_Netherlands.svg/800px-Flag_of_the_Netherlands.svg.png"
      key = "image"
    }
  }
}
```

Apply this and check with the computed ID:

```sh
curl \
  -vvv \
  -X GET \
  -H "Accept: application/json; charset=utf-8" \
  -H "Authorization: Bearer $1" \
  "https://api.europe-west1.gcp.commercetools.com/$2/categories/$3"
```

```json
{
  "id": "xyz",
  "version": 1,
  "lastMessageSequenceNumber": 1,
  "createdAt": "2022-04-01T10:53:48.699Z",
  "lastModifiedAt": "2022-04-01T10:53:48.699Z",
  "lastModifiedBy": {
    "clientId": "xyz",
    "isPlatformClient": false
  },
  "createdBy": {
    "clientId": "xyz",
    "isPlatformClient": false
  },
  "name": {
    "en": "Some category"
  },
  "slug": {
    "en": "some_category"
  },
  "ancestors": [],
  "orderHint": "",
  "assets": [
    {
      "id": "xyz",
      "sources": [
        {
          "uri": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Flag_of_the_Netherlands.svg/800px-Flag_of_the_Netherlands.svg.png",
          "key": "image",
          "contentType": ""
        }
      ],
      "name": {
        "en": "Image name"
      },
      "key": "some_key",
      "description": {
        "en": "Image description"
      },
      "tags": []
    }
  ]
}
```

But if you try to modify this resource, and add a new asset, it doesn't include the [addAsset](https://docs.commercetools.com/api/projects/categories#add-asset) action type for the newly added asset `some_key2`. 

```json
{
  "version": 1,
  "actions": [
    {
      "action": "changeAssetName",
      "assetKey": "some_key",
      "name": {
        "en": "Image name"
      }
    },
    {
      "action": "setAssetDescription",
      "assetKey": "some_key",
      "description": {
        "en": "Image description"
      }
    },
    {
      "action": "setAssetSources",
      "assetKey": "some_key",
      "sources": [
        {
          "uri": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Flag_of_the_Netherlands.svg/800px-Flag_of_the_Netherlands.svg.png",
          "key": "image",
          "contentType": ""
        }
      ]
    },
    {
      "action": "changeAssetName",
      "assetKey": "some_key2",
      "name": {
        "en": "Image name2"
      }
    },
    {
      "action": "setAssetDescription",
      "assetKey": "some_key2",
      "description": {
        "en": "Image description2"
      }
    },
    {
      "action": "setAssetSources",
      "assetKey": "some_key2",
      "sources": [
        {
          "uri": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Flag_of_the_Netherlands.svg/800px-Flag_of_the_Netherlands.svg.png",
          "key": "image",
          "contentType": ""
        }
      ]
    }
  ]
}
```

So, this fails with `Error: Asset with key 'some_key2' was not found.` because the asset was never created so you can't change it.

# Change

We can use the computed `id` attribute In order to differentiate between the new and the existing assets.

This change adds `id` to the schema definition of an asset object. If an `id` exists in the current state of an asset, as before we send a sequence of change actions, otherwise we sent a single `addAsset` action for performing the update.

