### PR TITLE
Fix empty keys being set during resource creation

### DIFF
--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -139,10 +139,14 @@ func resourceAPIExtensionCreate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	draft := platform.ExtensionDraft{
-		Key:         stringRef(d.Get("key")),
 		Destination: destination,
 		Triggers:    triggers,
 		TimeoutInMs: intRef(d.Get("timeout_in_ms")),
+	}
+
+	key := stringRef(d.Get("key"))
+	if *key != "" {
+		draft.Key = key
 	}
 
 	err = resource.RetryContext(ctx, 20*time.Second, func() *resource.RetryError {

--- a/commercetools/resource_cart_discount.go
+++ b/commercetools/resource_cart_discount.go
@@ -244,7 +244,6 @@ func resourceCartDiscountCreate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	draft := platform.CartDiscountDraft{
-		Key:                  stringRef(d.Get("key")),
 		Name:                 name,
 		Description:          &description,
 		Value:                &value,
@@ -253,6 +252,11 @@ func resourceCartDiscountCreate(ctx context.Context, d *schema.ResourceData, m i
 		IsActive:             boolRef(d.Get("is_active")),
 		RequiresDiscountCode: ctutils.BoolRef(d.Get("requires_discount_code").(bool)),
 		StackingMode:         &stackingMode,
+	}
+
+	key := stringRef(d.Get("key"))
+	if *key != "" {
+		draft.Key = key
 	}
 
 	if val, err := unmarshallCartDiscountTarget(d); err == nil {

--- a/commercetools/resource_customer_group.go
+++ b/commercetools/resource_customer_group.go
@@ -48,7 +48,11 @@ func resourceCustomerGroupCreate(ctx context.Context, d *schema.ResourceData, m 
 
 	draft := platform.CustomerGroupDraft{
 		GroupName: d.Get("name").(string),
-		Key:       stringRef(d.Get("key")),
+	}
+
+	key := stringRef(d.Get("key"))
+	if *key != "" {
+		draft.Key = key
 	}
 
 	errorResponse := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {

--- a/commercetools/resource_product_type.go
+++ b/commercetools/resource_product_type.go
@@ -229,10 +229,14 @@ func resourceProductTypeCreate(ctx context.Context, d *schema.ResourceData, m in
 	}
 
 	draft := platform.ProductTypeDraft{
-		Key:         stringRef(d.Get("key")),
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 		Attributes:  attributes,
+	}
+
+	key := stringRef(d.Get("key"))
+	if *key != "" {
+		draft.Key = key
 	}
 
 	err = resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {

--- a/commercetools/resource_shipping_method.go
+++ b/commercetools/resource_shipping_method.go
@@ -77,13 +77,17 @@ func resourceShippingMethodCreate(ctx context.Context, d *schema.ResourceData, m
 	localizedDescription := unmarshallLocalizedString(d.Get("localized_description"))
 
 	draft := platform.ShippingMethodDraft{
-		Key:                  stringRef(d.Get("key")),
 		Name:                 d.Get("name").(string),
 		Description:          stringRef(d.Get("description")),
 		LocalizedDescription: &localizedDescription,
 		IsDefault:            d.Get("is_default").(bool),
 		TaxCategory:          taxCategory,
 		Predicate:            stringRef(d.Get("predicate")),
+	}
+
+	key := stringRef(d.Get("key"))
+	if *key != "" {
+		draft.Key = key
 	}
 
 	err := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {

--- a/commercetools/resource_shipping_zone.go
+++ b/commercetools/resource_shipping_zone.go
@@ -71,10 +71,14 @@ func resourceShippingZoneCreate(ctx context.Context, d *schema.ResourceData, m i
 	locations := unmarshallShippingZoneLocations(input)
 
 	draft := platform.ZoneDraft{
-		Key:         stringRef(d.Get("key")),
 		Name:        d.Get("name").(string),
 		Description: stringRef(d.Get("description")),
 		Locations:   locations,
+	}
+
+	key := stringRef(d.Get("key"))
+	if *key != "" {
+		draft.Key = key
 	}
 
 	err := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {

--- a/commercetools/resource_tax_category.go
+++ b/commercetools/resource_tax_category.go
@@ -50,10 +50,14 @@ func resourceTaxCategoryCreate(ctx context.Context, d *schema.ResourceData, m in
 	emptyTaxRates := []platform.TaxRateDraft{}
 
 	draft := platform.TaxCategoryDraft{
-		Key:         stringRef(d.Get("key")),
 		Name:        d.Get("name").(string),
 		Description: stringRef(d.Get("description")),
 		Rates:       emptyTaxRates,
+	}
+
+	key := stringRef(d.Get("key"))
+	if *key != "" {
+		draft.Key = key
 	}
 
 	err := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {


### PR DESCRIPTION
Previously this was fixed only for the category resource. (#215)

>`key` is optional but it is still being sent as an empty string when not set. This causes the CT API to respond with an error because of the empty key. This change prevents the `key` from being included in the create request when not set.

This PR fixes the issue for all other affected resource types.

### Affected resources

* `cart_discount`
* `customer_group`
* `product_type`
* `shipping_method`
* `shipping_zone`
* `tax_category`
