### PR TITLE
Prevent import/plan drift on associate_role, category and project_settings

### DIFF
--- a/.changes/unreleased/Fixed-20260617-155545.yaml
+++ b/.changes/unreleased/Fixed-20260617-155545.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed commercetools_associate_role dropping all permissions on import, causing them to be recreated on the next plan
+time: 2026-06-17T15:55:45.460292+02:00

--- a/.changes/unreleased/Fixed-20260617-155551.yaml
+++ b/.changes/unreleased/Fixed-20260617-155551.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed commercetools_category not persisting slug on read/import, causing slug to be recreated on the next plan
+time: 2026-06-17T15:55:51.159625+02:00

--- a/.changes/unreleased/Fixed-20260617-155556.yaml
+++ b/.changes/unreleased/Fixed-20260617-155556.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed commercetools_project_settings dropping business_units configuration on import, causing it to be recreated on the next plan
+time: 2026-06-17T15:55:56.699412+02:00

--- a/commercetools/resource_category.go
+++ b/commercetools/resource_category.go
@@ -258,6 +258,7 @@ func resourceCategoryRead(ctx context.Context, d *schema.ResourceData, m any) di
 	_ = d.Set("version", category.Version)
 	_ = d.Set("key", category.Key)
 	_ = d.Set("name", category.Name)
+	_ = d.Set("slug", category.Slug)
 	if category.Parent != nil {
 		_ = d.Set("parent", category.Parent.ID)
 	} else {

--- a/commercetools/resource_category_test.go
+++ b/commercetools/resource_category_test.go
@@ -108,6 +108,41 @@ func TestAccCategoryRecreateAfterDelete(t *testing.T) {
 	})
 }
 
