### PR TITLE
fix: added check that no enum types are deleted

### DIFF
--- a/.changes/unreleased/Fixed-20250221-160803.yaml
+++ b/.changes/unreleased/Fixed-20250221-160803.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: added check that no enum types are deleted
+time: 2025-02-21T16:08:03.952221741+01:00

--- a/commercetools/resource_type.go
+++ b/commercetools/resource_type.go
@@ -785,6 +785,12 @@ func updateCustomFieldEnumType(fieldName string, old, new platform.CustomFieldEn
 		newValues.Set(new.Values[i].Key, new.Values[i])
 	}
 
+	for _, oldValue := range oldValues.Keys() {
+		if !newValues.Has(oldValue) {
+			return nil, fmt.Errorf("trying to delete enum value %s. Deleting enum values is not supported", oldValue)
+		}
+	}
+
 	var valueOrder []string
 	valueOrder = append(valueOrder, oldValues.Keys()...)
 

--- a/commercetools/resource_type_test.go
+++ b/commercetools/resource_type_test.go
@@ -194,6 +194,63 @@ func TestResourceTypeValidateFieldSet(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestUpdateCustomFieldEnumTypeAdd(t *testing.T) {
+	oldType := platform.CustomFieldEnumType{
+		Values: []platform.CustomFieldEnumValue{
+			{Key: "value1", Label: "Value 1"},
+		},
+	}
+
+	newType := platform.CustomFieldEnumType{
+		Values: []platform.CustomFieldEnumValue{
+			{Key: "value1", Label: "Value 1"},
+			{Key: "value2", Label: "Value 2"},
+		},
+	}
+
+	actions, err := updateCustomFieldEnumType("test", oldType, newType)
+	assert.NoError(t, err)
+	assert.Len(t, actions, 1)
+}
+
+func TestUpdateCustomFieldEnumTypeDelete(t *testing.T) {
+	oldType := platform.CustomFieldEnumType{
+		Values: []platform.CustomFieldEnumValue{
+			{Key: "value1", Label: "Value 1"},
+			{Key: "value2", Label: "Value 2"},
+		},
+	}
+
+	newType := platform.CustomFieldEnumType{
+		Values: []platform.CustomFieldEnumValue{
+			{Key: "value1", Label: "Value 1"},
+		},
+	}
+
+	_, err := updateCustomFieldEnumType("test", oldType, newType)
+	assert.ErrorContains(t, err, "trying to delete enum value value2. Deleting enum values is not supported")
+}
+
+func TestUpdateCustomFieldEnumTypeAddAndDelete(t *testing.T) {
+	oldType := platform.CustomFieldEnumType{
+		Values: []platform.CustomFieldEnumValue{
+			{Key: "value1", Label: "Value 1"},
+			{Key: "value2", Label: "Value 2"},
+		},
+	}
+
+	newType := platform.CustomFieldEnumType{
+		Values: []platform.CustomFieldEnumValue{
+			{Key: "value1", Label: "Value 1"},
+			{Key: "value3", Label: "Value 3"},
+			{Key: "value4", Label: "Value 4"},
+		},
+	}
+
+	_, err := updateCustomFieldEnumType("test", oldType, newType)
+	assert.ErrorContains(t, err, "trying to delete enum value value2. Deleting enum values is not supported")
+}
+
 func TestAccTypes_basic(t *testing.T) {
 	key := "acctest-type"
 	identifier := "acctest_type"


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

-->

Fixes #569

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of your changes. Examples:

- Fixed a bug
- Added a new feature
- Updated documentation

--> 

-  Throw error when deleting an enum type. This still allows for renaming enum types, it only checks if the total number of new values is smaller than old values
