### PR TITLE
type: Do not set field ordering when new fields are added at the bottom

### DIFF
--- a/commercetools/resource_type.go
+++ b/commercetools/resource_type.go
@@ -470,7 +470,7 @@ func resourceTypeFieldChangeActions(oldValues []interface{}, newValues []interfa
 		newNames[i] = v["name"].(string)
 	}
 
-	if checkAttributeOrder && !reflect.DeepEqual(oldNames, newNames) {
+	if checkAttributeOrder && !reflect.DeepEqual(oldNames, newNames[:len(oldNames)]) {
 		log.Printf("[DEBUG] Field ordering: %s", newNames)
 
 		actions = append(


### PR DESCRIPTION
Fixes #234 

If the ordering of fields has not changed while updating a type resource, the CT returns `400 'fieldDefinitions' has not changed` error. Because of this, we simply can't add a new field.

## Change
Make sure the old field names and the new ones have the same length while making deep equality check. Newly added fields should never add `changeFieldOrdering` action (which is the cause of the error) unless they are specified at the top.