### PR TITLE
project_settings: Fix shipping_rate_input_type marshaling

### DIFF
--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -485,15 +485,16 @@ func marshallProjectSearchIndexOrders(val *platform.SearchIndexingConfiguration)
 }
 
 func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) string {
-	switch val.(type) {
-	case platform.CartScoreType:
-		return "CartScore"
-	case platform.CartValueType:
-		return "CartValue"
-	case platform.CartClassificationType:
-		return "CartClassification"
+	var s string
+	if data, ok := val.(map[string]interface{}); ok {
+		s, ok = data["type"].(string)
+		if !ok {
+			return ""
+		}
+	} else {
+		return ""
 	}
-	return ""
+	return s
 }
 
 func marshallProjectMessages(val platform.MessagesConfiguration, d *schema.ResourceData) []map[string]interface{} {

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/labd/commercetools-go-sdk/platform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,7 +77,7 @@ func TestAccProjectCreate_basic(t *testing.T) {
 						assert.EqualValues(t, result.Languages, []string{"nl", "de", "en", "en-US"})
 						assert.EqualValues(t, result.Currencies, []string{"EUR", "USD"})
 						assert.Equal(t, *result.Carts.DeleteDaysAfterLastModification, 7)
-						assert.Equal(t, result.ShippingRateInputType, platform.CartValueType(platform.CartValueType{}))
+						assert.Equal(t, result.ShippingRateInputType, map[string]interface{}{"type": "CartValue"})
 						return nil
 					},
 				),


### PR DESCRIPTION
It appears the type switch in here doesn't work correctly with `ShippingRateInputTypes`. To fix this, I used `map[string]interface{}` for type assertion (as in the SDK) and just returned the value in type attribute if it exists, otherwise an empty string.