### PR TITLE
fix: remove duplicate `project_key` in example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,6 @@ provider "commercetools" {
   client_id     = "<your client id>"
   client_secret = "<your client secret>"
   project_key   = "<your project key>"
-  project_key   = "<your project key>"
   scopes        = "<space seperated list of scopes>"
   api_url       = "<api url>"
   token_url     = "<token url>"


### PR DESCRIPTION
The `project_key` was mentioned twice