### PR TITLE
Couple of document updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v1.6.8 (2023-02-02)
+==================
+ - `resource_subscription` Fix removing requirement to specify `access_key` when
+   the `access_secret` is defined. The latter is only needed for EventGrid.
+
 v1.6.7 (2023-01-24)
 ==================
  - `resource_project` Add extra checks to make sure we have a `message` block

--- a/docs/resources/type.md
+++ b/docs/resources/type.md
@@ -151,7 +151,7 @@ Optional:
 
 - `element_type` (Block List, Max: 1) (see [below for nested schema](#nestedblock--field--type--element_type))
 - `localized_value` (Block List) Localized values for the `lenum` type. (see [below for nested schema](#nestedblock--field--type--localized_value))
-- `reference_type_id` (String) Resource type the Custom Field can reference. Required when type is `reference`
+- `reference_type_id` (String) Resource type the Custom Field can reference. Required when type is `Reference`
 - `value` (Block List) Values for the `enum` type. (see [below for nested schema](#nestedblock--field--type--value))
 
 <a id="nestedblock--field--type--element_type"></a>
@@ -164,7 +164,7 @@ Required:
 Optional:
 
 - `localized_value` (Block List) Localized values for the `lenum` type. (see [below for nested schema](#nestedblock--field--type--element_type--localized_value))
-- `reference_type_id` (String) Resource type the Custom Field can reference. Required when type is `reference`
+- `reference_type_id` (String) Resource type the Custom Field can reference. Required when type is `Reference`
 - `value` (Block List) Values for the `enum` type. (see [below for nested schema](#nestedblock--field--type--element_type--value))
 
 <a id="nestedblock--field--type--element_type--localized_value"></a>


### PR DESCRIPTION
When I was working through the documentation I noticed the example `enum` fields were using a `value` key instead of `label`.