### PR TITLE
WIP: project_settings: Handle computed/optional and mixed-case values

### DIFF
--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -93,6 +93,7 @@ func resourceProjectSettings() *schema.Resource {
 				Description: "Enable the Search Indexing of orders",
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 			},
 			"external_oauth": {
 				Description: "[External OAUTH](https://docs.commercetools.com/api/projects/project#externaloauth)",

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -87,6 +87,7 @@ func resourceProjectSettings() *schema.Resource {
 				Description: "Enable the Search Indexing of products",
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed:    true,
 			},
 			"enable_search_index_orders": {
 				Description: "Enable the Search Indexing of orders",

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -147,7 +147,6 @@ func resourceProjectSettings() *schema.Resource {
 					"shippingRateInput field on the cart to select a tier",
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 			"shipping_rate_cart_classification_value": {
 				Description: "If shipping_rate_input_type is set to CartClassification these values are used to create " +

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -136,6 +136,7 @@ func resourceProjectSettings() *schema.Resource {
 								"projects created after December 2019.",
 							Type:     schema.TypeInt,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -491,16 +491,15 @@ func marshallProjectSearchIndexOrders(val *platform.SearchIndexingConfiguration)
 }
 
 func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) string {
-	var s string
-	if data, ok := val.(map[string]interface{}); ok {
-		s, ok = data["type"].(string)
-		if !ok {
-			return ""
-		}
-	} else {
-		return ""
+	switch val.(type) {
+	case platform.CartScoreType:
+		return "CartScore"
+	case platform.CartValueType:
+		return "CartValue"
+	case platform.CartClassificationType:
+		return "CartClassification"
 	}
-	return s
+	return ""
 }
 
 func marshallProjectMessages(val platform.MessagesConfiguration, d *schema.ResourceData) []map[string]interface{} {

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -49,14 +49,14 @@ func resourceProjectSettings() *schema.Resource {
 				Computed:    true,
 			},
 			"currencies": {
-				Description: "A three-digit currency code as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
+				Description: "A list of three-digit currency codes as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"countries": {
-				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
+				Description: "A list of two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -49,14 +49,14 @@ func resourceProjectSettings() *schema.Resource {
 				Computed:    true,
 			},
 			"currencies": {
-				Description: "A list of three-digit currency codes as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
+				Description: "A three-digit currency code as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"countries": {
-				Description: "A list of two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
+				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
@@ -598,7 +598,6 @@ func resourceProjectSettingsResourceV0() *schema.Resource {
 					"the sum of all line item prices, whereas CartClassification and CartScore use the " +
 					"shippingRateInput field on the cart to select a tier",
 				Type:     schema.TypeString,
-				Computed: true,
 				Optional: true,
 			},
 			"shipping_rate_cart_classification_value": {

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -129,7 +129,8 @@ func resourceProjectSettings() *schema.Resource {
 								"shipping address state is not explicitly covered in the rates lists of all tax " +
 								"categories of a cart line items",
 							Type:     schema.TypeBool,
-							Required: true,
+							Optional: true,
+							Computed: true,
 						},
 						"delete_days_after_last_modification": {
 							Description: "Number - Optional The default value for the " +

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -485,15 +485,16 @@ func marshallProjectSearchIndexOrders(val *platform.SearchIndexingConfiguration)
 }
 
 func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) string {
-	switch val.(type) {
-	case platform.CartScoreType:
-		return "CartScore"
-	case platform.CartValueType:
-		return "CartValue"
-	case platform.CartClassificationType:
-		return "CartClassification"
+	var s string
+	if data, ok := val.(map[string]interface{}); ok {
+		s, ok = data["type"].(string)
+		if !ok {
+			return ""
+		}
+	} else {
+		return ""
 	}
-	return ""
+	return s
 }
 
 func marshallProjectMessages(val platform.MessagesConfiguration, d *schema.ResourceData) []map[string]interface{} {

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -390,10 +390,14 @@ func projectUpdate(ctx context.Context, d *schema.ResourceData, client *platform
 			input.Actions,
 			&platform.ProjectChangeCartsConfigurationAction{
 				CartsConfiguration: platform.CartsConfiguration{
-					CountryTaxRateFallbackEnabled:   boolRef(fallbackEnabled),
 					DeleteDaysAfterLastModification: deleteDaysAfterLastModification,
+					CountryTaxRateFallbackEnabled:   boolRef(fallbackEnabled),
 				},
-			})
+			},
+			&platform.ProjectChangeCountryTaxRateFallbackEnabledAction{
+				CountryTaxRateFallbackEnabled: fallbackEnabled,
+			},
+		)
 	}
 
 	_, err := client.Post(input).Execute(ctx)

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -149,6 +149,7 @@ func resourceProjectSettings() *schema.Resource {
 					"shippingRateInput field on the cart to select a tier",
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"shipping_rate_cart_classification_value": {
 				Description: "If shipping_rate_input_type is set to CartClassification these values are used to create " +
@@ -598,6 +599,7 @@ func resourceProjectSettingsResourceV0() *schema.Resource {
 					"the sum of all line item prices, whereas CartClassification and CartScore use the " +
 					"shippingRateInput field on the cart to select a tier",
 				Type:     schema.TypeString,
+				Computed: true,
 				Optional: true,
 			},
 			"shipping_rate_cart_classification_value": {

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -147,6 +147,7 @@ func resourceProjectSettings() *schema.Resource {
 					"shippingRateInput field on the cart to select a tier",
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"shipping_rate_cart_classification_value": {
 				Description: "If shipping_rate_input_type is set to CartClassification these values are used to create " +

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -491,15 +491,16 @@ func marshallProjectSearchIndexOrders(val *platform.SearchIndexingConfiguration)
 }
 
 func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) string {
-	switch val.(type) {
-	case platform.CartScoreType:
-		return "CartScore"
-	case platform.CartValueType:
-		return "CartValue"
-	case platform.CartClassificationType:
-		return "CartClassification"
+	var s string
+	if data, ok := val.(map[string]interface{}); ok {
+		s, ok = data["type"].(string)
+		if !ok {
+			return ""
+		}
+	} else {
+		return ""
 	}
-	return ""
+	return s
 }
 
 func marshallProjectMessages(val platform.MessagesConfiguration, d *schema.ResourceData) []map[string]interface{} {
@@ -597,7 +598,8 @@ func resourceProjectSettingsResourceV0() *schema.Resource {
 				Description: "Three ways to dynamically select a ShippingRatePriceTier exist. The CartValue type uses " +
 					"the sum of all line item prices, whereas CartClassification and CartScore use the " +
 					"shippingRateInput field on the cart to select a tier",
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
+				// Computed: true,
 				Optional: true,
 			},
 			"shipping_rate_cart_classification_value": {

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -579,8 +579,7 @@ func resourceProjectSettingsResourceV0() *schema.Resource {
 				Description: "Three ways to dynamically select a ShippingRatePriceTier exist. The CartValue type uses " +
 					"the sum of all line item prices, whereas CartClassification and CartScore use the " +
 					"shippingRateInput field on the cart to select a tier",
-				Type: schema.TypeString,
-				// Computed: true,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"shipping_rate_cart_classification_value": {

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -432,7 +432,7 @@ func getCartClassificationValues(d *schema.ResourceData) ([]platform.CustomField
 	data := d.Get("shipping_rate_cart_classification_value").([]interface{})
 	for _, item := range data {
 		itemMap := item.(map[string]interface{})
-		label := unmarshallLocalizedString(d.Get("label"))
+		label := unmarshallLocalizedString(itemMap["label"].(map[string]interface{}))
 		values = append(values, platform.CustomFieldLocalizedEnumValue{
 			Label: label,
 			Key:   itemMap["key"].(string),

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -73,6 +73,7 @@ func resourceProjectSettings() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -500,12 +501,6 @@ func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) st
 }
 
 func marshallProjectMessages(val platform.MessagesConfiguration, d *schema.ResourceData) []map[string]interface{} {
-	if current, ok := d.Get("messages").([]interface{}); ok {
-		if len(current) == 0 && !val.Enabled {
-			return nil
-		}
-
-	}
 	return []map[string]interface{}{
 		{
 			"enabled": val.Enabled,

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -54,6 +54,9 @@ func resourceProjectSettings() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"countries": {
 				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
@@ -61,6 +64,9 @@ func resourceProjectSettings() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"languages": {
 				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
@@ -68,6 +74,9 @@ func resourceProjectSettings() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"messages": {
 				Description: "[Messages Configuration](https://docs.commercetools.com/api/projects/project#messages-configuration)",
@@ -275,14 +284,14 @@ func projectUpdate(ctx context.Context, d *schema.ResourceData, client *platform
 	}
 
 	if d.HasChange("currencies") {
-		newCurrencies := upperSlice(getStringSlice(d, "currencies"))
+		newCurrencies := upperStringSlice(getStringSlice(d, "currencies"))
 		input.Actions = append(
 			input.Actions,
 			&platform.ProjectChangeCurrenciesAction{Currencies: newCurrencies})
 	}
 
 	if d.HasChange("countries") {
-		newCountries := upperSlice(getStringSlice(d, "countries"))
+		newCountries := upperStringSlice(getStringSlice(d, "countries"))
 		input.Actions = append(
 			input.Actions,
 			&platform.ProjectChangeCountriesAction{Countries: newCountries})
@@ -509,34 +518,6 @@ func marshallProjectMessages(val platform.MessagesConfiguration, d *schema.Resou
 			"enabled": val.Enabled,
 		},
 	}
-}
-
-func upperSlice(items []string) []string {
-	s := make([]string, len(items))
-	for i, currency := range items {
-		s[i] = strings.ToUpper(currency)
-	}
-	return s
-}
-
-func languageCode(s string) string {
-	if len(s) == 2 {
-		return strings.ToLower(s)
-	}
-	parts := strings.Split(s, "-")
-	if len(parts) == 2 {
-		return strings.Join([]string{strings.ToLower(parts[0]), strings.ToUpper(parts[1])}, "-")
-	}
-	// fallback to the original
-	return s
-}
-
-func languageCodeSlice(items []string) []string {
-	codes := make([]string, len(items))
-	for i, code := range items {
-		codes[i] = languageCode(code)
-	}
-	return codes
 }
 
 func resourceProjectSettingsResourceV0() *schema.Resource {

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/labd/commercetools-go-sdk/platform"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -83,6 +83,38 @@ func TestAccProjectCreate_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccProjectEmptyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "name", "Test this thing",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "countries.#", "3",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "currencies.#", "2",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "languages.#", "4",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "messages.0.enabled", "true",
+					),
+					resource.TestCheckNoResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.url",
+					),
+					resource.TestCheckNoResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "external_oauth.0.authorization_header",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "shipping_rate_input_type", "CartValue",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled", "true",
+					),
+				),
+			},
+			{
 				Config: testAccProjectConfigUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -249,6 +281,12 @@ func testAccProjectConfig() string {
             }
 
 			shipping_rate_input_type = "CartValue"
+		}`
+}
+
+func testAccProjectEmptyConfig() string {
+	return `
+		resource "commercetools_project_settings" "acctest_project_settings" {
 		}`
 }
 

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -178,11 +178,11 @@ func TestAccProjectCreate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"commercetools_project_settings.acctest_project_settings", "shipping_rate_cart_classification_value.0.label.nl", "Klein",
 					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled",
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "carts.0.country_tax_rate_fallback_enabled", "false",
 					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_project_settings.acctest_project_settings", "carts.0.delete_days_after_last_modification",
+					resource.TestCheckResourceAttr(
+						"commercetools_project_settings.acctest_project_settings", "carts.0.delete_days_after_last_modification", "21",
 					),
 				),
 			},

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -78,7 +78,7 @@ func TestAccProjectCreate_basic(t *testing.T) {
 						assert.EqualValues(t, result.Languages, []string{"nl", "de", "en", "en-US"})
 						assert.EqualValues(t, result.Currencies, []string{"EUR", "USD"})
 						assert.Equal(t, *result.Carts.DeleteDaysAfterLastModification, 7)
-						assert.Equal(t, result.ShippingRateInputType, platform.CartValueType(platform.CartValueType{}))
+						assert.Equal(t, result.ShippingRateInputType, map[string]interface{}{"type": "CartValue"})
 						return nil
 					},
 				),

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -357,3 +357,34 @@ var validateLocalizedStringKey = validation.MapKeyMatch(
 	regexp.MustCompile("^[a-z]{2}(-[A-Z]{2})?$"),
 	"Locale keys must match pattern ^[a-z]{2}(-[A-Z]{2})?$",
 )
+
+func upperStringSlice(items []string) []string {
+	s := make([]string, len(items))
+	for i, v := range items {
+		s[i] = strings.ToUpper(v)
+	}
+	return s
+}
+
+func languageCode(s string) string {
+	if len(s) == 2 {
+		return strings.ToLower(s)
+	}
+	parts := strings.Split(s, "-")
+	if len(parts) == 2 {
+		return strings.Join([]string{strings.ToLower(parts[0]), strings.ToUpper(parts[1])}, "-")
+	}
+	// fallback to the original
+	return s
+}
+
+// languageCodeSlice maps a list of IETF language tags with mixed casing
+// into the case-sensitive format. The original items are returned if the given input
+// contains invalid language tags, .
+func languageCodeSlice(items []string) []string {
+	codes := make([]string, len(items))
+	for i, code := range items {
+		codes[i] = languageCode(code)
+	}
+	return codes
+}

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -366,6 +366,8 @@ func upperStringSlice(items []string) []string {
 	return s
 }
 
+// languageCode converts an IETF language tag with mixed casing into the case-sensitive format.
+// The original item is returned if the given input is not valid.
 func languageCode(s string) string {
 	if len(s) == 2 {
 		return strings.ToLower(s)
@@ -378,9 +380,6 @@ func languageCode(s string) string {
 	return s
 }
 
-// languageCodeSlice maps a list of IETF language tags with mixed casing
-// into the case-sensitive format. The original items are returned if the given input
-// contains invalid language tags, .
 func languageCodeSlice(items []string) []string {
 	codes := make([]string, len(items))
 	for i, code := range items {


### PR DESCRIPTION
## Handle computed/optional values

I created a new project on CT to see the actual defaults before any changes are made.

A Project resource looks like this initially:

```json
{
  "key": "4a579302a9113403",
  "name": "test3",
  "countries": [
    "DE",
    "US"
  ],
  "currencies": [
    "EUR",
    "USD"
  ],
  "languages": [
    "de-DE",
    "en-US"
  ],
  "createdAt": "2022-04-15T10:44:13.731Z",
  "trialUntil": "2022-06",
  "messages": {
    "enabled": false,
    "deleteDaysAfterCreation": 15
  },
  "carts": {
    "deleteDaysAfterLastModification": 90,
    "allowAddingUnpublishedProducts": false,
    "countryTaxRateFallbackEnabled": false
  },
  "shoppingLists": {
    "deleteDaysAfterLastModification": 360
  },
  "version": 3,
  "searchIndexing": {
    "products": {
      "status": "Deactivated"
    }
  }
}
```

This JSON can be safely set as computed/optional. These things are already initialised by CT.

With this change the following attributes will be computed even when they are not set by user.

- `enable_search_index_products`
- `enable_search_index_orders`
- `carts.delete_days_after_last_modification`
- `carts.country_tax_rate_fallback_enabled` (this was previously required but can be safely made optional)
- `carts`
- `messages`

Marshaling of `messages` object is changed. I removed the check that returns `nil` when current value doesn't exist, there will be always a `{ enabled: bool }` object in here.

`messages.enabled` is still required, but it can also be made an optional computed, since this also comes with a default value from CT. Currently there are no other attributes we set on `messages`, so it doesn't make sense to me to create an empty `messages {}` in your Terraform config. So, I kept it as it is, but if a new attribute is added in `messages`, we can make `messages.enabled` optional, too.

### Automatically handle mixed-case languages, currencies & countries

These attributes has to be set in a specific format, otherwise we receive a 400 error from CT.

We can use [DiffSupressFunc](https://www.terraform.io/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc) to remedy this a little bit and automatically handle mixed-case codes as long as the format is correct.

I added a case-insensitive string equality check on `currencies`, `languages` and `countries`.  This prevents mixed-case codes (such as nL-Nl language tag) from triggering an update. So users can use mixed-case letters, but during the update these are converted into the case-sensitive format before being sent. 

## shipping_rate_input_type

The type switch in here doesn't seem to work with `ShippingRateInputType`s. To fix this, I used `map[string]interface{}` for type assertion (as in the SDK) and just returned the value in `type` attribute if it exists, otherwise an empty string.

## shipping_rate_cart_classification_value

Fixed an issue where the label value not being set correctly.

## carts.country_tax_rate_fallback_enabled

This one is interesting. According to docs there are two ways to set CountryTaxRateFallbackEnabled value:

- In the `CartsConfiguration` field: https://docs.commercetools.com/api/projects/project#ctp:api:type:CartsConfiguration
- or as a separate action: https://docs.commercetools.com/api/projects/project#change-countrytaxratefallbackenabled

It's not clear to me why this is the case, but there is a note under `ChangeCountryTaxRateFallbackEnabled` documentation which says some earlier projects may not have this option. In my project `CartsConfiguration` method doesn't seem to work, I need to send `ChangeCountryTaxRateFallbackEnabled` instead. So, I included that, too! When there is a change on the `carts` object, both of these actions are posted. I hope they are not doing very different things 😅 