### PR TITLE
shipping_zone: Use TypeSet for defining locations to ignore ordering changes

### DIFF
--- a/commercetools/resource_shipping_zone.go
+++ b/commercetools/resource_shipping_zone.go
@@ -36,7 +36,7 @@ func resourceShippingZone() *schema.Resource {
 			},
 			"location": {
 				Description: "[Location](https://docs.commercetoolstools.pi/projects/zones#location)",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -203,7 +203,8 @@ func resourceShippingZoneDelete(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func expandShippingZoneLocations(input interface{}) []platform.Location {
-	inputSlice := input.([]interface{})
+	inputSet := input.(*schema.Set)
+	inputSlice := inputSet.List()
 	result := make([]platform.Location, len(inputSlice))
 
 	for i := range inputSlice {


### PR DESCRIPTION
Closes #259 

Fixes an issue where Terraform doesn't preserve sorting order while diffing for changes and the provider keeps applying the same change on the list type.

Since location IDs are unique, and a combination of both keys (country, state) we can make this a set instead to ignore ordering changes.


