### PR TITLE
subscription: Add format identifier aliases

### DIFF
--- a/commercetools/resource_subscription.go
+++ b/commercetools/resource_subscription.go
@@ -311,11 +311,15 @@ func resourceSubscriptionCreate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	draft := platform.SubscriptionDraft{
-		Key:         stringRef(d.Get("key")),
 		Destination: destination,
 		Format:      &format,
 		Messages:    messages,
 		Changes:     changes,
+	}
+
+	key := stringRef(d.Get("key"))
+	if *key != "" {
+		draft.Key = key
 	}
 
 	err = resource.RetryContext(ctx, 20*time.Second, func() *resource.RetryError {

--- a/commercetools/resource_subscription.go
+++ b/commercetools/resource_subscription.go
@@ -17,20 +17,20 @@ const (
 	// Destinations
 	subSQS                  = "SQS"
 	subSNS                  = "SNS"
-	subEventBridge          = "event_bridge"
-	subEventBridgeAlias     = "EventBridge"
-	subAzureEventGrid       = "azure_eventgrid"
-	subAzureEventGridAlias  = "EventGrid"
-	subAzureServiceBus      = "azure_servicebus"
-	subAzureServiceBusAlias = "AzureServiceBus"
-	subGooglePubSub         = "google_pubsub"
-	subGooglePubSubAlias    = "GoogleCloudPubSub"
+	subEventBridge          = "EventBridge"
+	subEventBridgeAlias     = "event_bridge"
+	subAzureEventGrid       = "EventGrid"
+	subAzureEventGridAlias  = "azure_eventgrid"
+	subAzureServiceBus      = "AzureServiceBus"
+	subAzureServiceBusAlias = "azure_servicebus"
+	subGooglePubSub         = "GoogleCloudPubSub"
+	subGooglePubSubAlias    = "google_pubsub"
 
 	// Formats
-	cloudEvents      = "cloud_events"
-	cloudEventsAlias = "CloudEvents"
-	fmtPlatform      = "platform"
-	fmtPlatformAlias = "Platform"
+	cloudEvents      = "CloudEvents"
+	cloudEventsAlias = "cloud_events"
+	fmtPlatform      = "Platform"
+	fmtPlatformAlias = "platform"
 )
 
 var destinationFields = map[string][]string{

--- a/commercetools/resource_subscription.go
+++ b/commercetools/resource_subscription.go
@@ -122,24 +122,31 @@ func resourceSubscription() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: func(d interface{}, v string) ([]string, []error) {
+								allowedAliases := []string{
+									subEventBridgeAlias,
+									subAzureEventGridAlias,
+									subAzureServiceBusAlias,
+									subGooglePubSubAlias,
+								}
+
 								allowed := []string{
 									subSQS,
 									subSNS,
 									subEventBridge,
-									subEventBridgeAlias,
 									subAzureEventGrid,
-									subAzureEventGridAlias,
 									subAzureServiceBus,
-									subAzureServiceBusAlias,
 									subGooglePubSub,
-									subGooglePubSubAlias,
 								}
 
 								if !stringInSlice(d.(string), allowed) {
-									return []string{}, []error{
-										fmt.Errorf("invalid destination type %s. Accepted are %s",
-											d.(string), strings.Join(allowed, ", "),
-										),
+									if !stringInSlice(d.(string), allowedAliases) {
+										return []string{}, []error{
+											fmt.Errorf("invalid destination type: %s. Accepted values are %s",
+												d.(string), strings.Join(allowed, ", "),
+											),
+										}
+									} else {
+										return []string{fmt.Sprintf("Deprecated destination type: %s. Replace with %s.", d.(string), destinationFieldAliases[d.(string)])}, nil
 									}
 								}
 

--- a/commercetools/resource_subscription.go
+++ b/commercetools/resource_subscription.go
@@ -226,12 +226,13 @@ func resourceSubscription() *schema.Resource {
 				Optional: true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if k == "format.#" && old == "1" && new == "0" {
-						fmt := d.Get("format.0.type").(string)
-						if strings.ToLower(fmt) == "platform" {
+						fmt := strings.ToLower(d.Get("format.0.type").(string))
+						if fmt == fmtPlatformAlias || fmt == fmtPlatform {
 							return true
 						}
 					}
-					if k == "format.0.type" && strings.ToLower(old) == "platform" && new == "" {
+					old = strings.ToLower(old)
+					if k == "format.0.type" && (old == fmtPlatformAlias || old == fmtPlatform) && new == "" {
 						return true
 					}
 

--- a/commercetools/resource_subscription.go
+++ b/commercetools/resource_subscription.go
@@ -680,21 +680,21 @@ func validateFormat(d *schema.ResourceData) error {
 		return nil
 	}
 
-	dst := input[0].(map[string]interface{})
+	format := input[0].(map[string]interface{})
 
-	dstType := dst["type"].(string)
+	formatType := format["type"].(string)
 
-	if dstTypeAlias, ok := formatFieldAliases[dstType]; ok {
-		dstType = dstTypeAlias
+	if formatTypeAlias, ok := formatFieldAliases[formatType]; ok {
+		formatType = formatTypeAlias
 	}
 
-	requiredFields, ok := formatFields[dstType]
+	requiredFields, ok := formatFields[formatType]
 	if !ok {
-		return fmt.Errorf("invalid type for format: '%v'", dstType)
+		return fmt.Errorf("invalid type for format: '%v'", formatType)
 	}
 
 	for _, field := range requiredFields {
-		value, ok := dst[field].(string)
+		value, ok := format[field].(string)
 		if !ok {
 			return fmt.Errorf("required property '%v' missing", field)
 		} else if len(value) == 0 {

--- a/commercetools/resource_subscription_test.go
+++ b/commercetools/resource_subscription_test.go
@@ -138,6 +138,10 @@ resource "commercetools_subscription" "subscription_%[1]s" {
 		region        = "eu-west-1"
 	}
 
+	format {
+		type = "Platform"
+	}
+
 	changes {
 		resource_type_ids = ["customer"]
 	}


### PR DESCRIPTION
Closes #245 #247 

(This PR is forked from pr #252 which adds the same feature for `destination` field types.)