### PR TITLE
project_settings: Fix shipping rate input type marshaling

### DIFF
--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -485,15 +485,16 @@ func marshallProjectSearchIndexOrders(val *platform.SearchIndexingConfiguration)
 }
 
 func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) string {
-	switch val.(type) {
-	case platform.CartScoreType:
-		return "CartScore"
-	case platform.CartValueType:
-		return "CartValue"
-	case platform.CartClassificationType:
-		return "CartClassification"
+	var s string
+	if data, ok := val.(map[string]interface{}); ok {
+		s, ok = data["type"].(string)
+		if !ok {
+			return ""
+		}
+	} else {
+		return ""
 	}
-	return ""
+	return s
 }
 
 func marshallProjectMessages(val platform.MessagesConfiguration, d *schema.ResourceData) []map[string]interface{} {


### PR DESCRIPTION
Not sure if this was caused by a recent change in the SDK or if it is coming from the computed optionals change we added recently. But this function was returning me empty string for valid `ShippingRateInputType` types, so I changed it with the one found in the SDK now.

https://github.com/labd/commercetools-go-sdk/blob/a4cefda875a28e7781896010f1ecbe3843006483/platform/types_project.go#L249