### PR TITLE
Use the flatten & expand naming convention

### DIFF
--- a/commercetools/marshalling.go
+++ b/commercetools/marshalling.go
@@ -6,18 +6,18 @@ import (
 	"github.com/labd/commercetools-go-sdk/platform"
 )
 
-func marshallTime(val *time.Time) string {
+func flattenTime(val *time.Time) string {
 	if val == nil {
 		return ""
 	}
 	return val.Format(time.RFC3339)
 }
 
-func unmarshallTime(input string) (time.Time, error) {
+func expandTime(input string) (time.Time, error) {
 	return time.Parse(time.RFC3339, input)
 }
 
-func marshallTypedMoney(val platform.TypedMoney) map[string]interface{} {
+func flattenTypedMoney(val platform.TypedMoney) map[string]interface{} {
 	switch v := val.(type) {
 	case platform.HighPrecisionMoney:
 		return map[string]interface{}{
@@ -33,7 +33,7 @@ func marshallTypedMoney(val platform.TypedMoney) map[string]interface{} {
 	panic("Unknown money type")
 }
 
-func unmarshallTypedMoney(d map[string]interface{}) []platform.Money {
+func expandTypedMoney(d map[string]interface{}) []platform.Money {
 	input := d["money"].([]interface{})
 	var result []platform.Money
 
@@ -50,7 +50,7 @@ func unmarshallTypedMoney(d map[string]interface{}) []platform.Money {
 	return result
 }
 
-func unmarshallLocalizedString(val interface{}) platform.LocalizedString {
+func expandLocalizedString(val interface{}) platform.LocalizedString {
 	values, ok := val.(map[string]interface{})
 	if !ok {
 		return platform.LocalizedString{}

--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -147,8 +147,8 @@ func validateExtensionDestination(draft platform.ExtensionDraft) error {
 func resourceAPIExtensionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := getClient(m)
 
-	triggers := unmarshallExtensionTriggers(d)
-	destination, err := unmarshallExtensionDestination(d)
+	triggers := expandExtensionTriggers(d)
+	destination, err := expandExtensionDestination(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -215,8 +215,8 @@ func resourceAPIExtensionRead(ctx context.Context, d *schema.ResourceData, m int
 
 		d.Set("version", extension.Version)
 		d.Set("key", extension.Key)
-		d.Set("destination", marshallExtensionDestination(extension.Destination, d))
-		d.Set("trigger", marshallExtensionTriggers(extension.Triggers))
+		d.Set("destination", flattenExtensionDestination(extension.Destination, d))
+		d.Set("trigger", flattenExtensionTriggers(extension.Triggers))
 		d.Set("timeout_in_ms", extension.TimeoutInMs)
 	}
 	return nil
@@ -238,14 +238,14 @@ func resourceAPIExtensionUpdate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	if d.HasChange("trigger") {
-		triggers := unmarshallExtensionTriggers(d)
+		triggers := expandExtensionTriggers(d)
 		input.Actions = append(
 			input.Actions,
 			&platform.ExtensionChangeTriggersAction{Triggers: triggers})
 	}
 
 	if d.HasChange("destination") {
-		destination, err := unmarshallExtensionDestination(d)
+		destination, err := expandExtensionDestination(d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -287,7 +287,7 @@ func resourceAPIExtensionDelete(ctx context.Context, d *schema.ResourceData, m i
 // Helper methods
 //
 
-func unmarshallExtensionDestination(d *schema.ResourceData) (platform.Destination, error) {
+func expandExtensionDestination(d *schema.ResourceData) (platform.Destination, error) {
 	input, err := elementFromList(d, "destination")
 	if err != nil {
 		return nil, err
@@ -295,7 +295,7 @@ func unmarshallExtensionDestination(d *schema.ResourceData) (platform.Destinatio
 
 	switch strings.ToLower(input["type"].(string)) {
 	case "http":
-		auth, err := unmarshallExtensionDestinationAuthentication(input)
+		auth, err := expandExtensionDestinationAuthentication(input)
 		if err != nil {
 			return nil, err
 		}
@@ -315,7 +315,7 @@ func unmarshallExtensionDestination(d *schema.ResourceData) (platform.Destinatio
 	}
 }
 
-func unmarshallExtensionDestinationAuthentication(destInput map[string]interface{}) (platform.HttpDestinationAuthentication, error) {
+func expandExtensionDestinationAuthentication(destInput map[string]interface{}) (platform.HttpDestinationAuthentication, error) {
 	authKeys := [2]string{"authorization_header", "azure_authentication"}
 	count := 0
 	for _, key := range authKeys {
@@ -344,7 +344,7 @@ func unmarshallExtensionDestinationAuthentication(destInput map[string]interface
 	return nil, nil
 }
 
-func marshallExtensionDestination(dst platform.Destination, d *schema.ResourceData) []map[string]string {
+func flattenExtensionDestination(dst platform.Destination, d *schema.ResourceData) []map[string]string {
 
 	switch v := dst.(type) {
 	case platform.HttpDestination:
@@ -375,7 +375,7 @@ func marshallExtensionDestination(dst platform.Destination, d *schema.ResourceDa
 		// the resource.
 		if !d.GetRawState().GetAttr("version").IsNull() {
 			// Read the access secret from the current resource data
-			c, _ := unmarshallExtensionDestination(d)
+			c, _ := expandExtensionDestination(d)
 			switch current := c.(type) {
 			case platform.AWSLambdaDestination:
 				accessSecret = current.AccessSecret
@@ -393,7 +393,7 @@ func marshallExtensionDestination(dst platform.Destination, d *schema.ResourceDa
 	return []map[string]string{}
 }
 
-func marshallExtensionTriggers(triggers []platform.ExtensionTrigger) []map[string]interface{} {
+func flattenExtensionTriggers(triggers []platform.ExtensionTrigger) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(triggers))
 
 	for _, t := range triggers {
@@ -406,7 +406,7 @@ func marshallExtensionTriggers(triggers []platform.ExtensionTrigger) []map[strin
 	return result
 }
 
-func unmarshallExtensionTriggers(d *schema.ResourceData) []platform.ExtensionTrigger {
+func expandExtensionTriggers(d *schema.ResourceData) []platform.ExtensionTrigger {
 	input := d.Get("trigger").([]interface{})
 	var result []platform.ExtensionTrigger
 

--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAPIExtensionUnmarshallExtensionDestination(t *testing.T) {
+func TestAPIExtensionExpandExtensionDestination(t *testing.T) {
 	rawDestination := map[string]interface{}{
 		"type":          "AWSLambda",
 		"arn":           "arn:aws:lambda:eu-west-1:111111111:function:api_extensions",
@@ -38,7 +38,7 @@ func TestAPIExtensionUnmarshallExtensionDestination(t *testing.T) {
 	}
 
 	d := schema.TestResourceDataRaw(t, resourceAPIExtension().Schema, resourceDataMap)
-	destination, _ := unmarshallExtensionDestination(d)
+	destination, _ := expandExtensionDestination(d)
 	lambdaDestination, ok := destination.(platform.AWSLambdaDestination)
 
 	assert.True(t, ok)
@@ -47,13 +47,13 @@ func TestAPIExtensionUnmarshallExtensionDestination(t *testing.T) {
 	assert.Equal(t, lambdaDestination.AccessSecret, "****abc/")
 }
 
-func TestAPIExtensionUnmarshallExtensionDestinationAuthentication(t *testing.T) {
+func TestAPIExtensionExpandExtensionDestinationAuthentication(t *testing.T) {
 	var input = map[string]interface{}{
 		"authorization_header": "12345",
 		"azure_authentication": "AzureKey",
 	}
 
-	auth, err := unmarshallExtensionDestinationAuthentication(input)
+	auth, err := expandExtensionDestinationAuthentication(input)
 	assert.Nil(t, auth)
 	assert.NotNil(t, err)
 
@@ -61,7 +61,7 @@ func TestAPIExtensionUnmarshallExtensionDestinationAuthentication(t *testing.T) 
 		"authorization_header": "12345",
 	}
 
-	auth, err = unmarshallExtensionDestinationAuthentication(input)
+	auth, err = expandExtensionDestinationAuthentication(input)
 	httpAuth, ok := auth.(*platform.AuthorizationHeaderAuthentication)
 	assert.True(t, ok)
 	assert.Equal(t, "12345", httpAuth.HeaderValue)
@@ -69,7 +69,7 @@ func TestAPIExtensionUnmarshallExtensionDestinationAuthentication(t *testing.T) 
 	assert.Nil(t, err)
 }
 
-func TestUnmarshallExtensionTriggers(t *testing.T) {
+func TestExpandExtensionTriggers(t *testing.T) {
 	resourceDataMap := map[string]interface{}{
 		"id":             "2845b936-e407-4f29-957b-f8deb0fcba97",
 		"version":        1,
@@ -86,7 +86,7 @@ func TestUnmarshallExtensionTriggers(t *testing.T) {
 	}
 
 	d := schema.TestResourceDataRaw(t, resourceAPIExtension().Schema, resourceDataMap)
-	triggers := unmarshallExtensionTriggers(d)
+	triggers := expandExtensionTriggers(d)
 
 	assert.Len(t, triggers, 1)
 	assert.Equal(t, triggers[0].ResourceTypeId, platform.ExtensionResourceTypeIdCart)

--- a/commercetools/resource_channel.go
+++ b/commercetools/resource_channel.go
@@ -56,8 +56,8 @@ func resourceChannel() *schema.Resource {
 }
 
 func resourceChannelCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	name := unmarshallLocalizedString(d.Get("name"))
-	description := unmarshallLocalizedString(d.Get("description"))
+	name := expandLocalizedString(d.Get("name"))
+	description := expandLocalizedString(d.Get("description"))
 
 	roles := []platform.ChannelRoleEnum{}
 	for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
@@ -130,14 +130,14 @@ func resourceChannelUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	if d.HasChange("name") {
-		newName := unmarshallLocalizedString(d.Get("name"))
+		newName := expandLocalizedString(d.Get("name"))
 		input.Actions = append(
 			input.Actions,
 			&platform.ChannelChangeNameAction{Name: newName})
 	}
 
 	if d.HasChange("description") {
-		newDescription := unmarshallLocalizedString(d.Get("description"))
+		newDescription := expandLocalizedString(d.Get("description"))
 		input.Actions = append(
 			input.Actions,
 			&platform.ChannelChangeDescriptionAction{Description: newDescription})

--- a/commercetools/resource_custom_object.go
+++ b/commercetools/resource_custom_object.go
@@ -98,7 +98,7 @@ func resourceCustomObjectRead(ctx context.Context, d *schema.ResourceData, m int
 		log.Print(stringFormatObject(customObject))
 		d.Set("container", customObject.Container)
 		d.Set("key", customObject.Key)
-		d.Set("value", marshallCustomObjectValue(customObject))
+		d.Set("value", flattenCustomObjectValue(customObject))
 		d.Set("version", customObject.Version)
 	}
 	return nil
@@ -219,7 +219,7 @@ func _decodeCustomObjectValue(value string) interface{} {
 	return data
 }
 
-func marshallCustomObjectValue(o *platform.CustomObject) string {
+func flattenCustomObjectValue(o *platform.CustomObject) string {
 	val, err := json.Marshal(o.Value)
 	if err != nil {
 		panic(err)

--- a/commercetools/resource_product_type.go
+++ b/commercetools/resource_product_type.go
@@ -661,10 +661,10 @@ func resourceProductTypeGetAttributeDefinition(input map[string]interface{}, dra
 		return nil, err
 	}
 
-	label := unmarshallLocalizedString(input["label"])
+	label := expandLocalizedString(input["label"])
 	var inputTip platform.LocalizedString
 	if inputTipRaw, ok := input["input_tip"]; ok {
-		inputTip = unmarshallLocalizedString(inputTipRaw)
+		inputTip = expandLocalizedString(inputTipRaw)
 	}
 
 	constraint := platform.AttributeConstraintEnumNone
@@ -734,7 +734,7 @@ func getAttributeType(input interface{}) (platform.AttributeType, error) {
 		var values []platform.AttributeLocalizedEnumValue
 		for _, value := range valuesInput.([]interface{}) {
 			v := value.(map[string]interface{})
-			labels := unmarshallLocalizedString(v["label"])
+			labels := expandLocalizedString(v["label"])
 
 			values = append(values, platform.AttributeLocalizedEnumValue{
 				Key:   v["key"].(string),

--- a/commercetools/resource_project.go
+++ b/commercetools/resource_project.go
@@ -236,12 +236,12 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interfac
 	d.Set("currencies", project.Currencies)
 	d.Set("countries", project.Countries)
 	d.Set("languages", project.Languages)
-	d.Set("shipping_rate_input_type", marshallProjectShippingRateInputType(project.ShippingRateInputType))
-	d.Set("enable_search_index_products", marshallProjectSearchIndexProducts(project.SearchIndexing))
-	d.Set("enable_search_index_orders", marshallProjectSearchIndexOrders(project.SearchIndexing))
-	d.Set("external_oauth", marshallProjectExternalOAuth(project.ExternalOAuth, d.Get("external_oauth")))
-	d.Set("carts", marshallProjectCarts(project.Carts))
-	d.Set("messages", marshallProjectMessages(project.Messages, d))
+	d.Set("shipping_rate_input_type", flattenProjectShippingRateInputType(project.ShippingRateInputType))
+	d.Set("enable_search_index_products", flattenProjectSearchIndexProducts(project.SearchIndexing))
+	d.Set("enable_search_index_orders", flattenProjectSearchIndexOrders(project.SearchIndexing))
+	d.Set("external_oauth", flattenProjectExternalOAuth(project.ExternalOAuth, d.Get("external_oauth")))
+	d.Set("carts", flattenProjectCarts(project.Carts))
+	d.Set("messages", flattenProjectMessages(project.Messages, d))
 	return nil
 }
 
@@ -427,7 +427,7 @@ func getCartClassificationValues(d *schema.ResourceData) ([]platform.CustomField
 	data := d.Get("shipping_rate_cart_classification_value").([]interface{})
 	for _, item := range data {
 		itemMap := item.(map[string]interface{})
-		label := unmarshallLocalizedString(itemMap["label"].(map[string]interface{}))
+		label := expandLocalizedString(itemMap["label"].(map[string]interface{}))
 		values = append(values, platform.CustomFieldLocalizedEnumValue{
 			Label: label,
 			Key:   itemMap["key"].(string),
@@ -436,7 +436,7 @@ func getCartClassificationValues(d *schema.ResourceData) ([]platform.CustomField
 	return values, nil
 }
 
-func marshallProjectCarts(val platform.CartsConfiguration) []map[string]interface{} {
+func flattenProjectCarts(val platform.CartsConfiguration) []map[string]interface{} {
 	if !*val.CountryTaxRateFallbackEnabled && val.DeleteDaysAfterLastModification == nil {
 		return []map[string]interface{}{}
 	}
@@ -450,7 +450,7 @@ func marshallProjectCarts(val platform.CartsConfiguration) []map[string]interfac
 	return result
 }
 
-func marshallProjectExternalOAuth(val *platform.ExternalOAuth, current interface{}) []map[string]interface{} {
+func flattenProjectExternalOAuth(val *platform.ExternalOAuth, current interface{}) []map[string]interface{} {
 	if val == nil {
 		return []map[string]interface{}{}
 	}
@@ -472,7 +472,7 @@ func marshallProjectExternalOAuth(val *platform.ExternalOAuth, current interface
 	}
 }
 
-func marshallProjectSearchIndexProducts(val *platform.SearchIndexingConfiguration) bool {
+func flattenProjectSearchIndexProducts(val *platform.SearchIndexingConfiguration) bool {
 	if val == nil {
 		return false
 	}
@@ -483,7 +483,7 @@ func marshallProjectSearchIndexProducts(val *platform.SearchIndexingConfiguratio
 	return false
 }
 
-func marshallProjectSearchIndexOrders(val *platform.SearchIndexingConfiguration) bool {
+func flattenProjectSearchIndexOrders(val *platform.SearchIndexingConfiguration) bool {
 	if val == nil {
 		return false
 	}
@@ -494,7 +494,7 @@ func marshallProjectSearchIndexOrders(val *platform.SearchIndexingConfiguration)
 	return false
 }
 
-func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) string {
+func flattenProjectShippingRateInputType(val platform.ShippingRateInputType) string {
 	switch val.(type) {
 	case platform.CartScoreType:
 		return "CartScore"
@@ -506,7 +506,7 @@ func marshallProjectShippingRateInputType(val platform.ShippingRateInputType) st
 	return ""
 }
 
-func marshallProjectMessages(val platform.MessagesConfiguration, d *schema.ResourceData) []map[string]interface{} {
+func flattenProjectMessages(val platform.MessagesConfiguration, d *schema.ResourceData) []map[string]interface{} {
 	if current, ok := d.Get("messages").([]interface{}); ok {
 		if len(current) == 0 && !val.Enabled {
 			return nil

--- a/commercetools/resource_shipping_method.go
+++ b/commercetools/resource_shipping_method.go
@@ -73,7 +73,7 @@ func resourceShippingMethodCreate(ctx context.Context, d *schema.ResourceData, m
 		taxCategory.ID = stringRef(taxCategoryID)
 	}
 
-	localizedDescription := unmarshallLocalizedString(d.Get("localized_description"))
+	localizedDescription := expandLocalizedString(d.Get("localized_description"))
 
 	draft := platform.ShippingMethodDraft{
 		Name:                 d.Get("name").(string),
@@ -177,7 +177,7 @@ func resourceShippingMethodUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if d.HasChange("localized_description") {
-		newLocalizedDescription := unmarshallLocalizedString(d.Get("localized_description"))
+		newLocalizedDescription := expandLocalizedString(d.Get("localized_description"))
 		input.Actions = append(
 			input.Actions,
 			&platform.ShippingMethodSetLocalizedDescriptionAction{LocalizedDescription: &newLocalizedDescription})

--- a/commercetools/resource_shipping_zone.go
+++ b/commercetools/resource_shipping_zone.go
@@ -66,7 +66,7 @@ func resourceShippingZoneCreate(ctx context.Context, d *schema.ResourceData, m i
 	client := getClient(m)
 
 	input := d.Get("location").([]interface{})
-	locations := unmarshallShippingZoneLocations(input)
+	locations := expandShippingZoneLocations(input)
 
 	draft := platform.ZoneDraft{
 		Name:        d.Get("name").(string),
@@ -121,7 +121,7 @@ func resourceShippingZoneRead(ctx context.Context, d *schema.ResourceData, m int
 		d.Set("key", shippingZone.Key)
 		d.Set("name", shippingZone.Name)
 		d.Set("description", shippingZone.Description)
-		d.Set("location", marshallShippingZoneLocations(shippingZone.Locations))
+		d.Set("location", flattenShippingZoneLocations(shippingZone.Locations))
 	}
 	return nil
 }
@@ -160,8 +160,8 @@ func resourceShippingZoneUpdate(ctx context.Context, d *schema.ResourceData, m i
 	if d.HasChange("location") {
 		old, new := d.GetChange("location")
 
-		oldLocations := unmarshallShippingZoneLocations(old)
-		newLocations := unmarshallShippingZoneLocations(new)
+		oldLocations := expandShippingZoneLocations(old)
+		newLocations := expandShippingZoneLocations(new)
 
 		for i, location := range oldLocations {
 			if !_locationInSlice(location, newLocations) {
@@ -202,7 +202,7 @@ func resourceShippingZoneDelete(ctx context.Context, d *schema.ResourceData, m i
 	return diag.FromErr(err)
 }
 
-func unmarshallShippingZoneLocations(input interface{}) []platform.Location {
+func expandShippingZoneLocations(input interface{}) []platform.Location {
 	inputSlice := input.([]interface{})
 	result := make([]platform.Location, len(inputSlice))
 
@@ -228,7 +228,7 @@ func unmarshallShippingZoneLocations(input interface{}) []platform.Location {
 	return result
 }
 
-func marshallShippingZoneLocations(locations []platform.Location) []map[string]interface{} {
+func flattenShippingZoneLocations(locations []platform.Location) []map[string]interface{} {
 	result := make([]map[string]interface{}, len(locations))
 
 	for i := range locations {

--- a/commercetools/resource_shipping_zone_rate.go
+++ b/commercetools/resource_shipping_zone_rate.go
@@ -196,7 +196,7 @@ func resourceShippingZoneRateCreate(ctx context.Context, d *schema.ResourceData,
 	}
 	log.Printf("[DEBUG] Setting freeAbove: %s", stringFormatObject(freeAbove))
 
-	shippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
+	shippingRatePriceTiers, err := expandShippingRatePriceTiers(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -244,7 +244,7 @@ func resourceShippingZoneRateCreate(ctx context.Context, d *schema.ResourceData,
 	return resourceShippingZoneRateRead(ctx, d, m)
 }
 
-func unmarshallShippingRatePriceTiers(d *schema.ResourceData) ([]platform.ShippingRatePriceTier, error) {
+func expandShippingRatePriceTiers(d *schema.ResourceData) ([]platform.ShippingRatePriceTier, error) {
 	values, ok := d.GetOk("shipping_rate_price_tier")
 	if !ok {
 		return []platform.ShippingRatePriceTier{}, nil
@@ -380,7 +380,7 @@ func resourceShippingZoneRateUpdate(ctx context.Context, d *schema.ResourceData,
 			}
 		}
 
-		newShippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
+		newShippingRatePriceTiers, err := expandShippingRatePriceTiers(d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -451,7 +451,7 @@ func resourceShippingZoneRateDelete(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	newShippingRatePriceTiers, err := unmarshallShippingRatePriceTiers(d)
+	newShippingRatePriceTiers, err := expandShippingRatePriceTiers(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/commercetools/resource_shipping_zone_test.go
+++ b/commercetools/resource_shipping_zone_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUnmarshallShippingZoneLocations(t *testing.T) {
+func TestExpandShippingZoneLocations(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"country": "DE",
@@ -22,7 +22,7 @@ func TestUnmarshallShippingZoneLocations(t *testing.T) {
 			"state":   "Nevada",
 		},
 	}
-	actual := unmarshallShippingZoneLocations(input)
+	actual := expandShippingZoneLocations(input)
 	expected := []platform.Location{
 		{
 			Country: "DE",

--- a/commercetools/resource_state.go
+++ b/commercetools/resource_state.go
@@ -94,8 +94,8 @@ func resourceState() *schema.Resource {
 }
 
 func resourceStateCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	name := unmarshallLocalizedString(d.Get("name"))
-	description := unmarshallLocalizedString(d.Get("description"))
+	name := expandLocalizedString(d.Get("name"))
+	description := expandLocalizedString(d.Get("description"))
 
 	roles := []platform.StateRoleEnum{}
 	for _, value := range expandStringArray(d.Get("roles").([]interface{})) {
@@ -167,7 +167,7 @@ func resourceStateRead(ctx context.Context, d *schema.ResourceData, m interface{
 		d.Set("roles", state.Roles)
 	}
 	if state.Transitions != nil {
-		d.Set("transitions", marshallStateTransitions(state.Transitions))
+		d.Set("transitions", flattenStateTransitions(state.Transitions))
 	}
 	return nil
 }
@@ -181,14 +181,14 @@ func resourceStateUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	if d.HasChange("name") {
-		newName := unmarshallLocalizedString(d.Get("name"))
+		newName := expandLocalizedString(d.Get("name"))
 		input.Actions = append(
 			input.Actions,
 			&platform.StateSetNameAction{Name: newName})
 	}
 
 	if d.HasChange("description") {
-		newDescription := unmarshallLocalizedString(d.Get("description"))
+		newDescription := expandLocalizedString(d.Get("description"))
 		input.Actions = append(
 			input.Actions,
 			&platform.StateSetDescriptionAction{Description: newDescription})
@@ -260,7 +260,7 @@ func resourceStateDelete(ctx context.Context, d *schema.ResourceData, m interfac
 	return diag.FromErr(err)
 }
 
-func marshallStateTransitions(values []platform.StateReference) []string {
+func flattenStateTransitions(values []platform.StateReference) []string {
 	result := make([]string, len(values))
 	for i := range values {
 		result[i] = values[i].ID

--- a/commercetools/resource_store.go
+++ b/commercetools/resource_store.go
@@ -65,7 +65,7 @@ func resourceStore() *schema.Resource {
 }
 
 func resourceStoreCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	name := unmarshallLocalizedString(d.Get("name"))
+	name := expandLocalizedString(d.Get("name"))
 	dcIdentifiers := expandStoreChannels(d.Get("distribution_channels"))
 	scIdentifiers := expandStoreChannels(d.Get("supply_channels"))
 
@@ -156,7 +156,7 @@ func resourceStoreUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	if d.HasChange("name") {
-		newName := unmarshallLocalizedString(d.Get("name"))
+		newName := expandLocalizedString(d.Get("name"))
 		input.Actions = append(
 			input.Actions,
 			&platform.StoreSetNameAction{Name: &newName})

--- a/commercetools/utils.go
+++ b/commercetools/utils.go
@@ -363,11 +363,11 @@ func compareDateString(a, b string) bool {
 	if a == b {
 		return true
 	}
-	da, err := unmarshallTime(a)
+	da, err := expandTime(a)
 	if err != nil {
 		return false
 	}
-	db, err := unmarshallTime(b)
+	db, err := expandTime(b)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
We switched to marshall/unmarshall earlier but it's better to keep the
terraform convention of using flatten and expand.

Flatten is the process of converting native Go values to Terraform state
and Expand is from Terraform state to native Go values.