### PR TITLE
api_extension: Prevent nil from being set as timeoutInMs value

### DIFF
--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -142,7 +142,11 @@ func resourceAPIExtensionCreate(ctx context.Context, d *schema.ResourceData, m i
 		Key:         stringRef(d.Get("key")),
 		Destination: destination,
 		Triggers:    triggers,
-		TimeoutInMs: intRef(d.Get("timeout_in_ms")),
+	}
+
+	timeoutInMs := d.Get("timeout_in_ms")
+	if timeoutInMs != 0 {
+		draft.TimeoutInMs = intRef(timeoutInMs)
 	}
 
 	err = resource.RetryContext(ctx, 20*time.Second, func() *resource.RetryError {

--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -117,6 +117,18 @@ func TestAccAPIExtension_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAPIExtensionConfigRequiredOnly(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAPIExtensionExists("ext"),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "key", name),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "trigger.0.actions.#", "1"),
+					resource.TestCheckResourceAttr(
+						"commercetools_api_extension.ext", "trigger.0.actions.0", "Create"),
+				),
+			},
+			{
 				Config: testAccAPIExtensionUpdate(name, timeoutInMs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAPIExtensionExists("ext"),
@@ -154,6 +166,24 @@ resource "commercetools_api_extension" "ext" {
   }
 }
 `, name, timeoutInMs)
+}
+
+func testAccAPIExtensionConfigRequiredOnly(name string) string {
+	return fmt.Sprintf(`
+resource "commercetools_api_extension" "ext" {
+  key = "%s"
+
+  destination {
+    type = "HTTP"
+    url  = "https://example.com"
+  }
+
+  trigger {
+    resource_type_id = "customer"
+    actions = ["Create"]
+  }
+}
+`, name)
 }
 
 func testAccAPIExtensionUpdate(name string, timeoutInMs int) string {


### PR DESCRIPTION
Fixes the following error thrown by CT when `timeout_in_ms` value is not set.

```
Error: 'timeoutInMs' must be >0.
```