### PR TITLE
Use `ForceNew` attribute type changes on the product_type and type resources

### DIFF
--- a/commercetools/resource_product_type.go
+++ b/commercetools/resource_product_type.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/elliotchance/orderedmap/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/labd/commercetools-go-sdk/platform"
@@ -142,9 +140,6 @@ func resourceProductType() *schema.Resource {
 				Computed: true,
 			},
 		},
-		CustomizeDiff: customdiff.ValidateChange("attribute", func(ctx context.Context, old, new, meta any) error {
-			return resourceProductTypeValidateAttribute(old.([]any), new.([]any))
-		}),
 	}
 }
 
@@ -153,6 +148,7 @@ func attributeTypeElement(setsAllowed bool) *schema.Resource {
 		"name": {
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 			ValidateFunc: func(val any, key string) (warns []string, errs []error) {
 				v := val.(string)
 				if !setsAllowed && v == "set" {
@@ -388,61 +384,6 @@ func resourceProductTypeDelete(ctx context.Context, d *schema.ResourceData, m an
 		return processRemoteError(err)
 	})
 	return diag.FromErr(err)
-}
-
-func resourceProductTypeValidateAttribute(old, new []any) error {
-	oldLookup := createLookup(old, "name")
-
-	for _, attribute := range new {
-		newF := attribute.(map[string]any)
-		name := newF["name"].(string)
-		oldF, ok := oldLookup[name].(map[string]any)
-		if !ok {
-			continue
-		}
-
-		oldType := firstElementFromSlice(oldF["type"].([]any))
-		newType := firstElementFromSlice(newF["type"].([]any))
-
-		oldTypeName := oldType["name"].(string)
-		newTypeName := newType["name"].(string)
-
-		if oldTypeName != newTypeName {
-			if oldTypeName == "" || newTypeName == "" {
-				continue
-			}
-
-			return fmt.Errorf(
-				"attribute '%s' type changed from %s to %s."+
-					" Changing types is not supported;"+
-					" please remove the attribute first and re-define it later",
-				name, oldTypeName, newTypeName)
-		}
-
-		if strings.EqualFold(newTypeName, "Set") {
-			oldElement, _ := elementFromSlice(oldType, "element_type")
-			newElement, _ := elementFromSlice(newType, "element_type")
-			oldElementName := oldElement["name"].(string)
-			newElementName := newElement["name"].(string)
-
-			if oldElementName != newElementName {
-				return fmt.Errorf(
-					"attribute '%s' element type changed from %s to %s."+
-						" Changing element types is not supported;"+
-						" please remove the attribute first and re-define it later",
-					name, oldElementName, newElementName)
-			}
-		}
-
-		if oldF["required"] != newF["required"] {
-			return fmt.Errorf(
-				"error on the '%s' attribute: "+
-					"Updating the 'required' attribute is not supported."+
-					"Consider removing the attribute first and then re-adding it",
-				name)
-		}
-	}
-	return nil
 }
 
 func resourceProductTypeAttributeChangeActions(oldValues []any, newValues []any) ([]platform.ProductTypeUpdateAction, error) {
@@ -1070,6 +1011,7 @@ func resourceProductTypeResourceV0() *schema.Resource {
 						"required": {
 							Description: "Whether the attribute is required to have a value",
 							Type:        schema.TypeBool,
+							ForceNew:    true,
 							Optional:    true,
 							Default:     false,
 						},

--- a/commercetools/resource_product_type_test.go
+++ b/commercetools/resource_product_type_test.go
@@ -29,66 +29,6 @@ type TestProductTypeElementType struct {
 	Values []TestProductTypeEnumValue
 }
 
-func TestResourceProductTypeValidateAttribute(t *testing.T) {
-	old := []any{
-		map[string]any{
-			"name": "attr-one",
-			"type": []any{
-				map[string]any{
-					"name": "text",
-				},
-			},
-		},
-	}
-	new := []any{
-		map[string]any{
-			"name": "attr-one",
-			"type": []any{
-				map[string]any{
-					"name": "Boolean",
-				},
-			},
-		},
-	}
-	err := resourceProductTypeValidateAttribute(old, new)
-	assert.NotNil(t, err)
-}
-
-func TestResourceProductTypeValidateAttributeSet(t *testing.T) {
-	old := []any{
-		map[string]any{
-			"name": "attr-one",
-			"type": []any{
-				map[string]any{
-					"name": "Set",
-					"element_type": []any{
-						map[string]any{
-							"name": "text",
-						},
-					},
-				},
-			},
-		},
-	}
-	new := []any{
-		map[string]any{
-			"name": "attr-one",
-			"type": []any{
-				map[string]any{
-					"name": "Set",
-					"element_type": []any{
-						map[string]any{
-							"name": "Enum",
-						},
-					},
-				},
-			},
-		},
-	}
-	err := resourceProductTypeValidateAttribute(old, new)
-	assert.NotNil(t, err)
-}
-
 func TestAttributeTypeElement(t *testing.T) {
 	elem := attributeTypeElement(true)
 	elemType, ok := elem.Schema["element_type"]

--- a/commercetools/resource_type_test.go
+++ b/commercetools/resource_type_test.go
@@ -133,67 +133,6 @@ func TestExpandTypeFieldType(t *testing.T) {
 	}
 }
 
-func TestResourceTypeValidateField(t *testing.T) {
-	old := []any{
-		map[string]any{
-			"name": "field-one",
-			"type": []any{
-				map[string]any{
-					"name": "String",
-				},
-			},
-		},
-	}
-	new := []any{
-		map[string]any{
-			"name": "field-one",
-			"type": []any{
-				map[string]any{
-					"name": "Boolean",
-				},
-			},
-		},
-	}
-	err := resourceTypeValidateField(old, new)
-	assert.NotNil(t, err)
-}
-
-func TestResourceTypeValidateFieldSet(t *testing.T) {
-
-	old := []any{
-		map[string]any{
-			"name": "field-one",
-			"type": []any{
-				map[string]any{
-					"name": "Set",
-					"element_type": []any{
-						map[string]any{
-							"name": "String",
-						},
-					},
-				},
-			},
-		},
-	}
-	new := []any{
-		map[string]any{
-			"name": "field-one",
-			"type": []any{
-				map[string]any{
-					"name": "Set",
-					"element_type": []any{
-						map[string]any{
-							"name": "Enum",
-						},
-					},
-				},
-			},
-		},
-	}
-	err := resourceTypeValidateField(old, new)
-	assert.NotNil(t, err)
-}
-
 func TestAccTypes_basic(t *testing.T) {
 	key := "acctest-type"
 	identifier := "acctest_type"


### PR DESCRIPTION
Instead of showing an error that the user needs to recreate the type
or product type for a change in the attribute type we use the `ForceNew`
option from terraform. This automatically recreates the resource