### PR TITLE
shipping_zone: Make name attribute required

### DIFF
--- a/commercetools/resource_shipping_zone.go
+++ b/commercetools/resource_shipping_zone.go
@@ -23,7 +23,7 @@ func resourceShippingZone() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
`ZoneDraft` type doesn't specify `name` attribute as pointer:

```go
type ZoneDraft struct {
	// User-defined unique identifier for the Zone.
	Key *string `json:"key,omitempty"`
	// Name of the Zone.
	Name string `json:"name"`
	// Description of the Zone.
	Description *string `json:"description,omitempty"`
}
```

This causes plan to fail, `name` is serialised into empty string when not set.

I assume `Name string` implies that it is not optional, but the [REST API docs](https://docs.commercetools.com/api/projects/zones#create-zone) says the otherwise. Regardless, I removed the optional flag and added required since we depend on the SDK as the primary spec.