### PR TITLE
cart_discount: Fix valid dates check

### DIFF
--- a/commercetools/resource_cart_discount.go
+++ b/commercetools/resource_cart_discount.go
@@ -156,14 +156,14 @@ func resourceCartDiscount() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return compareCartDiscountValidDates(old, new)
+					return compareDateString(old, new)
 				},
 			},
 			"valid_until": {
 				Type:     schema.TypeString,
 				Optional: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return compareCartDiscountValidDates(old, new)
+					return compareDateString(old, new)
 				},
 			},
 			"requires_discount_code": {
@@ -623,21 +623,6 @@ func unmarshallCartDiscountStackingMode(d *schema.ResourceData) (platform.Stacki
 	default:
 		return "", fmt.Errorf("stacking mode %s not implemented", d.Get("stacking_mode").(string))
 	}
-}
-
-func compareCartDiscountValidDates(old, new string) bool {
-	if old == "" && new == "" {
-		return false
-	}
-	oldDate, err := unmarshallTime(old)
-	if err != nil {
-		return true
-	}
-	newDate, err := unmarshallTime(new)
-	if err != nil {
-		return true
-	}
-	return oldDate.Unix() == newDate.Unix()
 }
 
 func resourceCartDiscountResourceV0() *schema.Resource {

--- a/commercetools/resource_cart_discount.go
+++ b/commercetools/resource_cart_discount.go
@@ -153,18 +153,14 @@ func resourceCartDiscount() *schema.Resource {
 				Default:     true,
 			},
 			"valid_from": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return compareDateString(old, new)
-				},
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressDateString,
 			},
 			"valid_until": {
-				Type:     schema.TypeString,
-				Optional: true,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return compareDateString(old, new)
-				},
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressDateString,
 			},
 			"requires_discount_code": {
 				Description: "States whether the discount can only be used in a connection with a " +
@@ -735,12 +731,14 @@ func resourceCartDiscountResourceV0() *schema.Resource {
 				Default:     true,
 			},
 			"valid_from": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressDateString,
 			},
 			"valid_until": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressDateString,
 			},
 			"requires_discount_code": {
 				Description: "States whether the discount can only be used in a connection with a " +

--- a/commercetools/resource_discount_code.go
+++ b/commercetools/resource_discount_code.go
@@ -44,14 +44,16 @@ func resourceDiscountCode() *schema.Resource {
 				Required: true,
 			},
 			"valid_from": {
-				Description: "The time from which the discount can be applied on a cart. Before that time the code is invalid",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "The time from which the discount can be applied on a cart. Before that time the code is invalid",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressDateString,
 			},
 			"valid_until": {
-				Description: "The time until the discount can be applied on a cart. After that time the code is invalid",
-				Type:        schema.TypeString,
-				Optional:    true,
+				Description:      "The time until the discount can be applied on a cart. After that time the code is invalid",
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: diffSuppressDateString,
 			},
 			"is_active": {
 				Type:     schema.TypeBool,

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -402,3 +402,7 @@ func compareDateString(a, b string) bool {
 	}
 	return da.Unix() == db.Unix()
 }
+
+func diffSuppressDateString(k, old, new string, d *schema.ResourceData) bool {
+	return compareDateString(old, new)
+}

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -387,3 +387,18 @@ func languageCodeSlice(items []string) []string {
 	}
 	return codes
 }
+
+func compareDateString(a, b string) bool {
+	if a == b {
+		return true
+	}
+	da, err := unmarshallTime(a)
+	if err != nil {
+		return false
+	}
+	db, err := unmarshallTime(b)
+	if err != nil {
+		return false
+	}
+	return da.Unix() == db.Unix()
+}

--- a/commercetools/utils_test.go
+++ b/commercetools/utils_test.go
@@ -27,6 +27,36 @@ func TestCreateLookup(t *testing.T) {
 	}
 }
 
+func TestCompareDateString(t *testing.T) {
+	type testCase struct {
+		a        string
+		b        string
+		expected bool
+	}
+
+	testCases := []testCase{
+		{"2018-01-02T15:04:05.000Z", "2018-01-02T15:04:05.000Z", true},
+		{"2017-03-04T10:01:02.000Z", "2018-01-02T15:04:05.000Z", false},
+		{"2018-01-02T15:04:05.000Z", "2018-01-02T15:04:05Z", true},
+		{"2018-01-02T15:04:05Z", "2018-01-02T15:04:05Z", true},
+		{"2018-01-02T15:04:05Z", "2018-01-02T15:04:05.999Z", true},
+		{"2018-01-02T15:04:04Z", "2018-01-02T15:04:05Z", false},
+		{"2018-01-02T15:06:04Z", "2018-01-02T15:04:05.999Z", false},
+		{"", "2018-01-02T15:04:05.999Z", false},
+		{"", "xxx", false},
+		{"", "", true},
+	}
+
+	var res bool
+	for _, tt := range testCases {
+		res = compareDateString(tt.a, tt.b)
+		if res != tt.expected {
+			t.Errorf("expected %v, got %v", tt.expected, res)
+		}
+	}
+
+}
+
 func checkApiResult(err error) error {
 	switch v := err.(type) {
 	case platform.GenericRequestError:


### PR DESCRIPTION
- If two dates are same as a string, suppress the change.
- Retain if one of them could not be parsed.
- Finally, compare the Unix seconds.

To test it, I simply added trailing zeroes to `valid_from` and `valid_to` attributes in the cart_discount test update config. 