### PR TITLE
Properly handle resource not found errors

### DIFF
--- a/.changes/unreleased/Fixed-20240209-134722.yaml
+++ b/.changes/unreleased/Fixed-20240209-134722.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Properly handle resource not found errors for `subscription`, `state`,
+  `state_transitions`, `product_selection`, `attribute_group` and
+  `associate_role`.
+time: 2024-02-09T13:47:22.878305+01:00

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/elliotchance/orderedmap/v2 v2.2.0
 	github.com/elliotchance/pie/v2 v2.8.0
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
@@ -14,6 +15,7 @@ require (
 	github.com/labd/commercetools-go-sdk v1.4.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/oauth2 v0.14.0
+	golang.org/x/text v0.14.0
 )
 
 require (
@@ -34,7 +36,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
@@ -74,7 +75,6 @@ require (
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/grpc v1.59.0 // indirect

--- a/internal/resources/associate_role/resource.go
+++ b/internal/resources/associate_role/resource.go
@@ -2,7 +2,6 @@ package associate_role
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -14,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-
 	"github.com/labd/commercetools-go-sdk/platform"
+
 	"github.com/labd/terraform-provider-commercetools/internal/utils"
 )
 
@@ -160,7 +159,7 @@ func (r *associateRoleResource) Read(ctx context.Context, req resource.ReadReque
 	// Read remote associate role and check for errors.
 	associateRole, err := r.client.AssociateRoles().WithId(state.ID.ValueString()).Get().Execute(ctx)
 	if err != nil {
-		if errors.Is(err, platform.ErrNotFound) {
+		if utils.IsResourceNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/attribute_group/resource.go
+++ b/internal/resources/attribute_group/resource.go
@@ -2,20 +2,19 @@ package attribute_group
 
 import (
 	"context"
-	"errors"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/labd/terraform-provider-commercetools/internal/customtypes"
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	sdk_resource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/labd/commercetools-go-sdk/platform"
 
+	"github.com/labd/terraform-provider-commercetools/internal/customtypes"
 	"github.com/labd/terraform-provider-commercetools/internal/utils"
 )
 
@@ -158,7 +157,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 
 	res, err := r.client.AttributeGroups().WithId(current.ID.ValueString()).Get().Execute(ctx)
 	if err != nil {
-		if errors.Is(err, platform.ErrNotFound) {
+		if utils.IsResourceNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/product_selection/resource.go
+++ b/internal/resources/product_selection/resource.go
@@ -2,7 +2,6 @@ package product_selection
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -163,7 +162,7 @@ func (r *productSelectionResource) Read(ctx context.Context, req resource.ReadRe
 	// Read remote product selection and check for errors.
 	productSelection, err := r.client.ProductSelections().WithId(state.ID.ValueString()).Get().Execute(ctx)
 	if err != nil {
-		if errors.Is(err, platform.ErrNotFound) {
+		if utils.IsResourceNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/state/resource.go
+++ b/internal/resources/state/resource.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -178,7 +177,7 @@ func (r *stateResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	res, err := r.client.States().WithId(state.ID.ValueString()).Get().Execute(ctx)
 	if err != nil {
-		if errors.Is(err, platform.ErrNotFound) {
+		if utils.IsResourceNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/state_transition/resource.go
+++ b/internal/resources/state_transition/resource.go
@@ -2,7 +2,6 @@ package state_transition
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -154,7 +153,7 @@ func (r *stateTransitionResource) Read(ctx context.Context, req resource.ReadReq
 
 	res, err := r.client.States().WithId(resourceID).Get().Execute(ctx)
 	if err != nil {
-		if errors.Is(err, platform.ErrNotFound) {
+		if utils.IsResourceNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/resources/subscription/resource.go
+++ b/internal/resources/subscription/resource.go
@@ -2,8 +2,6 @@ package subscription
 
 import (
 	"context"
-	"errors"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"regexp"
 	"time"
 
@@ -16,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/labd/commercetools-go-sdk/platform"
 
 	"github.com/labd/terraform-provider-commercetools/internal/customvalidator"
@@ -376,7 +375,7 @@ func (r *subscriptionResource) Read(ctx context.Context, req resource.ReadReques
 
 	subscription, err := r.client.Subscriptions().WithId(state.ID.ValueString()).Get().Execute(ctx)
 	if err != nil {
-		if errors.Is(err, platform.ErrNotFound) {
+		if utils.IsResourceNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -473,7 +472,7 @@ func (r *subscriptionResource) Delete(ctx context.Context, req resource.DeleteRe
 func (r *subscriptionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	subscription, err := r.client.Subscriptions().WithId(req.ID).Get().Execute(ctx)
 	if err != nil {
-		if errors.Is(err, platform.ErrNotFound) {
+		if utils.IsResourceNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}


### PR DESCRIPTION
This updates the check if an errors is due to a resource not being found for all new resources (`subscription`, `state`, `state_transitions`, `product_selection`, `attribute_group` and `associate_role`).
