### PR TITLE
Fixed issue with NotFound error not checked correctly

### DIFF
--- a/.changes/unreleased/Fixed-20230829-093530.yaml
+++ b/.changes/unreleased/Fixed-20230829-093530.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: NotFound error not handled correctly
+time: 2023-08-29T09:35:30.532843909+02:00

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -77,6 +77,37 @@ func TestAccCategoryCreate_basic(t *testing.T) {
 	})
 }
 
+func TestAccCategoryRecreateAfterDelete(t *testing.T) {
+	resourceName := "commercetools_category.accessories"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCategoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCategoryConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", "accessories"),
+				),
+			},
+			{
+				Config: testAccCategoryConfig(),
+				PreConfig: func() {
+					client := getClient(testAccProvider.Meta())
+					_, err := client.Categories().WithKey("accessories").Delete().Execute(context.Background())
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", "accessories"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCategoryConfig() string {
 	return hclTemplate(`
 		resource "commercetools_category" "accessories_base" {

--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -89,6 +89,8 @@ func extractRawDetailedError(content []byte) error {
 
 // IsResourceNotFoundError returns true if commercetools returned a 404 error
 func IsResourceNotFoundError(err error) bool {
+	//Occasionally the SDK returns a sentinel value instead of the parsed error response for 404.
+	//This is a workaround to handle that case.
 	if errors.Is(err, platform.ErrNotFound) {
 		return true
 	}

--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -62,14 +62,14 @@ func extractRawDetailedError(content []byte) error {
 	// code, message and detailedErrorMessage values.
 	if val, ok := data["errors"].([]any); ok {
 		for i := range val {
-			if err, ok := val[i].(map[string]any); ok {
+			if error, ok := val[i].(map[string]any); ok {
 				var message string
 
-				if detail, ok := err["message"].(string); ok {
+				if detail, ok := error["message"].(string); ok {
 					message = detail
 				}
 
-				if detail, ok := err["detailedErrorMessage"].(string); ok {
+				if detail, ok := error["detailedErrorMessage"].(string); ok {
 					if message != "" {
 						return fmt.Errorf("%s %s", message, detail)
 					}

--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -62,14 +62,14 @@ func extractRawDetailedError(content []byte) error {
 	// code, message and detailedErrorMessage values.
 	if val, ok := data["errors"].([]any); ok {
 		for i := range val {
-			if error, ok := val[i].(map[string]any); ok {
+			if err, ok := val[i].(map[string]any); ok {
 				var message string
 
-				if detail, ok := error["message"].(string); ok {
+				if detail, ok := err["message"].(string); ok {
 					message = detail
 				}
 
-				if detail, ok := error["detailedErrorMessage"].(string); ok {
+				if detail, ok := err["detailedErrorMessage"].(string); ok {
 					if message != "" {
 						return fmt.Errorf("%s %s", message, detail)
 					}
@@ -87,8 +87,12 @@ func extractRawDetailedError(content []byte) error {
 	return nil
 }
 
-// utils.IsResourceNotFoundError returns true if commercetools returned a 404 error
+// IsResourceNotFoundError returns true if commercetools returned a 404 error
 func IsResourceNotFoundError(err error) bool {
+	if errors.Is(err, platform.ErrNotFound) {
+		return true
+	}
+
 	switch e := err.(type) {
 	case platform.ResourceNotFoundError:
 		return true

--- a/internal/utils/errors_test.go
+++ b/internal/utils/errors_test.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"github.com/labd/commercetools-go-sdk/platform"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestIsResourceNotFoundError(t *testing.T) {
+	var cases = []struct {
+		err      error
+		expected bool
+	}{
+		{platform.ErrNotFound, true},
+		{platform.ResourceNotFoundError{}, true},
+		{platform.ErrorResponse{StatusCode: 404}, true},
+		{platform.ErrorResponse{StatusCode: 500}, false},
+		{platform.GenericRequestError{StatusCode: 404}, true},
+		{platform.GenericRequestError{StatusCode: 500}, false},
+	}
+
+	for _, tt := range cases {
+		assert.Equal(t, tt.expected, IsResourceNotFoundError(tt.err))
+	}
+}


### PR DESCRIPTION
Bug introduced because of a change in error generation by the SDK (https://github.com/labd/commercetools-go-sdk/commit/2a3c3778415c7794f4ea84a449759da4406f450d)

Fixes #384 

### BUG FIXES

-  Added correct check for resource not found case
