### PR TITLE
Fix continues project settings updates

### DIFF
--- a/internal/resources/project/model.go
+++ b/internal/resources/project/model.go
@@ -68,13 +68,14 @@ func NewProjectFromNative(n *platform.Project) Project {
 		ExternalOAuth: []ExternalOAuth{},
 	}
 
+	// always set it to an empty list to avoid the wrong comparison in the update actions part
+	res.ShippingRateCartClassificationValue = []models.CustomFieldLocalizedEnumValue{}
+
 	switch s := n.ShippingRateInputType.(type) {
 	case platform.CartScoreType:
 		res.ShippingRateInputType = types.StringValue("CartScore")
-		res.ShippingRateCartClassificationValue = []models.CustomFieldLocalizedEnumValue{}
 	case platform.CartValueType:
 		res.ShippingRateInputType = types.StringValue("CartValue")
-		res.ShippingRateCartClassificationValue = []models.CustomFieldLocalizedEnumValue{}
 	case platform.CartClassificationType:
 		res.ShippingRateInputType = types.StringValue("CartClassification")
 		values := make([]models.CustomFieldLocalizedEnumValue, len(s.Values))

--- a/internal/resources/project/model_test.go
+++ b/internal/resources/project/model_test.go
@@ -41,9 +41,11 @@ func TestNewProjectFromNative(t *testing.T) {
 				},
 				Messages: []Messages{
 					{
-						Enabled: types.BoolValue(false),
+						Enabled:                 types.BoolValue(false),
+						DeleteDaysAfterCreation: types.Int64Value(DefaultDeleteDaysAfterCreation),
 					},
 				},
+				ShippingRateCartClassificationValue: []models.CustomFieldLocalizedEnumValue{},
 			},
 		},
 	}


### PR DESCRIPTION
* fix continues project settings updates as the `ShippingRateCartClassificationValue` is by default nil if you are using fixed shipping rates and the plan is using an empty slice

* Fixed https://github.com/labd/terraform-provider-commercetools/issues/334