### PR TITLE
project_settings: Allow setting case-insensitive language, currency and language codes

### DIFF
--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -278,21 +278,21 @@ func projectUpdate(ctx context.Context, d *schema.ResourceData, client *platform
 	}
 
 	if d.HasChange("currencies") {
-		newCurrencies := getStringSlice(d, "currencies")
+		newCurrencies := upperStringSlice(getStringSlice(d, "currencies"))
 		input.Actions = append(
 			input.Actions,
 			&platform.ProjectChangeCurrenciesAction{Currencies: newCurrencies})
 	}
 
 	if d.HasChange("countries") {
-		newCountries := getStringSlice(d, "countries")
+		newCountries := upperStringSlice(getStringSlice(d, "countries"))
 		input.Actions = append(
 			input.Actions,
 			&platform.ProjectChangeCountriesAction{Countries: newCountries})
 	}
 
 	if d.HasChange("languages") {
-		newLanguages := getStringSlice(d, "languages")
+		newLanguages := languageCodeSlice(getStringSlice(d, "languages"))
 		input.Actions = append(
 			input.Actions,
 			&platform.ProjectChangeLanguagesAction{Languages: newLanguages})

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -53,6 +54,9 @@ func resourceProjectSettings() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"countries": {
 				Description: "A two-digit country code as per [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)",
@@ -60,6 +64,9 @@ func resourceProjectSettings() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"languages": {
 				Description: "[IETF Language Tag](https://en.wikipedia.org/wiki/IETF_language_tag)",
@@ -67,6 +74,9 @@ func resourceProjectSettings() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"messages": {
 				Description: "[Messages Configuration](https://docs.commercetools.com/api/projects/project#messages-configuration)",

--- a/commercetools/resource_project_test.go
+++ b/commercetools/resource_project_test.go
@@ -257,9 +257,9 @@ func testAccProjectConfigUpdate() string {
 	return `
 		resource "commercetools_project_settings" "acctest_project_settings" {
 			name       = "Test this thing new"
-			countries  = ["NL", "DE", "US", "GB"]
-			currencies = ["EUR", "USD", "GBP"]
-			languages  = ["nl", "de", "en", "en-US", "fr"]
+			countries  = ["nL", "De", "us", "gb"]
+			currencies = ["Eur", "UsD", "GbP"]
+			languages  = ["NL", "dE", "en", "eN-uS", "Fr"]
 			external_oauth {
 				url = "https://new-example.com/oauth/token"
 				authorization_header = "Bearer new-secret"

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -357,3 +357,33 @@ var validateLocalizedStringKey = validation.MapKeyMatch(
 	regexp.MustCompile("^[a-z]{2}(-[A-Z]{2})?$"),
 	"Locale keys must match pattern ^[a-z]{2}(-[A-Z]{2})?$",
 )
+
+func upperStringSlice(items []string) []string {
+	s := make([]string, len(items))
+	for i, v := range items {
+		s[i] = strings.ToUpper(v)
+	}
+	return s
+}
+
+// languageCode converts an IETF language tag with mixed casing into the case-sensitive format.
+// The original item is returned if the given input is not valid.
+func languageCode(s string) string {
+	if len(s) == 2 {
+		return strings.ToLower(s)
+	}
+	parts := strings.Split(s, "-")
+	if len(parts) == 2 {
+		return strings.Join([]string{strings.ToLower(parts[0]), strings.ToUpper(parts[1])}, "-")
+	}
+	// fallback to the original
+	return s
+}
+
+func languageCodeSlice(items []string) []string {
+	codes := make([]string, len(items))
+	for i, code := range items {
+		codes[i] = languageCode(code)
+	}
+	return codes
+}


### PR DESCRIPTION
This change adds support for automatically handling mixed-case languages, currencies & countries

These attributes has to be set in a specific format, otherwise we receive a 400 error from CT. We can use [DiffSupressFunc](https://www.terraform.io/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc) to  automatically handle mixed-case codes as long as the format is correct. I added a case-insensitive string equality check on `currencies`, `languages` and `countries` attributes. This prevents mixed-case codes (such as `nL-Nl` language tag) from triggering an update. So users can use mixed-case letters, but during the apply these are converted into the stricter case-sensitive format.