### PR TITLE
Don't require `access_key` if `access_secret` is specified

### DIFF
--- a/internal/resources/subscription/resource.go
+++ b/internal/resources/subscription/resource.go
@@ -156,11 +156,10 @@ func (r *subscriptionResource) Schema(_ context.Context, _ resource.SchemaReques
 							Sensitive: true,
 						},
 						"access_secret": schema.StringAttribute{
-							Optional: true,
+							Optional:   true,
 							Validators: []validator.String{
-								stringvalidator.AlsoRequires(
-									path.MatchRelative().AtParent().AtName("access_key"),
-								),
+								// TODO Require value if access_key is set and
+								// type is SNS, SQS
 							},
 							Sensitive: true,
 						},


### PR DESCRIPTION
This is only needed when the type is SQS or SNS