### PR TITLE
feat: removed unnecessary check on default carts type

### DIFF
--- a/.changes/unreleased/Fixed-20250926-150825.yaml
+++ b/.changes/unreleased/Fixed-20250926-150825.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Removed unnecessary check on default carts type
+time: 2025-09-26T15:08:25.451220481+02:00

--- a/internal/resources/project/model.go
+++ b/internal/resources/project/model.go
@@ -47,13 +47,6 @@ type Project struct {
 	BusinessUnits []BusinessUnits `tfsdk:"business_units"`
 }
 
-func IsDefaultCartsConfiguration(c platform.CartsConfiguration) bool {
-	return (c.CountryTaxRateFallbackEnabled == nil || *c.CountryTaxRateFallbackEnabled == false) &&
-		(c.DeleteDaysAfterLastModification == nil || *c.DeleteDaysAfterLastModification == DefaultDaysAfterLastModification) &&
-		(c.PriceRoundingMode == nil || *c.PriceRoundingMode == platform.RoundingModeHalfEven) &&
-		(c.TaxRoundingMode == nil || *c.TaxRoundingMode == platform.RoundingModeHalfEven)
-}
-
 func IsDefaultShoppingListsConfiguration(c *platform.ShoppingListsConfiguration) bool {
 	if c == nil {
 		return true
@@ -88,15 +81,13 @@ func NewProjectFromNative(n *platform.Project) Project {
 		BusinessUnits: []BusinessUnits{},
 	}
 
-	if !IsDefaultCartsConfiguration(n.Carts) {
-		res.Carts = []Carts{
-			{
-				DeleteDaysAfterLastModification: utils.FromOptionalInt(n.Carts.DeleteDaysAfterLastModification),
-				CountryTaxRateFallbackEnabled:   utils.FromOptionalBool(n.Carts.CountryTaxRateFallbackEnabled),
-				PriceRoundingMode:               utils.FromOptionalString((*string)(n.Carts.PriceRoundingMode)),
-				TaxRoundingMode:                 utils.FromOptionalString((*string)(n.Carts.TaxRoundingMode)),
-			},
-		}
+	res.Carts = []Carts{
+		{
+			DeleteDaysAfterLastModification: utils.FromOptionalInt(n.Carts.DeleteDaysAfterLastModification),
+			CountryTaxRateFallbackEnabled:   utils.FromOptionalBool(n.Carts.CountryTaxRateFallbackEnabled),
+			PriceRoundingMode:               utils.FromOptionalString((*string)(n.Carts.PriceRoundingMode)),
+			TaxRoundingMode:                 utils.FromOptionalString((*string)(n.Carts.TaxRoundingMode)),
+		},
 	}
 
 	if !IsDefaultShoppingListsConfiguration(n.ShoppingLists) {

--- a/internal/resources/project/model_test.go
+++ b/internal/resources/project/model_test.go
@@ -40,7 +40,14 @@ func TestNewProjectFromNative(t *testing.T) {
 				EnableSearchIndexBusinessUnits: types.BoolValue(false),
 
 				ExternalOAuth: []ExternalOAuth{},
-				Carts:         nil,
+				Carts: []Carts{
+					{
+						CountryTaxRateFallbackEnabled:   types.BoolNull(),
+						DeleteDaysAfterLastModification: types.Int64Null(),
+						PriceRoundingMode:               types.StringNull(),
+						TaxRoundingMode:                 types.StringNull(),
+					},
+				},
 				Messages: []Messages{
 					{
 						Enabled:                 types.BoolValue(false),
@@ -517,49 +524,6 @@ func TestSetStateData(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.state)
 		})
 	}
-}
-
-func IsDefaultCartsConfiguration_DefaultValues(t *testing.T) {
-	c := platform.CartsConfiguration{
-		CountryTaxRateFallbackEnabled:   utils.BoolRef(false),
-		DeleteDaysAfterLastModification: utils.IntRef(DefaultDaysAfterLastModification),
-		PriceRoundingMode:               utils.GetRef(platform.RoundingModeHalfEven),
-		TaxRoundingMode:                 utils.GetRef(platform.RoundingModeHalfEven),
-	}
-	assert.True(t, IsDefaultCartsConfiguration(c))
-}
-
-func IsDefaultCartsConfiguration_NilFields(t *testing.T) {
-	c := platform.CartsConfiguration{}
-	assert.True(t, IsDefaultCartsConfiguration(c))
-}
-
-func IsDefaultCartsConfiguration_NonDefaultCountryTaxRateFallbackEnabled(t *testing.T) {
-	c := platform.CartsConfiguration{
-		CountryTaxRateFallbackEnabled: utils.BoolRef(true),
-	}
-	assert.False(t, IsDefaultCartsConfiguration(c))
-}
-
-func IsDefaultCartsConfiguration_NonDefaultDeleteDaysAfterLastModification(t *testing.T) {
-	c := platform.CartsConfiguration{
-		DeleteDaysAfterLastModification: utils.IntRef(30),
-	}
-	assert.False(t, IsDefaultCartsConfiguration(c))
-}
-
-func IsDefaultCartsConfiguration_NonDefaultPriceRoundingMode(t *testing.T) {
-	c := platform.CartsConfiguration{
-		PriceRoundingMode: utils.GetRef(platform.RoundingModeHalfUp),
-	}
-	assert.False(t, IsDefaultCartsConfiguration(c))
-}
-
-func IsDefaultCartsConfiguration_NonDefaultTaxRoundingMode(t *testing.T) {
-	c := platform.CartsConfiguration{
-		TaxRoundingMode: utils.GetRef(platform.RoundingModeHalfUp),
-	}
-	assert.False(t, IsDefaultCartsConfiguration(c))
 }
 
 func IsDefaultShoppingListsConfiguration_Nil(t *testing.T) {


### PR DESCRIPTION
This pull request removes an unnecessary check for the default carts configuration in the `Project` model, simplifying both the implementation and its tests. Now, the carts configuration is always included without checking if it matches default values.

Codebase simplification:

* Removed the `IsDefaultCartsConfiguration` function and all related logic from `internal/resources/project/model.go`, so the carts configuration is always set without checking for default values. [[1]](diffhunk://#diff-ea98c1ce792b12a8f06a166483106a667595c3a1dc6ae3467b33fb6fb04cf61bL50-L56) [[2]](diffhunk://#diff-ea98c1ce792b12a8f06a166483106a667595c3a1dc6ae3467b33fb6fb04cf61bL91) [[3]](diffhunk://#diff-ea98c1ce792b12a8f06a166483106a667595c3a1dc6ae3467b33fb6fb04cf61bL100)
* Deleted all associated unit tests for `IsDefaultCartsConfiguration` from `internal/resources/project/model_test.go`.

Changelog:

* Added a changelog entry noting the removal of the unnecessary check on the default carts type. (.changes/unreleased/Fixed-20250926-150825.yaml)