### PR TITLE
fix: added default for timeout_in_ms on commercetools_api_extension

### DIFF
--- a/.changes/unreleased/Fixed-20250912-161456.yaml
+++ b/.changes/unreleased/Fixed-20250912-161456.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Added default for timeout_in_ms on commercetools_api_extension
+time: 2025-09-12T16:14:56.492882523+02:00

--- a/commercetools/resource_api_extension.go
+++ b/commercetools/resource_api_extension.go
@@ -114,9 +114,13 @@ func resourceAPIExtension() *schema.Resource {
 				},
 			},
 			"timeout_in_ms": {
-				Description: "Extension timeout in milliseconds",
-				Type:        schema.TypeInt,
-				Optional:    true,
+				Description: "Maximum time (in milliseconds) that the Extension can respond within. If no timeout is " +
+					"provided, the default value is used for all types of Extensions, including payment Extensions. " +
+					"The maximum value is 10000 ms (10 seconds) for payment Extensions and 2000 ms (2 seconds) for " +
+					"all other Extensions.",
+				Type:     schema.TypeInt,
+				Default:  2000,
+				Optional: true,
 			},
 			"version": {
 				Type:     schema.TypeInt,

--- a/docs/resources/api_extension.md
+++ b/docs/resources/api_extension.md
@@ -99,7 +99,7 @@ resource "google_cloudfunctions_function_iam_member" "invoker" {
 ### Optional
 
 - `key` (String) User-specific unique identifier for the extension
-- `timeout_in_ms` (Number) Extension timeout in milliseconds
+- `timeout_in_ms` (Number) Maximum time (in milliseconds) that the Extension can respond within. If no timeout is provided, the default value is used for all types of Extensions, including payment Extensions. The maximum value is 10000 ms (10 seconds) for payment Extensions and 2000 ms (2 seconds) for all other Extensions.
 
 ### Read-Only
 


### PR DESCRIPTION
<!--

Describe in detail the changes you are proposing, and the rationale.

-->

<!--

Link all GitHub issues fixed by this PR, and add references to prior related PRs.

-->

Fixes #

### NEW FEATURES | UPGRADE NOTES | ENHANCEMENTS | BUG FIXES | EXPERIMENTS

<!--

Write a short description of your changes. Examples:

- Fixed a bug
- Added a new feature
- Updated documentation

--> 

-  
