### PR TITLE
fix(404): expand 404 cases

### DIFF
--- a/commercetools/errors.go
+++ b/commercetools/errors.go
@@ -95,6 +95,9 @@ func IsResourceNotFoundError(err error) bool {
 
 	case platform.ErrorResponse:
 		return e.StatusCode == 404
+
+	case platform.GenericRequestError:
+		return e.StatusCode == 404
 	}
 	return false
 }


### PR DESCRIPTION
Turns out the error type in the example given with product types is actually platform.GenericRequestError.