### PR TITLE
add GoogleCloudFunction type to resource_api_extension

### DIFF
--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -131,11 +131,12 @@ func validateDestinationType(val any, key string) (warns []string, errs []error)
 
 	switch v {
 	case
+		"googlecloudfunction",
 		"http",
 		"awslambda":
 		return
 	default:
-		errs = append(errs, fmt.Errorf("%q not a valid value for %q, valid options are: http, awslambda", val, key))
+		errs = append(errs, fmt.Errorf("%q not a valid value for %q, valid options are: googlecloudfunction, http, awslambda", val, key))
 	}
 	return
 }
@@ -301,6 +302,10 @@ func expandExtensionDestination(d *schema.ResourceData) (platform.Destination, e
 	}
 
 	switch strings.ToLower(input["type"].(string)) {
+	case "googlecloudfunction":
+		return platform.GoogleCloudFunctionDestination{
+			Url:            input["url"].(string),
+		}, nil
 	case "http":
 		auth, err := expandExtensionDestinationAuthentication(input)
 		if err != nil {
@@ -370,8 +375,14 @@ func flattenExtensionDestination(dst platform.Destination, d *schema.ResourceDat
 		current, _ = expandExtensionDestination(d)
 	}
 
-	// A destination is either HTTP or AWSLambda
+	// A destination is either GoogleCloudFunction, HTTP or AWSLambda
 	switch d := dst.(type) {
+
+    case platform.GoogleCloudFunctionDestination:
+        return []map[string]string{{
+            "type": "GoogleCloudFunction",
+            "url":  d.Url,
+        }}
 
 	// For the HTTP Destination there are two specific authentication types:
 	// AuthorizationHeader and AzureFunctions.

--- a/commercetools/resource_api_extension_test.go
+++ b/commercetools/resource_api_extension_test.go
@@ -105,6 +105,20 @@ func TestAccAPIExtension_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAPIExtensionDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccAPIExtensionGCFConfig(identifier, name, timeoutInMs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAPIExtensionExists("ext"),
+					resource.TestCheckResourceAttr(
+						resourceName, "key", name),
+					resource.TestCheckResourceAttr(
+						resourceName, "timeout_in_ms", strconv.FormatInt(int64(timeoutInMs), 10)),
+					resource.TestCheckResourceAttr(
+						resourceName, "trigger.0.actions.#", "1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "trigger.0.actions.0", "Create"),
+				),
+			},
+			{
 				Config: testAccAPIExtensionConfig(identifier, name, timeoutInMs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccAPIExtensionExists("ext"),
@@ -149,6 +163,29 @@ func TestAccAPIExtension_basic(t *testing.T) {
 				),
 			},
 		},
+	})
+}
+
+func testAccAPIExtensionGCFConfig(identifier, key string, timeoutInMs int) string {
+	return hclTemplate(`
+		resource "commercetools_api_extension" "{{ .identifier }}" {
+			key = "{{ .key }}"
+			timeout_in_ms = {{ .timeoutInMs }}
+
+			destination {
+				type                 = "GoogleCloudFunction"
+				url                  = "https://example.com"
+			}
+
+			trigger {
+				resource_type_id = "customer"
+				actions = ["Create"]
+			}
+		}
+	`, map[string]any{
+		"identifier":  identifier,
+		"key":         key,
+		"timeoutInMs": timeoutInMs,
 	})
 }
 


### PR DESCRIPTION
Implement new feature - add new type `GoogleCloudFunction`:
- https://github.com/labd/terraform-provider-commercetools/issues/348
- which is also in SDK: https://github.com/labd/commercetools-go-sdk/blob/2a3c3778415c7794f4ea84a449759da4406f450d/platform/types_extension.go#L88-L93

which was announced in 2023-02-17
- https://docs.commercetools.com/api/releases/2023-02-17-introducing-google-cloud-function-destination-for-api-extensions
