### PR TITLE
Add a proper sorting of associate-role's permissions

### DIFF
--- a/.changes/unreleased/Fixed-20241217-190228.yaml
+++ b/.changes/unreleased/Fixed-20241217-190228.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: This adds a sorting of the permissions we get from the commercetools API response, so that it's identical to the one from the plan.
+time: 2024-12-17T19:02:28.854328+01:00


### PR DESCRIPTION
This PR adds a sorting of the permission-list, which we receive from the commercetools-API. The sorting was added within the function Create, Update and Read of the resource associate-role. The sorting of the permissions, which we get from commercetools, is not predictable so that terraform gets confused (See description of issue #505). After sorting the permissions, so that they are in the same order as in the plan, the create, read and update works fine.

Fixes #505

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

- Fixed a bug, which prevents the proper creation, updating and reading of permissions from associate-roles