### PR TITLE
category: Fix empty key being sent during creation

### DIFF
--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -156,12 +156,16 @@ func resourceCategoryCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	name := unmarshallLocalizedString(d.Get("name"))
 	slug := unmarshallLocalizedString(d.Get("slug"))
+	key := stringRef(d.Get("key"))
 
 	draft := platform.CategoryDraft{
-		Key:       stringRef(d.Get("key")),
 		Name:      name,
 		Slug:      slug,
 		OrderHint: stringRef(d.Get("order_hint")),
+	}
+
+	if *key != "" {
+		draft.Key = key
 	}
 
 	if d.Get("description") != nil {


### PR DESCRIPTION
`key` is optional but it is still being sent as an empty string when not set. This causes the CT API to respond with an error because of the empty key. This change prevents the `key` from being included in the create request when not set.