### PR TITLE
Don't error when a resource is no longer found (drift)

### DIFF
--- a/commercetools/utils_test.go
+++ b/commercetools/utils_test.go
@@ -1,6 +1,7 @@
 package commercetools
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -58,6 +59,10 @@ func TestCompareDateString(t *testing.T) {
 }
 
 func checkApiResult(err error) error {
+	if errors.Is(err, platform.ErrNotFound) {
+		return nil
+	}
+
 	switch v := err.(type) {
 	case platform.GenericRequestError:
 		if v.StatusCode == 404 {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-mux v0.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/labd/commercetools-go-sdk v1.2.1-0.20221221185604-b337ce17e269
+	github.com/labd/commercetools-go-sdk v1.2.1-0.20230227114902-2a3c3778415c
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401
 )

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LE
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/labd/commercetools-go-sdk v1.2.1-0.20221221185604-b337ce17e269 h1:2ARQmpl1w7h7eOf2Qmy+oSTFiKnXyRR1QufMJdjTLlQ=
 github.com/labd/commercetools-go-sdk v1.2.1-0.20221221185604-b337ce17e269/go.mod h1:I+KKNALlg6PcSertsVA7E442koO99GT7gldWqwZlUGo=
+github.com/labd/commercetools-go-sdk v1.2.1-0.20230227114902-2a3c3778415c h1:3EBKxskXc6SCcp9NccCONnixKkOK0CQdWwtdjhQjyqM=
+github.com/labd/commercetools-go-sdk v1.2.1-0.20230227114902-2a3c3778415c/go.mod h1:I+KKNALlg6PcSertsVA7E442koO99GT7gldWqwZlUGo=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/internal/acctest/client.go
+++ b/internal/acctest/client.go
@@ -1,6 +1,7 @@
 package acctest
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -45,6 +46,10 @@ func GetClient() (*platform.ByProjectKeyRequestBuilder, error) {
 }
 
 func CheckApiResult(err error) error {
+	if errors.Is(err, platform.ErrNotFound) {
+		return nil
+	}
+
 	switch v := err.(type) {
 	case platform.GenericRequestError:
 		if v.StatusCode == 404 {

--- a/internal/resources/state/resource.go
+++ b/internal/resources/state/resource.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -174,6 +175,11 @@ func (r *stateResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	res, err := r.client.States().WithId(state.ID.ValueString()).Get().Execute(ctx)
 	if err != nil {
+		if errors.Is(err, platform.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error reading state",
 			"Could not retrieve state, unexpected error: "+err.Error(),

--- a/internal/resources/state_transition/resource.go
+++ b/internal/resources/state_transition/resource.go
@@ -2,6 +2,7 @@ package state_transition
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -153,6 +154,11 @@ func (r *stateTransitionResource) Read(ctx context.Context, req resource.ReadReq
 
 	res, err := r.client.States().WithId(resourceID).Get().Execute(ctx)
 	if err != nil {
+		if errors.Is(err, platform.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error reading state",
 			"Could not retrieve state, unexpected error: "+err.Error(),


### PR DESCRIPTION
When a resource was defined in the state but no longer available in commercetools we now remove the value from the state.

Fixes #345