### PR TITLE
category: Add support for external_id attribute

### DIFF
--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -64,6 +64,11 @@ func resourceCategory() *schema.Resource {
 				Optional:    true,
 				Description: "An attribute as base for a custom category order in one level, filled with random value when left empty",
 			},
+			"external_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "",
+			},
 			"meta_title": {
 				Type:             TypeLocalizedString,
 				ValidateDiagFunc: validateLocalizedStringKey,
@@ -211,6 +216,10 @@ func resourceCategoryCreate(ctx context.Context, d *schema.ResourceData, m inter
 		draft.Assets = assets
 	}
 
+	if d.Get("external_id").(string) != "" {
+		draft.ExternalId = stringRef(d.Get("external_id"))
+	}
+
 	err := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
 		var err error
 
@@ -268,6 +277,7 @@ func resourceCategoryRead(ctx context.Context, d *schema.ResourceData, m interfa
 			d.Set("parent", "")
 		}
 		d.Set("order_hint", category.OrderHint)
+		d.Set("external_id", category.ExternalId)
 		if category.Description != nil {
 			d.Set("description", *category.Description)
 		}
@@ -326,6 +336,13 @@ func resourceCategoryUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		input.Actions = append(
 			input.Actions,
 			&platform.CategoryChangeOrderHintAction{OrderHint: newVal})
+	}
+
+	if d.HasChange("external_id") {
+		newExternalID := d.Get("external_id").(string)
+		input.Actions = append(
+			input.Actions,
+			&platform.CategorySetExternalIdAction{ExternalId: &newExternalID})
 	}
 
 	if d.HasChange("description") {
@@ -585,6 +602,11 @@ func resourceCategoryResourceV0() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "An attribute as base for a custom category order in one level, filled with random value when left empty",
+			},
+			"external_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "",
 			},
 			"meta_title": {
 				Type:             TypeLocalizedString,

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -42,6 +42,9 @@ func TestAccCategoryCreate_basic(t *testing.T) {
 						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
 					),
 					resource.TestCheckResourceAttr(
+						"commercetools_category.accessories", "external_id", "some external id",
+					),
+					resource.TestCheckResourceAttr(
 						"commercetools_category.accessories", "meta_title.en", "meta text",
 					),
 					resource.TestCheckResourceAttr(
@@ -83,6 +86,9 @@ func TestAccCategoryCreate_basic(t *testing.T) {
 						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
 					),
 					resource.TestCheckResourceAttr(
+						"commercetools_category.accessories", "external_id", "some external id",
+					),
+					resource.TestCheckResourceAttr(
 						"commercetools_category.accessories", "meta_title.en", "updated meta text",
 					),
 					resource.TestCheckResourceAttr(
@@ -122,6 +128,9 @@ func TestAccCategoryCreate_basic(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_category.accessories", "order_hint", "0.000016143365484621617765232",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_category.accessories", "external_id", "some external id",
 					),
 					resource.TestCheckNoResourceAttr(
 						"commercetools_category.accessories", "meta_title",
@@ -179,6 +188,7 @@ func testAccCategoryConfig() string {
 			en = "accessories"
 		}
 		order_hint = "0.000016143365484621617765232"
+		external_id = "some external id"
 		meta_title = {
 			en = "meta text"
 		}
@@ -243,6 +253,7 @@ func testAccCategoryUpdate() string {
 			en = "accessories_updated"
 		}
 		order_hint = "0.000016143365484621617765232"
+		external_id = "some external id"
 		meta_title = {
 			en = "updated meta text"
 		}
@@ -303,6 +314,7 @@ func testAccCategoryRemoveProperties() string {
 			en = "accessories_updated"
 		}
 		order_hint = "0.000016143365484621617765232"
+		external_id = "some external id"
 	}  `
 }
 


### PR DESCRIPTION
Allow setting `external_id`

* https://docs.commercetools.com/api/projects/categories#categorydraft
