### PR TITLE
Updating GoogleCloudPubSub to Reference Topic

### DIFF
--- a/internal/resources/subscription/model.go
+++ b/internal/resources/subscription/model.go
@@ -266,7 +266,7 @@ func (d Destination) ToNative() platform.Destination {
 	case GoogleCloudPubSub:
 		return platform.GoogleCloudPubSubDestination{
 			ProjectId: d.ProjectID.ValueString(),
-			Topic:     d.TopicARN.ValueString(),
+			Topic:     d.Topic.ValueString(),
 		}
 	case SQS:
 		result := platform.SqsDestination{


### PR DESCRIPTION
Currently any attempt to create a GooglePubSub Subscription fails with the following error message:
```
A test message could not be delivered to this destination: GoogleCloudPubSub topic '' in project '****xxxx'. Please make sure your destination is correctly configured.
```

This is likely due a improper reference to TopicARN rather than Topic, which is used by GCP
This update should resolve this issue 