### PR TITLE
Use the resource version from the terraform state

### DIFF
--- a/commercetools/resource_cart_discount.go
+++ b/commercetools/resource_cart_discount.go
@@ -324,13 +324,9 @@ func resourceCartDiscountRead(ctx context.Context, d *schema.ResourceData, m any
 
 func resourceCartDiscountUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := getClient(m)
-	cartDiscount, err := client.CartDiscounts().WithId(d.Id()).Get().Execute(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	input := platform.CartDiscountUpdate{
-		Version: cartDiscount.Version,
+		Version: d.Get("version").(int),
 		Actions: []platform.CartDiscountUpdateAction{},
 	}
 
@@ -450,7 +446,7 @@ func resourceCartDiscountUpdate(ctx context.Context, d *schema.ResourceData, m a
 			&platform.CartDiscountChangeStackingModeAction{StackingMode: newStackingMode})
 	}
 
-	err = resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
+	err := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
 		_, err := client.CartDiscounts().WithId(d.Id()).Post(input).Execute(ctx)
 		return processRemoteError(err)
 	})

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -279,13 +279,9 @@ func resourceCategoryRead(ctx context.Context, d *schema.ResourceData, m any) di
 
 func resourceCategoryUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := getClient(m)
-	category, err := client.Categories().WithId(d.Id()).Get().Execute(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	input := platform.CategoryUpdate{
-		Version: category.Version,
+		Version: d.Get("version").(int),
 		Actions: []platform.CategoryUpdateAction{},
 	}
 
@@ -398,7 +394,7 @@ func resourceCategoryUpdate(ctx context.Context, d *schema.ResourceData, m any) 
 		}
 	}
 
-	err = resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
+	err := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
 		_, err := client.Categories().WithId(d.Id()).Post(input).Execute(ctx)
 		return processRemoteError(err)
 	})

--- a/commercetools/resource_customer_group.go
+++ b/commercetools/resource_customer_group.go
@@ -101,13 +101,9 @@ func resourceCustomerGroupRead(ctx context.Context, d *schema.ResourceData, m an
 
 func resourceCustomerGroupUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := getClient(m)
-	customerGroup, err := client.CustomerGroups().WithId(d.Id()).Get().Execute(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	input := platform.CustomerGroupUpdate{
-		Version: customerGroup.Version,
+		Version: d.Get("version").(int),
 		Actions: []platform.CustomerGroupUpdateAction{},
 	}
 
@@ -135,7 +131,7 @@ func resourceCustomerGroupUpdate(ctx context.Context, d *schema.ResourceData, m 
 		}
 	}
 
-	err = resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
+	err := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
 		_, err := client.CustomerGroups().WithId(d.Id()).Post(input).Execute(ctx)
 		return processRemoteError(err)
 	})

--- a/commercetools/resource_discount_code.go
+++ b/commercetools/resource_discount_code.go
@@ -175,13 +175,9 @@ func resourceDiscountCodeRead(ctx context.Context, d *schema.ResourceData, m any
 
 func resourceDiscountCodeUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := getClient(m)
-	discountCode, err := client.DiscountCodes().WithId(d.Id()).Get().Execute(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	input := platform.DiscountCodeUpdate{
-		Version: discountCode.Version,
+		Version: d.Get("version").(int),
 		Actions: []platform.DiscountCodeUpdateAction{},
 	}
 
@@ -289,8 +285,8 @@ func resourceDiscountCodeUpdate(ctx context.Context, d *schema.ResourceData, m a
 		}
 	}
 
-	err = resource.RetryContext(ctx, 20*time.Second, func() *resource.RetryError {
-		_, err := client.DiscountCodes().WithId(discountCode.ID).Post(input).Execute(ctx)
+	err := resource.RetryContext(ctx, 20*time.Second, func() *resource.RetryError {
+		_, err := client.DiscountCodes().WithId(d.Id()).Post(input).Execute(ctx)
 		return processRemoteError(err)
 	})
 	if err != nil {

--- a/commercetools/resource_product_discount.go
+++ b/commercetools/resource_product_discount.go
@@ -211,13 +211,9 @@ func resourceProductDiscountRead(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceProductDiscountUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := getClient(m)
-	productDiscount, err := client.ProductDiscounts().WithId(d.Id()).Get().Execute(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	input := platform.ProductDiscountUpdate{
-		Version: productDiscount.Version,
+		Version: d.Get("version").(int),
 		Actions: []platform.ProductDiscountUpdateAction{},
 	}
 
@@ -305,7 +301,7 @@ func resourceProductDiscountUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	err = resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
+	err := resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
 		_, err := client.ProductDiscounts().WithId(d.Id()).Post(input).Execute(ctx)
 		return processRemoteError(err)
 	})

--- a/commercetools/resource_shipping_method.go
+++ b/commercetools/resource_shipping_method.go
@@ -140,6 +140,9 @@ func resourceShippingMethodUpdate(ctx context.Context, d *schema.ResourceData, m
 	defer ctMutexKV.Unlock(d.Id())
 
 	client := getClient(m)
+
+	// Fetch the latest version. The version can be changed outside this resource
+	// when a shipping methode rate is added.
 	shippingMethod, err := client.ShippingMethods().WithId(d.Id()).Get().Execute(ctx)
 	if err != nil {
 		return diag.FromErr(err)

--- a/commercetools/resource_store.go
+++ b/commercetools/resource_store.go
@@ -194,6 +194,9 @@ func resourceStoreUpdate(ctx context.Context, d *schema.ResourceData, m any) dia
 	if d.HasChange("custom") {
 		actions, err := CustomFieldUpdateActions[platform.StoreSetCustomTypeAction, platform.StoreSetCustomFieldAction](d)
 		if err != nil {
+			// Workaround invalid state to be written, see
+			// https://github.com/hashicorp/terraform-plugin-sdk/issues/476
+			d.Partial(true)
 			return diag.FromErr(err)
 		}
 		for i := range actions {
@@ -206,6 +209,9 @@ func resourceStoreUpdate(ctx context.Context, d *schema.ResourceData, m any) dia
 		return processRemoteError(err)
 	})
 	if err != nil {
+		// Workaround invalid state to be written, see
+		// https://github.com/hashicorp/terraform-plugin-sdk/issues/476
+		d.Partial(true)
 		return diag.FromErr(err)
 	}
 

--- a/commercetools/resource_tax_category.go
+++ b/commercetools/resource_tax_category.go
@@ -99,6 +99,9 @@ func resourceTaxCategoryUpdate(ctx context.Context, d *schema.ResourceData, m an
 	defer ctMutexKV.Unlock(d.Id())
 
 	client := getClient(m)
+
+	// Fetch the latest version. The version can be changed outside this resource
+	// when a tax category rate is added.
 	taxCategory, err := client.TaxCategories().WithId(d.Id()).Get().Execute(ctx)
 	if err != nil {
 		// Workaround invalid state to be written, see


### PR DESCRIPTION
For some resource the version from the state was used and for other not.
Make this consistent and use the state version where possible.

There are two exceptions, the tax and shipping_method resources. Reason
is that they both have 'fake' child resources
(tax_rate, shipping_method_rate) which modifies the version of the parent