### PR TITLE
cart_discount: Prevent dates with trailing zeroes from triggering updates

### DIFF
--- a/commercetools/resource_cart_discount.go
+++ b/commercetools/resource_cart_discount.go
@@ -155,10 +155,16 @@ func resourceCartDiscount() *schema.Resource {
 			"valid_from": {
 				Type:     schema.TypeString,
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return compareCartDiscountValidDates(old, new)
+				},
 			},
 			"valid_until": {
 				Type:     schema.TypeString,
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return compareCartDiscountValidDates(old, new)
+				},
 			},
 			"requires_discount_code": {
 				Description: "States whether the discount can only be used in a connection with a " +
@@ -613,6 +619,21 @@ func unmarshallCartDiscountStackingMode(d *schema.ResourceData) (platform.Stacki
 	default:
 		return "", fmt.Errorf("stacking mode %s not implemented", d.Get("stacking_mode").(string))
 	}
+}
+
+func compareCartDiscountValidDates(old, new string) bool {
+	if old == "" && new == "" {
+		return false
+	}
+	oldDate, err := unmarshallTime(old)
+	if err != nil {
+		return true
+	}
+	newDate, err := unmarshallTime(new)
+	if err != nil {
+		return true
+	}
+	return oldDate.Unix() == newDate.Unix()
 }
 
 func resourceCartDiscountResourceV0() *schema.Resource {


### PR DESCRIPTION
`validFrom` and `validUntil` attributes should be set to an RFC3339 formatted date string according to the [docs](https://docs.commercetools.com/api/types#datetime).

Given date example is `2022-10-02T15:04:05.000Z` But dates without trailing zeroes are also valid (`2022-10-02T15:04:05Z`).

The problem is Go removes trailing zeroes while parsing them so both dates are same, with zeroes or not. In our case the exact string is saved to the state. So the comparison always yields false if you used trailing zeroes.

As a remedy, I included a diff check which simply decodes the old and new dates with the existing unmarshal function and compares their Unix seconds to make sure they are not same.
