### PR TITLE
Fix attribute checks in tests

### DIFF
--- a/commercetools/resource_cart_discount_test.go
+++ b/commercetools/resource_cart_discount_test.go
@@ -123,7 +123,7 @@ func TestAccCartDiscountCreate_basic(t *testing.T) {
 						"commercetools_cart_discount.standard", "name.en", "standard name",
 					),
 					resource.TestCheckNoResourceAttr(
-						"commercetools_cart_discount.standard", "description",
+						"commercetools_cart_discount.standard", "description.en",
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_cart_discount.standard", "sort_order", "0.8",

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -54,6 +54,9 @@ func TestAccCategoryCreate_basic(t *testing.T) {
 						"commercetools_category.accessories", "meta_keywords.en", "keywords",
 					),
 					resource.TestCheckResourceAttr(
+						"commercetools_category.accessories", "assets.#", "1",
+					),
+					resource.TestCheckResourceAttr(
 						"commercetools_category.accessories", "assets.0.name.en", "My Product Video",
 					),
 					resource.TestCheckResourceAttr(
@@ -96,6 +99,9 @@ func TestAccCategoryCreate_basic(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_category.accessories", "meta_keywords.en", "keywords, updated",
+					),
+					resource.TestCheckResourceAttr(
+						"commercetools_category.accessories", "assets.#", "1",
 					),
 					resource.TestCheckResourceAttr(
 						"commercetools_category.accessories", "assets.0.name.en", "Updated name",
@@ -141,8 +147,8 @@ func TestAccCategoryCreate_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(
 						"commercetools_category.accessories", "meta_keywords",
 					),
-					resource.TestCheckNoResourceAttr(
-						"commercetools_category.accessories", "assets",
+					resource.TestCheckResourceAttr(
+						"commercetools_category.accessories", "assets.#", "0",
 					),
 				),
 			},


### PR DESCRIPTION
* commercetools_cart_discount.standard: map attribute 'description' must be checked by element count key (description.%) or element value keys (e.g. description.examplekey).
* commercetools_category.accessories: list or set attribute 'assets' must be checked by element count key (assets.#) or element value keys (e.g. assets.0). Set element value checks should use TestCheckTypeSet functions instead.

Not sure if this change is introduced in the latest version of the plugin SDK.

I included a "fix" to assert `list` and `map` attributes at the element level instead.