### PR TITLE
project_settings: Revert computed optionals change

### DIFF
--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -45,27 +45,23 @@ func resourceProjectSettings() *schema.Resource {
 				Description: "The name of the project",
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 			},
 			"currencies": {
 				Description: "A three-digit currency code as per [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)",
 				Type:        schema.TypeList,
 				Optional:    true,
-				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"countries": {
 				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
 				Type:        schema.TypeList,
 				Optional:    true,
-				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"languages": {
 				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
 				Type:        schema.TypeList,
 				Optional:    true,
-				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"messages": {
@@ -117,7 +113,6 @@ func resourceProjectSettings() *schema.Resource {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
-				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"country_tax_rate_fallback_enabled": {


### PR DESCRIPTION
I think this change may create a lot of confusion so I decided to revert it.

It sounded like a good idea at first since there can be only one type of `project_settings` resource with some required defaults, but this is not how Terraform users usually work with resources such as this one.

To my knowledge there is no distinction between singleton resources and others. In the ideal workflow you want to manually run `terraform import` to fill in the resource details and you expect to see changes on your plan if an optional attribute is not specified in the config, whether it is singleton or not.

This PR reverts #212 only. But on top of it I'd suggest making these default attributes required, since deleting them (or not specifying them without `Computed: true`) will have no effect and raises an error.

