### PR TITLE
fix: custom fields cache concurrent writes

### DIFF
--- a/.changes/unreleased/Fixed-20250206-113217.yaml
+++ b/.changes/unreleased/Fixed-20250206-113217.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Custom fields cache concurrent writes
+time: 2025-02-06T11:32:17.345811+01:00


### PR DESCRIPTION
Fixes #563

Ensure cacheTypes use a lock for concurrent access.