+func TestAccCategoryImport(t *testing.T) {
+	resourceName := "commercetools_category.accessories"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCategoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCategoryConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "slug.en", "accessories"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccCategorySlugImported,
+			},
+		},
+	})
+}
+
+func testAccCategorySlugImported(states []*terraform.InstanceState) error {
+	if len(states) != 1 {
+		return fmt.Errorf("expected exactly one imported state, got %d", len(states))
+	}
+
+	if slug := states[0].Attributes["slug.en"]; slug != "accessories" {
+		return fmt.Errorf("expected imported slug.en to be %q, got %q", "accessories", slug)
+	}
+
+	return nil
+}
+
 func testAccCategoryConfig() string {
 	return hclTemplate(`
 		resource "commercetools_category" "accessories_base" {

--- a/internal/resources/associate_role/resource.go
+++ b/internal/resources/associate_role/resource.go
@@ -102,32 +102,30 @@ func (*associateRoleResource) Metadata(_ context.Context, req resource.MetadataR
 }
 
 func resortPermissions(permissions, plan []platform.Permission) []platform.Permission {
-
-	// Build a map which maps the planned permissions to its index from the array
+	// Map each planned permission to its position so we can restore that order.
 	indexMap := make(map[platform.Permission]int)
-	for idx, p := range plan {
-		indexMap[p] = idx
+	for index, permission := range plan {
+		indexMap[permission] = index
 	}
 
-	// Build a map of the current permissions to the planned index
-	targetMap := make(map[platform.Permission]int)
-	for _, p := range permissions {
-		idx, ok := indexMap[p]
-		if ok {
-			targetMap[p] = idx
+	// Permissions present in the plan keep the plan ordering; permissions not in the
+	// plan (e.g. during import, or drift introduced outside Terraform) are appended
+	// afterwards in their API order so they are never dropped from state.
+	ordered := make([]platform.Permission, 0, len(permissions))
+	extra := make([]platform.Permission, 0)
+	for _, permission := range permissions {
+		if _, found := indexMap[permission]; found {
+			ordered = append(ordered, permission)
+		} else {
+			extra = append(extra, permission)
 		}
 	}
 
-	// Sort the target permission list by the index from the map
-	targetList := make([]platform.Permission, 0, len(targetMap))
-	for key := range targetMap {
-		targetList = append(targetList, key)
-	}
-	sort.SliceStable(targetList, func(i, j int) bool {
-		return targetMap[targetList[i]] < targetMap[targetList[j]]
+	sort.SliceStable(ordered, func(first, second int) bool {
+		return indexMap[ordered[first]] < indexMap[ordered[second]]
 	})
 
-	return targetList
+	return append(ordered, extra...)
 }
 
 // Create implements resource.Resource.

--- a/internal/resources/associate_role/resource_test.go
+++ b/internal/resources/associate_role/resource_test.go
@@ -1,6 +1,8 @@
 package associate_role_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -44,6 +46,70 @@ func TestAssociateRoleResource_Create(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAssociateRoleResource_ImportPermissions(t *testing.T) {
+	resourceName := "commercetools_associate_role.sales_manager_associate_role"
+
+	identifier := "sales_manager_associate_role"
+	key := "sales_manager_europe_region"
+	name := "Sales Manager - Europe"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAssociateRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAssociateRoleConfig(identifier, name, key),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "6"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAssociateRolePermissionsImported,
+			},
+		},
+	})
+}
+
+// testAssociateRolePermissionsImported asserts that every permission from the
+// configuration survives the import. The check is order-insensitive to
+// check that the permissions are not being dropped entirely, regardless of their ordering.
+func testAssociateRolePermissionsImported(states []*terraform.InstanceState) error {
+	if len(states) != 1 {
+		return fmt.Errorf("expected exactly one imported state, got %d", len(states))
+	}
+
+	imported := states[0]
+	expectedPermissions := []string{
+		"UpdateBusinessUnitDetails",
+		"UpdateAssociates",
+		"CreateMyCarts",
+		"DeleteMyCarts",
+		"UpdateMyCarts",
+		"ViewMyCarts",
+	}
+
+	if count := imported.Attributes["permissions.#"]; count != "6" {
+		return fmt.Errorf("expected 6 permissions after import, got %q", count)
+	}
+
+	importedPermissions := make(map[string]bool)
+	for attribute, value := range imported.Attributes {
+		if strings.HasPrefix(attribute, "permissions.") && attribute != "permissions.#" {
+			importedPermissions[value] = true
+		}
+	}
+	for _, permission := range expectedPermissions {
+		if !importedPermissions[permission] {
+			return fmt.Errorf("permission %q missing from imported state", permission)
+		}
+	}
+
+	return nil
 }
 
 func testAssociateRoleDestroy(_ *terraform.State) error {

--- a/internal/resources/project/model.go
+++ b/internal/resources/project/model.go
@@ -203,7 +203,12 @@ func (p *Project) setStateData(o Project) {
 		p.Messages = o.Messages
 	}
 
-	if len(o.BusinessUnits) == 0 {
+	if len(o.BusinessUnits) == 0 && len(p.BusinessUnits) == 0 {
+		p.BusinessUnits = nil
+	}
+
+	// if the only existing BusinessUnit is the default config, remove the stored BusinessUnits in the state
+	if len(o.BusinessUnits) == 0 && len(p.BusinessUnits) == 1 && p.BusinessUnits[0].isDefault() {
 		p.BusinessUnits = nil
 	}
 }
@@ -585,7 +590,7 @@ func (b BusinessUnits) toNative() platform.BusinessUnitDraft {
 }
 
 func (b BusinessUnits) isDefault() bool {
-	return b.MyBusinessUnitStatusOnCreation.ValueString() == string(platform.BusinessUnitStatusActive) &&
+	return b.MyBusinessUnitStatusOnCreation.ValueString() == string(platform.BusinessUnitConfigurationStatusInactive) &&
 		b.MyBusinessUnitAssociateRoleKeyOnCreation.IsNull()
 }
 

--- a/internal/resources/project/model.go
+++ b/internal/resources/project/model.go
@@ -181,7 +181,7 @@ func NewProjectFromNative(n *platform.Project) Project {
 	return res
 }
 
-func (p *Project) setStateData(o Project) {
+func (p *Project) setStateData(o Project, isImport bool) {
 	if len(p.ExternalOAuth) > 0 && len(o.ExternalOAuth) > 0 {
 		p.ExternalOAuth[0].AuthorizationHeader = o.ExternalOAuth[0].AuthorizationHeader
 	}
@@ -203,12 +203,14 @@ func (p *Project) setStateData(o Project) {
 		p.Messages = o.Messages
 	}
 
-	if len(o.BusinessUnits) == 0 && len(p.BusinessUnits) == 0 {
-		p.BusinessUnits = nil
-	}
-
-	// if the only existing BusinessUnit is the default config, remove the stored BusinessUnits in the state
-	if len(o.BusinessUnits) == 0 && len(p.BusinessUnits) == 1 && p.BusinessUnits[0].isDefault() {
+	// Import has no prior config, so keep the API's business units or import loses
+	// them. Otherwise mirror o: the associate role can't be unset via the SDK, so
+	// keeping the API value would cause endless drift after the block is removed.
+	if isImport {
+		if len(p.BusinessUnits) == 0 || (len(p.BusinessUnits) == 1 && p.BusinessUnits[0].isDefault()) {
+			p.BusinessUnits = nil
+		}
+	} else if len(o.BusinessUnits) == 0 {
 		p.BusinessUnits = nil
 	}
 }

--- a/internal/resources/project/model_test.go
+++ b/internal/resources/project/model_test.go
@@ -412,6 +412,7 @@ func TestSetStateData(t *testing.T) {
 		name     string
 		state    Project
 		plan     Project
+		isImport bool
 		expected Project
 	}{
 		{
@@ -517,7 +518,8 @@ func TestSetStateData(t *testing.T) {
 				},
 			},
 		}, {
-			name: "business unit imported with empty prior state",
+			name:     "business unit imported with empty prior state",
+			isImport: true,
 			state: Project{
 				BusinessUnits: []BusinessUnits{
 					{
@@ -537,11 +539,30 @@ func TestSetStateData(t *testing.T) {
 					},
 				},
 			},
+		}, {
+			// The role can't be unset via the SDK, so the API still reports it;
+			// state must still match the empty plan to avoid an inconsistent apply.
+			name:     "business unit removed on apply matches empty plan",
+			isImport: false,
+			state: Project{
+				BusinessUnits: []BusinessUnits{
+					{
+						MyBusinessUnitStatusOnCreation:           types.StringValue(string(platform.BusinessUnitConfigurationStatusInactive)),
+						MyBusinessUnitAssociateRoleKeyOnCreation: types.StringValue("my-role"),
+					},
+				},
+			},
+			plan: Project{
+				BusinessUnits: []BusinessUnits{},
+			},
+			expected: Project{
+				BusinessUnits: nil,
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.state.setStateData(tt.plan)
+			tt.state.setStateData(tt.plan, tt.isImport)
 			assert.Equal(t, tt.expected, tt.state)
 		})
 	}

--- a/internal/resources/project/model_test.go
+++ b/internal/resources/project/model_test.go
@@ -516,6 +516,27 @@ func TestSetStateData(t *testing.T) {
 					},
 				},
 			},
+		}, {
+			name: "business unit imported with empty prior state",
+			state: Project{
+				BusinessUnits: []BusinessUnits{
+					{
+						MyBusinessUnitStatusOnCreation:           types.StringValue(string(platform.BusinessUnitConfigurationStatusInactive)),
+						MyBusinessUnitAssociateRoleKeyOnCreation: types.StringValue("viewer"),
+					},
+				},
+			},
+			plan: Project{
+				BusinessUnits: []BusinessUnits{},
+			},
+			expected: Project{
+				BusinessUnits: []BusinessUnits{
+					{
+						MyBusinessUnitStatusOnCreation:           types.StringValue(string(platform.BusinessUnitConfigurationStatusInactive)),
+						MyBusinessUnitAssociateRoleKeyOnCreation: types.StringValue("viewer"),
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/internal/resources/project/resource.go
+++ b/internal/resources/project/resource.go
@@ -393,7 +393,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	result := NewProjectFromNative(res)
-	result.setStateData(plan)
+	result.setStateData(plan, false)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, result)
@@ -422,7 +422,8 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 	current := NewProjectFromNative(res)
-	current.setStateData(state)
+	// Only import has a null version; import must keep remote business units.
+	current.setStateData(state, state.Version.IsNull())
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, current)
@@ -467,7 +468,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 	result := NewProjectFromNative(res)
-	result.setStateData(plan)
+	result.setStateData(plan, false)
 
 	diags = resp.State.Set(ctx, result)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
## What
Three resources lost part of their configuration when read or imported, causing fields to drift or get recreated on the next `terraform plan`.

- Associate role — On import, all permissions were dropped and then recreated on the next apply. Permissions are now preserved on read and import.
- Category — The slug was never read back into state, so it was recreated on the next plan. It is now read like the other fields.
- Project settings — The business units configuration was dropped on import, discarding a real setup.

This one needs care: an associate role on the project can't be removed again afterwards, so the API keeps reporting it. Simply keeping that value caused two new problems — removing the business units block failed during apply, and a later refresh kept showing changes that never went away.

The fix treats import and normal use differently: on import the existing configuration is kept so nothing is lost, while during apply and refresh the state follows what you actually configured, so there's no error and no endless drift.