### PR TITLE
Proposal: Allow to adjust token validity for Api Clients via Terraform

### DIFF
--- a/.changes/unreleased/Changed-20241127-143527.yaml
+++ b/.changes/unreleased/Changed-20241127-143527.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '`resource_api_client` add support for setting and managing token validity via Terraform.'
+time: 2024-11-27T14:35:27.885461+01:00

--- a/docs/resources/api_client.md
+++ b/docs/resources/api_client.md
@@ -4,7 +4,7 @@ page_title: "commercetools_api_client Resource - terraform-provider-commercetool
 subcategory: ""
 description: |-
   Create a new API client. Note that Commercetools might return slightly different scopes, resulting in a new API client being created everytime Terraform is run. In this case, fix your scopes accordingly to match what is returned by Commercetools.
-  Also see the API client HTTP API documentation https://docs.commercetools.com//http-api-projects-api-clients.
+  Also see the API client HTTP API documentation https://docs.commercetools.com/api/projects/api-clients.
 ---
 
 # commercetools_api_client (Resource)
@@ -19,6 +19,8 @@ Also see the [API client HTTP API documentation](https://docs.commercetools.com/
 resource "commercetools_api_client" "my-api-client" {
   name  = "My API Client"
   scope = ["manage_orders:my-ct-project-key", "manage_payments:my-ct-project-key"]
+  accessTokenValiditySeconds = 3600
+  refreshTokenValiditySeconds = 60
 }
 ```
 
@@ -27,8 +29,14 @@ resource "commercetools_api_client" "my-api-client" {
 
 ### Required
 
-- `name` (String) Name of the API client
-- `scope` (Set of String) A list of the [OAuth scopes](https://docs.commercetools.com/http-api-authorization.html#scopes)
+- `name` (String) Name of the API client.
+- `scope` (Set of String) A list of the [OAuth scopes](https://docs.commercetools.com/api/scopes).
+
+
+### Optional
+
+- `accessTokenValiditySeconds` (Int) Expiration time in seconds for each access token obtained by the APIClient. See the latest CommerceTools documentation for [API Clients](https://docs.commercetools.com/api/projects/api-clients) for valid number ranges.
+- `refreshTokenValiditySeconds` (Int) Inactivity expiration time in seconds for each refresh token obtained by the APIClient. See the latest CommerceTools documentation for [API Clients](https://docs.commercetools.com/api/projects/api-clients) for valid number ranges.
 
 ### Read-Only
 


### PR DESCRIPTION
The [API Clients](https://docs.commercetools.com/api/projects/api-clients) allow to override the default token validity but this is only possible during the creation of the api client.

While the access_token's are valid for 48 hours, the lifetime of refresh_tokens is 200 days, which is pretty high. I would like to be able to set custom validity values for the api clients. Especially because there is no way to update existing clients, so after creation hooks wont work here.

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

Extends `resource_api_client` to read and write the fields `accessTokenValiditySeconds` and `refreshTokenValiditySeconds`.

---

Please double check if these changes are good to go. It seems there is not much that needs to be changed but i am unfamiliar with Go and working with TF providers.