### PR TITLE
fix: ensure an empty slice is set if subscription messages or changes are removed

### DIFF
--- a/.changes/unreleased/Fixed-20231115-113250.yaml
+++ b/.changes/unreleased/Fixed-20231115-113250.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: ensure an empty slice is set if subscription messages or changes are removed
+time: 2023-11-15T11:32:50.093744942+01:00

--- a/internal/resources/subscription/model.go
+++ b/internal/resources/subscription/model.go
@@ -129,7 +129,7 @@ func (s *Subscription) updateActions(plan Subscription) platform.SubscriptionUpd
 
 	// setChanges
 	if !reflect.DeepEqual(s.Changes, plan.Changes) {
-		var changes []platform.ChangeSubscription
+		var changes = make([]platform.ChangeSubscription, 0, len(plan.Changes))
 		for _, c := range plan.Changes {
 			changes = append(changes, c.toNative()...)
 		}
@@ -143,9 +143,11 @@ func (s *Subscription) updateActions(plan Subscription) platform.SubscriptionUpd
 
 	// setMessages
 	if !reflect.DeepEqual(s.Messages, plan.Messages) {
-		messages := pie.Map(plan.Messages, func(m Message) platform.MessageSubscription {
-			return m.toNative()
-		})
+		var messages = make([]platform.MessageSubscription, 0, len(plan.Messages))
+		for _, m := range plan.Messages {
+			messages = append(messages, m.toNative())
+		}
+
 		result.Actions = append(
 			result.Actions,
 			platform.SubscriptionSetMessagesAction{Messages: messages})

--- a/internal/resources/subscription/model_test.go
+++ b/internal/resources/subscription/model_test.go
@@ -234,6 +234,50 @@ func TestUpdateActions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "remove messages",
+			state: Subscription{
+				Version: types.Int64Value(10),
+				Messages: []Message{
+					{
+						ResourceTypeID: types.StringValue("product"),
+					},
+				},
+			},
+			plan: Subscription{
+				Messages: nil,
+			},
+			expected: platform.SubscriptionUpdate{
+				Version: 10,
+				Actions: []platform.SubscriptionUpdateAction{
+					platform.SubscriptionSetMessagesAction{
+						Messages: []platform.MessageSubscription{},
+					},
+				},
+			},
+		},
+		{
+			name: "remove changes",
+			state: Subscription{
+				Version: types.Int64Value(10),
+				Changes: []Changes{
+					{
+						ResourceTypeIds: []types.String{types.StringValue("product")},
+					},
+				},
+			},
+			plan: Subscription{
+				Changes: nil,
+			},
+			expected: platform.SubscriptionUpdate{
+				Version: 10,
+				Actions: []platform.SubscriptionUpdateAction{
+					platform.SubscriptionSetChangesAction{
+						Changes: []platform.ChangeSubscription{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #440

### BUG FIXES

-  ensure an empty slice is set if subscription messages or changes are removed
